### PR TITLE
Fix broken links and typos in documentation.

### DIFF
--- a/docs/pages/docs/data/icon.mdx
+++ b/docs/pages/docs/data/icon.mdx
@@ -5,7 +5,7 @@ import LinkBadge from "../../../components/link-badge/link-badge.tsx";
 import LinkBadgeGroup from "../../../components/link-badge/link-badge-group.tsx";
 
 # Icon
-An icon that inherits its style from an enclosing, supported widget, such as a [button](/docs/button).
+An icon that inherits its style from an enclosing, supported widget, such as a [button](/docs/form/button).
 
 <LinkBadgeGroup>
   <LinkBadge label="API Reference" href="https://pub.dev/documentation/forui/latest/forui.widgets.icon/forui.widgets.icon-library.html"/>

--- a/docs/pages/docs/form/calendar.mdx
+++ b/docs/pages/docs/form/calendar.mdx
@@ -9,7 +9,7 @@ A date field component that allows users to enter and edit date.
 The calendar pages are designed to be navigable through swipe gestures on mobile platforms, allowing left and right
 swipes to transition between pages.
 
-A [`FCalendarController`](https://pub.dev/documentation/forui/latest/forui.widgets.calendar/FCalendarController-class.html) is used
+An [`FCalendarController`](https://pub.dev/documentation/forui/latest/forui.widgets.calendar/FCalendarController-class.html) is used
 to customize the date selection behavior.
 
 <LinkBadgeGroup>

--- a/docs/pages/docs/form/calendar.mdx
+++ b/docs/pages/docs/form/calendar.mdx
@@ -9,7 +9,7 @@ A date field component that allows users to enter and edit date.
 The calendar pages are designed to be navigable through swipe gestures on mobile platforms, allowing left and right
 swipes to transition between pages.
 
-A [`FCalendarController`](https://pub.dev/documentation/forui/latest/forui.widgets/FCalendarController-class.html) is used
+A [`FCalendarController`](https://pub.dev/documentation/forui/latest/forui.widgets.calendar/FCalendarController-class.html) is used
 to customize the date selection behavior.
 
 <LinkBadgeGroup>

--- a/docs/pages/docs/form/checkbox.mdx
+++ b/docs/pages/docs/form/checkbox.mdx
@@ -6,7 +6,7 @@ import LinkBadgeGroup from "../../../components/link-badge/link-badge-group.tsx"
 # Checkbox
 A control that allows the user to toggle between checked and not checked.
 
-For touch devices, a [switch](/docs/switch) is generally recommended over a checkbox.
+For touch devices, a [switch](/docs/form/switch) is generally recommended over a checkbox.
 
 <LinkBadgeGroup>
     <LinkBadge label="API Reference" href="https://pub.dev/documentation/forui/latest/forui.widgets.checkbox/forui.widgets.checkbox-library.html"/>
@@ -14,7 +14,7 @@ For touch devices, a [switch](/docs/switch) is generally recommended over a chec
 
 <div className="pb-5">
     <Callout type="info">
-        We recommend using a [select group](/docs/select-group#checkbox-form) to create a group of checkboxes.
+        We recommend using a [select group](/docs/form/select-group#checkbox-form) to create a group of checkboxes.
     </Callout>
 </div>
 

--- a/docs/pages/docs/form/radio.mdx
+++ b/docs/pages/docs/form/radio.mdx
@@ -12,7 +12,7 @@ A radio button that typically allows the user to choose only one of a predefined
 
 <div className="pb-5">
     <Callout type="info">
-        We recommend using a [select group](/docs/select-group#radio-form) to create a group of radio buttons instead of using `FRadio` directly.
+        We recommend using a [select group](/docs/form/select-group#radio-form) to create a group of radio buttons instead of using `FRadio` directly.
     </Callout>
 </div>
 

--- a/docs/pages/docs/icon-library.mdx
+++ b/docs/pages/docs/icon-library.mdx
@@ -28,7 +28,7 @@ flutter pub install forui_assets
 </Callout>
 
 <Callout type="info">
-    While you can use an icon from `forui_assets` directly, it is recommended to wrap it in an [FIcon](/docs/icon) to
+    While you can use an icon from `forui_assets` directly, it is recommended to wrap it in an [FIcon](/docs/data/icon) to
     automatically configure its color and size.
 </Callout>
 

--- a/docs/pages/docs/index.mdx
+++ b/docs/pages/docs/index.mdx
@@ -33,7 +33,7 @@ flutter pub add forui_assets
 
 To use Forui widgets in your Flutter app, import the Forui package and place the
 [`FTheme`](https://pub.dev/documentation/forui/latest/forui.theme/FTheme-class.html) widget underneath `CupertinoApp`,
-`MaterialApp`, or `WidgetsApp` at at the root of the widget tree.
+`MaterialApp`, or `WidgetsApp` at the root of the widget tree.
 
 ```dart filename="main.dart" {3,12-18}
 import 'package:flutter/material.dart';

--- a/docs/pages/docs/navigation/bottom-navigation-bar.mdx
+++ b/docs/pages/docs/navigation/bottom-navigation-bar.mdx
@@ -63,7 +63,7 @@ It is used to navigate between a small number of views, typically between three 
 ## Usage
 
 <Callout type="info">
-    A bottom navigation bar is typically used with `FScaffold`. A working example can be found [here](/docs/scaffold).
+    A bottom navigation bar is typically used with `FScaffold`. A working example can be found [here](/docs/layout/scaffold).
 </Callout>
 
 ### `FBottomNavigationBar(...)`

--- a/docs/pages/docs/navigation/header.mdx
+++ b/docs/pages/docs/navigation/header.mdx
@@ -67,7 +67,7 @@ It is typically used on nested pages or sheets.
 ## Usage
 
 <Callout type="info">
-    A header is typically used with `FScaffold`. A working example can be found [here](/docs/scaffold).
+    A header is typically used with `FScaffold`. A working example can be found [here](/docs/layout/scaffold).
 </Callout>
 
 ### `FHeader(...)`

--- a/docs/pages/docs/themes.mdx
+++ b/docs/pages/docs/themes.mdx
@@ -77,7 +77,7 @@ A more detailed explanation of each class can be found in the [Class Diagram](#c
 ## Customize Themes
 
 It's recommended to use the predefined themes as a starting point and customize them with the
-[`inhert(...)`](https://pub.dev/documentation/forui/latest/forui.theme/FThemeData/FThemeData.inherit.html) constructor
+[`inherit(...)`](https://pub.dev/documentation/forui/latest/forui.theme/FThemeData/FThemeData.inherit.html) constructor
 and [`copyWith(...)`](https://pub.dev/documentation/forui/latest/forui.theme/FThemeData/copyWith.html) method to suit your needs.
 
 ```dart filename="main.dart" {3-14, 17-23}


### PR DESCRIPTION
**Describe the changes**
A few of the documentation pages currently contain broken links that are intended to reference other Forui documentation. This change updates those links with corrected locations. This change also fixes a few typos in the documentation.

I ran the documentation on a local server to verify that the updated links work correctly.

Let me know if I missed anything please. Thanks for creating this useful library!

---

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [x] I have included the relevant samples.
- [x] I have updated the documentation accordingly.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.