### PR TITLE
Add relative URL lint for website preview

### DIFF
--- a/.github/workflows/docs_preview_deploy.yaml
+++ b/.github/workflows/docs_preview_deploy.yaml
@@ -83,3 +83,7 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: ${{ steps.render-markdown.outputs.result }}
           edit-mode: replace
+
+      # Check that all relative URLs are working. We don't check external links due to rate limiting.
+      - run: go install github.com/raviqqe/muffet/v2@latest
+      - run: muffet ${{ steps.publish-docs.outputs.url }} --buffer-size=8192 --exclude="(\/cdn-cgi\/)|(github.com)|(pub.dev)"


### PR DESCRIPTION
**Describe the changes**
This PR adds a lint for the website preview which ensures all relative URLs are valid. This should reduce issues such as #235.

The linting is done using [muffet](https://github.com/raviqqe/muffet). It doesn't check external links to avoid rate-limiting as the docs might be deployed fairly frequently.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [x] I have included the relevant samples.
- [x] I have updated the documentation accordingly.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.