### PR TITLE
Fix separatorStyles throwing errors in console

### DIFF
--- a/forui/example/lib/main.dart
+++ b/forui/example/lib/main.dart
@@ -20,22 +20,9 @@ class Application extends StatelessWidget {
             body: Padding(
               padding: const EdgeInsets.all(16),
               child: Center(
-                child: FBadge.raw(
+                child: FBadge(
                   design: FBadgeVariant.outline,
-                  builder: (context, style) => Padding(
-                    padding: const EdgeInsets.all(50),
-                    child: Container(
-                      width: 50,
-                      height: 50,
-                      decoration: BoxDecoration(
-                        color: style.background,
-                        border: Border.all(
-                          color: Colors.blueAccent,
-                          width: 2,
-                        ),
-                      ),
-                    )
-                  )
+                  label: 'Hello, World!',
                 ),
               ),
             ),

--- a/forui/lib/src/theme/theme_data.dart
+++ b/forui/lib/src/theme/theme_data.dart
@@ -23,7 +23,7 @@ class FThemeData with Diagnosticable {
   final FCardStyle cardStyle;
 
   /// The separator styles.
-  final ({FSeparatorStyle horizontal, FSeparatorStyle vertical}) separatorStyles;
+  final FSeparatorStyles separatorStyles;
 
   /// Creates a [FThemeData].
   FThemeData({
@@ -45,18 +45,7 @@ class FThemeData with Diagnosticable {
     badgeStyles = FBadgeStyles.inherit(colorScheme: colorScheme, style: style),
     boxStyle = FBoxStyle.inherit(colorScheme: colorScheme),
     cardStyle = FCardStyle.inherit(colorScheme: colorScheme, style: style),
-    separatorStyles = (
-      horizontal: FSeparatorStyle.inherit(
-        colorScheme: colorScheme,
-        style: style,
-        padding: FSeparatorStyle.defaultPadding.horizontal,
-      ),
-      vertical: FSeparatorStyle.inherit(
-        colorScheme: colorScheme,
-        style: style,
-        padding: FSeparatorStyle.defaultPadding.vertical,
-      )
-    );
+    separatorStyles = FSeparatorStyles.inherit(colorScheme: colorScheme, style: style);
 
   /// Creates a copy of this [FThemeData] with the given properties replaced.
   FThemeData copyWith({
@@ -66,7 +55,7 @@ class FThemeData with Diagnosticable {
     FBadgeStyles? badgeStyles,
     FBoxStyle? boxStyle,
     FCardStyle? cardStyle,
-    ({FSeparatorStyle horizontal, FSeparatorStyle vertical})? separatorStyles,
+    FSeparatorStyles? separatorStyles,
   }) => FThemeData(
     colorScheme: colorScheme ?? this.colorScheme,
     font: font ?? this.font,
@@ -87,7 +76,7 @@ class FThemeData with Diagnosticable {
       ..add(DiagnosticsProperty<FBadgeStyles>('badgeStyles', badgeStyles, level: DiagnosticLevel.debug))
       ..add(DiagnosticsProperty<FBoxStyle>('boxStyle', boxStyle, level: DiagnosticLevel.debug))
       ..add(DiagnosticsProperty<FCardStyle>('cardStyle', cardStyle, level: DiagnosticLevel.debug))
-      ..add(DiagnosticsProperty<({FSeparatorStyle horizontal, FSeparatorStyle vertical})>('separatorStyles', separatorStyles, level: DiagnosticLevel.debug));
+      ..add(DiagnosticsProperty<FSeparatorStyles>('separatorStyles', separatorStyles, level: DiagnosticLevel.debug));
   }
 
   @override

--- a/forui/lib/src/widgets/badge/badge.dart
+++ b/forui/lib/src/widgets/badge/badge.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
 import 'package:meta/meta.dart';

--- a/forui/lib/src/widgets/separator.dart
+++ b/forui/lib/src/widgets/separator.dart
@@ -47,6 +47,58 @@ final class FSeparator extends StatelessWidget {
 
 }
 
+/// The [FSeparator] styles.
+final class FSeparatorStyles with Diagnosticable {
+
+  /// The horizontal separator style.
+  final FSeparatorStyle horizontal;
+
+  /// The vertical separator style.
+  final FSeparatorStyle vertical;
+
+  /// Creates a [FSeparatorStyles].
+  FSeparatorStyles({required this.horizontal, required this.vertical});
+
+  /// Creates a [FSeparatorStyles] that inherits its properties from [colorScheme].
+  FSeparatorStyles.inherit({required FColorScheme colorScheme, required FStyle style}):
+    horizontal = FSeparatorStyle.inherit(
+      colorScheme: colorScheme,
+      style: style,
+      padding: FSeparatorStyle.defaultPadding.horizontal,
+    ),
+    vertical = FSeparatorStyle.inherit(
+      colorScheme: colorScheme,
+      style: style,
+      padding: FSeparatorStyle.defaultPadding.vertical
+    );
+
+  /// Creates a copy of this [FSeparatorStyles] with the given properties replaced.
+  FSeparatorStyles copyWith({FSeparatorStyle? horizontal, FSeparatorStyle? vertical}) => FSeparatorStyles(
+    horizontal: horizontal ?? this.horizontal,
+    vertical: vertical ?? this.vertical,
+  );
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty<FSeparatorStyle>('horizontal', horizontal))
+      ..add(DiagnosticsProperty<FSeparatorStyle>('vertical', vertical));
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FSeparatorStyles &&
+          runtimeType == other.runtimeType &&
+          horizontal == other.horizontal &&
+          vertical == other.vertical;
+
+  @override
+  int get hashCode => horizontal.hashCode ^ vertical.hashCode;
+
+}
+
 /// [FSeparator]'s style.
 final class FSeparatorStyle with Diagnosticable {
 


### PR DESCRIPTION
This PR converts the record used to store horizontal and vertical styles to a normal class. It seems like Flutter devtools doesn't know how to handle records (yet).