### PR TITLE
Fix FTappable stuck in hovered/touched state after being disabled

### DIFF
--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -19,6 +19,9 @@
 * **Breaking:** Remove `onChange` parameter from `FSelectTile`. This was an artifact from early prototyping that was 
   unfortunately overlooked and did not remove.
 
+### Fixes
+
+* Resolved an issue where `FTappable` remained in a hovered or touched state when its `onPress`/`onLongPress` callbacks were nulled after being non-null.
 
 ## 0.8.0
 

--- a/forui/lib/src/foundation/tappable.dart
+++ b/forui/lib/src/foundation/tappable.dart
@@ -171,6 +171,15 @@ class _FTappableState extends State<FTappable> {
 
   @override
   Widget build(BuildContext context) {
+
+    // In the case where a tappable is no longer enabled, we want to reset the hovered and touched states.
+    // This may occur in a menu where a tappable is disabled after being pressed.
+    // The variables _hovered and _touched must be reset in case the item is re-enabled.
+    if (!_enabled) {
+      _hovered = false;
+      _touched = false;
+    }
+    
     var tappable = widget.builder(context, (focused: _focused, hovered: _hovered || _touched), widget.child);
     tappable = _decorate(context, tappable);
 

--- a/forui/lib/src/foundation/tappable.dart
+++ b/forui/lib/src/foundation/tappable.dart
@@ -171,7 +171,6 @@ class _FTappableState extends State<FTappable> {
 
   @override
   Widget build(BuildContext context) {
-
     // In the case where a tappable is no longer enabled, we want to reset the hovered and touched states.
     // This may occur in a menu where a tappable is disabled after being pressed.
     // The variables _hovered and _touched must be reset in case the item is re-enabled.
@@ -179,7 +178,7 @@ class _FTappableState extends State<FTappable> {
       _hovered = false;
       _touched = false;
     }
-    
+
     var tappable = widget.builder(context, (focused: _focused, hovered: _hovered || _touched), widget.child);
     tappable = _decorate(context, tappable);
 

--- a/forui/lib/src/foundation/tappable.dart
+++ b/forui/lib/src/foundation/tappable.dart
@@ -155,6 +155,8 @@ class FTappable extends StatefulWidget {
       ..add(ObjectFlagProperty.has('onLongPress', onLongPress))
       ..add(ObjectFlagProperty.has('builder', builder));
   }
+
+  bool get _enabled => onPress != null || onLongPress != null;
 }
 
 class _FTappableState extends State<FTappable> {
@@ -170,19 +172,20 @@ class _FTappableState extends State<FTappable> {
   }
 
   @override
-  Widget build(BuildContext context) {
-    // In the case where a tappable is no longer enabled, we want to reset the hovered and touched states.
-    // This may occur in a menu where a tappable is disabled after being pressed.
-    // The variables _hovered and _touched must be reset in case the item is re-enabled.
-    if (!_enabled) {
+  void didUpdateWidget(covariant FTappable oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget._enabled != oldWidget._enabled) {
       _hovered = false;
       _touched = false;
     }
+  }
 
+  @override
+  Widget build(BuildContext context) {
     var tappable = widget.builder(context, (focused: _focused, hovered: _hovered || _touched), widget.child);
     tappable = _decorate(context, tappable);
 
-    if (_enabled) {
+    if (widget._enabled) {
       tappable = MouseRegion(
         cursor: SystemMouseCursors.click,
         onEnter: (_) => setState(() => _hovered = true),
@@ -220,7 +223,7 @@ class _FTappableState extends State<FTappable> {
     }
 
     tappable = Semantics(
-      enabled: _enabled,
+      enabled: widget._enabled,
       label: widget.semanticLabel,
       container: true,
       button: true,
@@ -263,8 +266,6 @@ class _FTappableState extends State<FTappable> {
   void _onPointerDown() {}
 
   void _onPointerUp() {}
-
-  bool get _enabled => widget.onPress != null || widget.onLongPress != null;
 }
 
 @internal


### PR DESCRIPTION
When FTappable's onPress/onLongPress callbacks are set to null after being non-null, the widget becomes stuck in a hovered/touched state. To remedy this, the `_hovered` and `_touched` states are reset to false when `_enabled == false`.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [x] I have included the relevant samples.
- [x] I have updated the documentation accordingly.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.