### PR TITLE
Change alignment/border-radius/edge-insets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,12 +116,6 @@ class Foo extends StatelessWidget {
 
 These subclasses have additional life-cycle tracking capabilities baked-in.
 
-### Mark widgets as final when sensible
-
-Subclasses can interact with Forui in unforeseen ways, and cause potential issues. It is not breaking to initially mark
-classes as `final`, and subsequently unmark it. The inverse isn't true. Favor composition over inheritance.
-
-
 ### Minimize dependency on Cupertino/Material
 
 Cupertino and Material specific widgets should be avoided when possible.
@@ -139,6 +133,9 @@ In some situations, it is unrealistic to implement things ourselves. In these ca
 
 Lastly, types from 3rd party packages should not be publicly exported by Forui.
 
+### Prefer `AlignmentGeomtry`/`BorderRadiussGeomtry`/`EdgeInsetsGeomtry` over `Alignment`/`BorderRadius`/`EdgeInsets`
+
+Prefer the `Geomtry` variants when possible because they are more flexible.
 
 ### Widget Styles
 
@@ -166,7 +163,6 @@ They should:
 3. mix-in `_$FooStyleFunctions`, which contains several utility functions.
 4. provide a primary constructor, and a named constructor, `inherit(...)` , that configures itself based on
    an ancestor `FTheme`.
-5. provide a `copyWith(...)` method.
 
 Lastly, the order of the fields and methods should be as shown above.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,10 +133,9 @@ In some situations, it is unrealistic to implement things ourselves. In these ca
 
 Lastly, types from 3rd party packages should not be publicly exported by Forui.
 
-### Prefer `AlignmentGeomtry`/`BorderRadiussGeomtry`/`EdgeInsetsGeomtry` over `Alignment`/`BorderRadius`/`EdgeInsets`
+### Prefer `AlignmentGeometry`/`BorderRadiusGeometry`/`EdgeInsetsGeometry` over `Alignment`/`BorderRadius`/`EdgeInsets`
 
-Prefer the `Geomtry` variants when possible because they are more flexible.
-
+Prefer the `Geometry` variants when possible because they are more flexible.
 ### Widget Styles
 
 ```dart

--- a/docs/pages/docs/data/calendar.mdx
+++ b/docs/pages/docs/data/calendar.mdx
@@ -4,7 +4,7 @@ import LinkBadge from "../../../components/link-badge/link-badge.tsx";
 import LinkBadgeGroup from "../../../components/link-badge/link-badge-group.tsx";
 
 # Calendar
-A date field component that allows users to enter and edit date.
+A calendar that allows users to enter and edit dates.
 
 The calendar pages are designed to be navigable through swipe gestures on mobile platforms, allowing left and right
 swipes to transition between pages.

--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -18,6 +18,9 @@
 
 * Change all widget styles to use code generated functions.
 * Change spacing between `FDateField`'s default prefix icon and content.
+* Change most occurrences of `Alignment` to `AlignmentGeomtry`.
+* Change most occurrences of `BorderRadius` to `BorderRadiussGeomtry`.
+* Change most occurrences of `EdgeInsets` to `EdgeInsetsGeomtry`.
 * **Breaking** Change `FDatePicker` to `FDateField`.
 * **Breaking** Change `FDatePickerController` to `FDateFieldController`.
 * **Breaking** Change `FDatePickerController.calendar` to `FDateFieldController.popover`.

--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -18,9 +18,9 @@
 
 * Change all widget styles to use code generated functions.
 * Change spacing between `FDateField`'s default prefix icon and content.
-* Change most occurrences of `Alignment` to `AlignmentGeomtry`.
-* Change most occurrences of `BorderRadius` to `BorderRadiussGeomtry`.
-* Change most occurrences of `EdgeInsets` to `EdgeInsetsGeomtry`.
+* Change most occurrences of `Alignment` to `AlignmentGeometry`.
+* Change most occurrences of `BorderRadius` to `BorderRadiusGeometry`.
+* Change most occurrences of `EdgeInsets` to `EdgeInsetsGeometry`.
 * **Breaking** Change `FDatePicker` to `FDateField`.
 * **Breaking** Change `FDatePickerController` to `FDateFieldController`.
 * **Breaking** Change `FDatePickerController.calendar` to `FDateFieldController.popover`.

--- a/forui/lib/src/foundation/input/input.dart
+++ b/forui/lib/src/foundation/input/input.dart
@@ -150,7 +150,7 @@ abstract class InputState<T extends Input<U>, U> extends State<T> {
           validator:
               (value) => switch (this.value) {
                 null when value == controller.placeholder => widget.validator(null),
-                null => invalidDateError,
+                null => errorMessage,
                 final value => widget.validator(value),
               },
           autovalidateMode: widget.autovalidateMode,
@@ -168,7 +168,7 @@ abstract class InputState<T extends Input<U>, U> extends State<T> {
   U get value;
 
   @protected
-  String get invalidDateError;
+  String get errorMessage;
 
   @override
   void dispose() {
@@ -184,7 +184,7 @@ abstract class InputState<T extends Input<U>, U> extends State<T> {
       ..add(DiagnosticsProperty('controller', controller))
       ..add(DiagnosticsProperty('textFieldStyle', textFieldStyle))
       ..add(DiagnosticsProperty('value', value))
-      ..add(StringProperty('invalidDateError', invalidDateError));
+      ..add(StringProperty('errorMessage', errorMessage));
   }
 }
 

--- a/forui/lib/src/foundation/portal/portal.dart
+++ b/forui/lib/src/foundation/portal/portal.dart
@@ -23,7 +23,7 @@ class FPortal extends StatefulWidget {
   /// See [childAnchor] for changing the child's anchor.
   ///
   /// Defaults to [Alignment.topCenter].
-  final Alignment portalAnchor;
+  final AlignmentGeometry portalAnchor;
 
   /// The point on the child widget that connections with the portal (floating content), at the portal's anchor.
   ///
@@ -31,7 +31,7 @@ class FPortal extends StatefulWidget {
   /// See [childAnchor] for changing the child's anchor.
   ///
   /// Defaults to [Alignment.bottomCenter].
-  final Alignment childAnchor;
+  final AlignmentGeometry childAnchor;
 
   /// The shifting strategy used to shift a portal when it overflows out of the viewport. Defaults to
   /// [FPortalShift.flip].
@@ -103,16 +103,16 @@ class _State extends State<FPortal> {
 
 class _Alignment extends SingleChildRenderObjectWidget {
   final LayerLink _link;
-  final Alignment _childAnchor;
-  final Alignment _portalAnchor;
+  final AlignmentGeometry _childAnchor;
+  final AlignmentGeometry _portalAnchor;
   final Offset Function(Size, FPortalChildBox, FPortalBox) _shift;
   final Offset _offset;
 
   const _Alignment({
     required Widget child,
     required LayerLink link,
-    required Alignment childAnchor,
-    required Alignment portalAnchor,
+    required AlignmentGeometry childAnchor,
+    required AlignmentGeometry portalAnchor,
     required Offset Function(Size, FPortalChildBox, FPortalBox) shift,
     required Offset offset,
   }) : _link = link,
@@ -123,15 +123,24 @@ class _Alignment extends SingleChildRenderObjectWidget {
        super(child: child);
 
   @override
-  RenderObject createRenderObject(BuildContext _) =>
-      _RenderBox(link: _link, childAnchor: _childAnchor, portalAnchor: _portalAnchor, shift: _shift, offset: _offset);
+  RenderObject createRenderObject(BuildContext context) {
+    final direction = Directionality.maybeOf(context) ?? TextDirection.ltr;
+    return _RenderBox(
+      link: _link,
+      childAnchor: _childAnchor.resolve(direction),
+      portalAnchor: _portalAnchor.resolve(direction),
+      shift: _shift,
+      offset: _offset,
+    );
+  }
 
   @override
-  void updateRenderObject(BuildContext _, _RenderBox box) {
+  void updateRenderObject(BuildContext context, _RenderBox box) {
+    final direction = Directionality.maybeOf(context) ?? TextDirection.ltr;
     box
       ..link = _link
-      ..childAnchor = _childAnchor
-      ..portalAnchor = _portalAnchor
+      ..childAnchor = _childAnchor.resolve(direction)
+      ..portalAnchor = _portalAnchor.resolve(direction)
       ..shift = _shift
       ..offset = _offset;
   }

--- a/forui/lib/src/widgets/accordion/accordion.dart
+++ b/forui/lib/src/widgets/accordion/accordion.dart
@@ -98,11 +98,11 @@ final class FAccordionStyle with Diagnosticable, _$FAccordionStyleFunctions {
 
   /// The padding around the title. Defaults to `EdgeInsets.symmetric(vertical: 15)`.
   @override
-  final EdgeInsets titlePadding;
+  final EdgeInsetsGeometry titlePadding;
 
   /// The padding around the content. Defaults to `EdgeInsets.only(bottom: 15)`.
   @override
-  final EdgeInsets childPadding;
+  final EdgeInsetsGeometry childPadding;
 
   /// The icon's color.
   @override

--- a/forui/lib/src/widgets/alert.dart
+++ b/forui/lib/src/widgets/alert.dart
@@ -168,7 +168,7 @@ final class FAlertCustomStyle extends FAlertStyle with Diagnosticable, _$FAlertC
 
   /// The padding. Defaults to `EdgeInsets.fromLTRB(16, 12, 16, 12)`.
   @override
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// The icon's color.
   ///

--- a/forui/lib/src/widgets/badge/badge_content.dart
+++ b/forui/lib/src/widgets/badge/badge_content.dart
@@ -37,7 +37,7 @@ final class FBadgeContentStyle with Diagnosticable, _$FBadgeContentStyleFunction
 
   /// The padding.
   @override
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// Creates a [FBadgeContentStyle].
   FBadgeContentStyle({

--- a/forui/lib/src/widgets/bottom_navigation_bar/bottom_navigation_bar.dart
+++ b/forui/lib/src/widgets/bottom_navigation_bar/bottom_navigation_bar.dart
@@ -37,15 +37,15 @@ class FBottomNavigationBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final style = this.style ?? context.theme.bottomNavigationBarStyle;
+    final padding = style.padding.resolve(Directionality.maybeOf(context) ?? TextDirection.ltr);
+
     return DecoratedBox(
       decoration: style.decoration,
       child: SafeArea(
         top: false,
         bottom: false,
         child: Padding(
-          padding: style.padding.copyWith(
-            bottom: style.padding.bottom + (MediaQuery.viewPaddingOf(context).bottom * 2 / 3),
-          ),
+          padding: padding.copyWith(bottom: padding.bottom + (MediaQuery.viewPaddingOf(context).bottom * 2 / 3)),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceAround,
             children: [
@@ -117,7 +117,7 @@ class FBottomNavigationBarStyle with Diagnosticable, _$FBottomNavigationBarStyle
 
   /// The padding. Defaults to `EdgeInsets.all(5)`.
   @override
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// The item's focused outline style.
   @override

--- a/forui/lib/src/widgets/bottom_navigation_bar/bottom_navigation_bar_item.dart
+++ b/forui/lib/src/widgets/bottom_navigation_bar/bottom_navigation_bar_item.dart
@@ -84,7 +84,7 @@ final class FBottomNavigationBarItemStyle with Diagnosticable, _$FBottomNavigati
 
   /// The padding. Defaults to `EdgeInsets.all(5)`.
   @override
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// Creates a [FBottomNavigationBarItemStyle].
   FBottomNavigationBarItemStyle({

--- a/forui/lib/src/widgets/breadcrumb.dart
+++ b/forui/lib/src/widgets/breadcrumb.dart
@@ -110,8 +110,8 @@ abstract interface class FBreadcrumbItem extends Widget {
     double maxHeight,
     DragStartBehavior dragStartBehavior,
     FTileDivider divider,
-    Alignment menuAnchor,
-    Alignment childAnchor,
+    AlignmentGeometry menuAnchor,
+    AlignmentGeometry childAnchor,
     Offset Function(Size, FPortalChildBox, FPortalBox) shift,
     FHidePopoverRegion hideOnTapOutside,
     bool directionPadding,
@@ -175,8 +175,8 @@ class _CollapsedCrumb extends StatefulWidget implements FBreadcrumbItem {
   final double maxHeight;
   final DragStartBehavior dragStartBehavior;
   final FTileDivider divider;
-  final Alignment menuAnchor;
-  final Alignment childAnchor;
+  final AlignmentGeometry menuAnchor;
+  final AlignmentGeometry childAnchor;
   final Offset Function(Size, FPortalChildBox, FPortalBox) shift;
   final FHidePopoverRegion hideOnTapOutside;
   final bool directionPadding;
@@ -321,7 +321,7 @@ final class FBreadcrumbStyle with Diagnosticable, _$FBreadcrumbStyleFunctions {
 
   /// The padding. Defaults to `EdgeInsets.symmetric(horizontal: 5)`.
   @override
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// Creates a [FBreadcrumbStyle].
   FBreadcrumbStyle({

--- a/forui/lib/src/widgets/button/button_content.dart
+++ b/forui/lib/src/widgets/button/button_content.dart
@@ -73,7 +73,7 @@ final class FButtonContentStyle with Diagnosticable, _$FButtonContentStyleFuncti
 
   /// The padding. Defaults to `EdgeInsets.symmetric(horizontal: 16, vertical: 12.5)`.
   @override
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// The icon's color when this button is enabled.
   @override
@@ -111,7 +111,7 @@ final class FButtonContentStyle with Diagnosticable, _$FButtonContentStyleFuncti
 final class FButtonIconContentStyle with Diagnosticable, _$FButtonIconContentStyleFunctions {
   /// The padding. Defaults to `EdgeInsets.all(7.5)`.
   @override
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// The icon's color when this button is enabled.
   @override

--- a/forui/lib/src/widgets/calendar/calendar.dart
+++ b/forui/lib/src/widgets/calendar/calendar.dart
@@ -204,7 +204,7 @@ final class FCalendarStyle with Diagnosticable, _$FCalendarStyleFunctions {
 
   /// The padding surrounding the header & picker. Defaults to `EdgeInsets.symmetric(horizontal: 12, vertical: 16)`.
   @override
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// The duration of the page switch animation. Defaults to 200 milliseconds.
   @override

--- a/forui/lib/src/widgets/calendar/shared/entry.dart
+++ b/forui/lib/src/widgets/calendar/shared/entry.dart
@@ -52,10 +52,7 @@ abstract class Entry extends StatelessWidget {
         ),
         _Content(
           style: entryStyle,
-          borderRadius: switch (Directionality.maybeOf(context)) {
-            TextDirection.ltr || null => BorderRadius.horizontal(left: yesterday, right: tomorrow),
-            TextDirection.rtl => BorderRadius.horizontal(left: tomorrow, right: yesterday),
-          },
+          borderRadius: BorderRadiusDirectional.horizontal(start: yesterday, end: tomorrow),
           text: (FLocalizations.of(context) ?? FDefaultLocalizations()).day(date.toNative()),
           data: data,
           current: today,
@@ -172,7 +169,7 @@ class _UnselectableEntry extends Entry {
 
 class _Content extends StatelessWidget {
   final FCalendarEntryStyle style;
-  final BorderRadius borderRadius;
+  final BorderRadiusGeometry borderRadius;
   final String text;
   final FTappableData data;
   final bool current;

--- a/forui/lib/src/widgets/card/card_content.dart
+++ b/forui/lib/src/widgets/card/card_content.dart
@@ -74,7 +74,7 @@ final class FCardContentStyle with Diagnosticable, _$FCardContentStyleFunctions 
 
   /// The padding. Defaults to `EdgeInsets.all(16)`.
   @override
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// Creates a [FCardContentStyle].
   const FCardContentStyle({

--- a/forui/lib/src/widgets/date_field/calendar/calendar_date_field.dart
+++ b/forui/lib/src/widgets/date_field/calendar/calendar_date_field.dart
@@ -11,9 +11,9 @@ class _CalendarDateField extends FDateField implements FDateFieldCalendarPropert
   final MouseCursor mouseCursor;
   final bool canRequestFocus;
   @override
-  final Alignment anchor;
+  final AlignmentGeometry anchor;
   @override
-  final Alignment inputAnchor;
+  final AlignmentGeometry inputAnchor;
   @override
   final Offset Function(Size, FPortalChildBox, FPortalBox) shift;
   @override

--- a/forui/lib/src/widgets/date_field/calendar/properties.dart
+++ b/forui/lib/src/widgets/date_field/calendar/properties.dart
@@ -6,10 +6,10 @@ import 'package:forui/forui.dart';
 /// A date picker calendar popover's properties.
 class FDateFieldCalendarProperties with Diagnosticable {
   /// The alignment point on the calendar popover. Defaults to [Alignment.topLeft].
-  final Alignment anchor;
+  final AlignmentGeometry anchor;
 
   /// The alignment point on the input field. Defaults to [Alignment.bottomLeft].
-  final Alignment inputAnchor;
+  final AlignmentGeometry inputAnchor;
 
   /// {@macro forui.widgets.FPopover.shift}
   final Offset Function(Size, FPortalChildBox, FPortalBox) shift;

--- a/forui/lib/src/widgets/date_field/date_field.dart
+++ b/forui/lib/src/widgets/date_field/date_field.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:forui/src/widgets/date_field/input/date_input.dart';
 
 import 'package:intl/intl.dart' hide TextDirection;
 
 import 'package:forui/forui.dart';
+import 'package:forui/src/widgets/date_field/input/date_input.dart';
 
 part 'calendar/calendar_date_field.dart';
 

--- a/forui/lib/src/widgets/date_field/input/date_input.dart
+++ b/forui/lib/src/widgets/date_field/input/date_input.dart
@@ -108,5 +108,5 @@ class _DateInputState extends InputState<DateInput, DateTime?> {
 
   @override
   @protected
-  String get invalidDateError => localizations.dateFieldInvalidDateError;
+  String get errorMessage => localizations.dateFieldInvalidDateError;
 }

--- a/forui/lib/src/widgets/dialog/dialog.dart
+++ b/forui/lib/src/widgets/dialog/dialog.dart
@@ -127,7 +127,9 @@ class FDialog extends StatelessWidget {
     final style = this.style ?? theme.dialogStyle;
 
     return AnimatedPadding(
-      padding: MediaQuery.viewInsetsOf(context) + style.insetPadding,
+      padding:
+          MediaQuery.viewInsetsOf(context) +
+          style.insetPadding.resolve(Directionality.maybeOf(context) ?? TextDirection.ltr),
       duration: insetAnimationDuration,
       curve: insetAnimationCurve,
       child: MediaQuery.removeViewInsets(
@@ -175,7 +177,7 @@ final class FDialogStyle with Diagnosticable, _$FDialogStyleFunctions {
 
   /// The inset padding. Defaults to `EdgeInsets.symmetric(horizontal: 40, vertical: 24)`.
   @override
-  final EdgeInsets insetPadding;
+  final EdgeInsetsGeometry insetPadding;
 
   /// The horizontal dialog content's style.
   @override

--- a/forui/lib/src/widgets/dialog/dialog_content.dart
+++ b/forui/lib/src/widgets/dialog/dialog_content.dart
@@ -118,7 +118,7 @@ final class FDialogContentStyle with Diagnosticable, _$FDialogContentStyleFuncti
 
   /// The padding surrounding the content.
   @override
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// The space between actions.
   @override

--- a/forui/lib/src/widgets/header/nested_header.dart
+++ b/forui/lib/src/widgets/header/nested_header.dart
@@ -107,7 +107,7 @@ final class FNestedHeaderStyle with Diagnosticable, _$FNestedHeaderStyleFunction
 
   /// The padding.
   @override
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// Creates a [FNestedHeaderStyle].
   const FNestedHeaderStyle({

--- a/forui/lib/src/widgets/header/root_header.dart
+++ b/forui/lib/src/widgets/header/root_header.dart
@@ -83,7 +83,7 @@ final class FRootHeaderStyle with Diagnosticable, _$FRootHeaderStyleFunctions {
 
   /// The padding.
   @override
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// Creates a [FRootHeaderStyle].
   FRootHeaderStyle({

--- a/forui/lib/src/widgets/label.dart
+++ b/forui/lib/src/widgets/label.dart
@@ -196,7 +196,7 @@ final class _FHorizontalLabel extends StatelessWidget {
     );
   }
 
-  Widget _buildCell({required EdgeInsets padding, required TextStyle textStyle, Widget? child}) {
+  Widget _buildCell({required EdgeInsetsGeometry padding, required TextStyle textStyle, Widget? child}) {
     if (child == null) {
       return const TableCell(child: SizedBox());
     }
@@ -320,19 +320,19 @@ final class FLabelStyles with Diagnosticable, _$FLabelStylesFunctions {
 final class FLabelLayoutStyle with Diagnosticable, _$FLabelLayoutStyleFunctions {
   /// The label's padding.
   @override
-  final EdgeInsets labelPadding;
+  final EdgeInsetsGeometry labelPadding;
 
   /// The description's padding.
   @override
-  final EdgeInsets descriptionPadding;
+  final EdgeInsetsGeometry descriptionPadding;
 
   /// The error's padding.
   @override
-  final EdgeInsets errorPadding;
+  final EdgeInsetsGeometry errorPadding;
 
   /// The child's padding.
   @override
-  final EdgeInsets childPadding;
+  final EdgeInsetsGeometry childPadding;
 
   /// Creates a [FLabelLayoutStyle].
   const FLabelLayoutStyle({

--- a/forui/lib/src/widgets/line_calendar/line_calendar.dart
+++ b/forui/lib/src/widgets/line_calendar/line_calendar.dart
@@ -126,7 +126,7 @@ class FLineCalendar extends StatelessWidget {
 final class FLineCalendarStyle with Diagnosticable, _$FLineCalendarStyleFunctions {
   /// The horizontal padding around each calendar item. Defaults to `EdgeInsets.symmetric(horizontal: 6.5)`.
   @override
-  final EdgeInsets itemPadding;
+  final EdgeInsetsGeometry itemPadding;
 
   /// The vertical height between the content and the edges. Defaults to 15.5.
   ///

--- a/forui/lib/src/widgets/picker/picker_style.dart
+++ b/forui/lib/src/widgets/picker/picker_style.dart
@@ -46,7 +46,7 @@ class FPickerStyle with Diagnosticable, _$FPickerStyleFunctions {
 
   /// The selection's border radius.
   @override
-  final BorderRadius selectionBorderRadius;
+  final BorderRadiusGeometry selectionBorderRadius;
 
   /// The selection's color.
   @override

--- a/forui/lib/src/widgets/popover.dart
+++ b/forui/lib/src/widgets/popover.dart
@@ -104,7 +104,7 @@ class FPopover extends StatefulWidget {
   /// {@endtemplate}
   ///
   /// Defaults to [Alignment.bottomCenter] on Android and iOS, and [Alignment.topCenter] on all other platforms.
-  final Alignment popoverAnchor;
+  final AlignmentGeometry popoverAnchor;
 
   /// {@template forui.widgets.FPopover.childAnchor}
   /// The point on the child that connects with the popover, at the popover's anchor.
@@ -114,7 +114,7 @@ class FPopover extends StatefulWidget {
   /// {@endtemplate}
   ///
   /// Defaults to [Alignment.topCenter] on Android and iOS, and [Alignment.bottomCenter] on all other platforms.
-  final Alignment childAnchor;
+  final AlignmentGeometry childAnchor;
 
   /// {@template forui.widgets.FPopover.shift}
   /// The shifting strategy used to shift a popover when it overflows out of the viewport. Defaults to
@@ -169,8 +169,8 @@ class FPopover extends StatefulWidget {
     this.autofocus = false,
     this.focusNode,
     this.onFocusChange,
-    Alignment? popoverAnchor,
-    Alignment? childAnchor,
+    AlignmentGeometry? popoverAnchor,
+    AlignmentGeometry? childAnchor,
     super.key,
   }) : popoverAnchor = popoverAnchor ?? defaultPlatform.popover,
        childAnchor = childAnchor ?? defaultPlatform.child,
@@ -193,8 +193,8 @@ class FPopover extends StatefulWidget {
     this.focusNode,
     this.onFocusChange,
     this.semanticLabel,
-    Alignment? popoverAnchor,
-    Alignment? childAnchor,
+    AlignmentGeometry? popoverAnchor,
+    AlignmentGeometry? childAnchor,
     super.key,
   }) : popoverAnchor = popoverAnchor ?? defaultPlatform.popover,
        childAnchor = childAnchor ?? defaultPlatform.child,
@@ -249,6 +249,7 @@ class _State extends State<FPopover> with SingleTickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
     final style = widget.style ?? context.theme.popoverStyle;
+    final textDirection = Directionality.maybeOf(context) ?? TextDirection.ltr;
     final popover = widget.popoverAnchor;
     final childAnchor = widget.childAnchor;
 
@@ -269,7 +270,11 @@ class _State extends State<FPopover> with SingleTickerProviderStateMixin {
       offset:
           widget.directionPadding
               ? Offset.zero
-              : Alignments.removeDirectionalPadding(style.padding, popover, childAnchor),
+              : Alignments.removeDirectionalPadding(
+                style.padding.resolve(textDirection),
+                popover.resolve(textDirection),
+                childAnchor.resolve(textDirection),
+              ),
       portalBuilder:
           (context) => CallbackShortcuts(
             bindings: {const SingleActivator(LogicalKeyboardKey.escape): _controller.hide},
@@ -324,7 +329,7 @@ class FPopoverStyle with Diagnosticable, _$FPopoverStyleFunctions {
 
   /// The margin surrounding the popover. Defaults to `EdgeInsets.all(4)`.
   @override
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// Creates a [FPopoverStyle].
   const FPopoverStyle({required this.decoration, this.padding = const EdgeInsets.all(4)});

--- a/forui/lib/src/widgets/popover_menu.dart
+++ b/forui/lib/src/widgets/popover_menu.dart
@@ -45,7 +45,7 @@ class FPopoverMenu extends StatefulWidget {
   /// See [childAnchor] for changing the child's anchor.
   ///
   /// Defaults to [Alignment.topCenter].
-  final Alignment menuAnchor;
+  final AlignmentGeometry menuAnchor;
 
   /// The point on the child that connects with the menu, at the menu's anchor.
   ///
@@ -53,7 +53,7 @@ class FPopoverMenu extends StatefulWidget {
   /// See [menuAnchor] for changing the popover's anchor.
   ///
   /// Defaults to [Alignment.bottomCenter].
-  final Alignment childAnchor;
+  final AlignmentGeometry childAnchor;
 
   /// {@macro forui.widgets.FPopover.shift}
   final Offset Function(Size, FPortalChildBox, FPortalBox) shift;

--- a/forui/lib/src/widgets/scaffold.dart
+++ b/forui/lib/src/widgets/scaffold.dart
@@ -110,7 +110,7 @@ final class FScaffoldStyle with Diagnosticable, _$FScaffoldStyleFunctions {
 
   /// The content padding. Only used when [FScaffold.contentPad] is `true`.
   @override
-  final EdgeInsets contentPadding;
+  final EdgeInsetsGeometry contentPadding;
 
   /// The header decoration.
   @override

--- a/forui/lib/src/widgets/select_group/select_group_item.dart
+++ b/forui/lib/src/widgets/select_group/select_group_item.dart
@@ -277,7 +277,7 @@ class FCheckboxSelectGroupStyle extends FCheckboxStyle with _$FCheckboxSelectGro
 class FRadioSelectGroupStyle extends FRadioStyle with _$FRadioSelectGroupStyleFunctions {
   /// The padding around the radio. Defaults to `EdgeInsets.symmetric(vertical: 2)`.
   @override
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// Creates a [FRadioSelectGroupStyle].
   FRadioSelectGroupStyle({

--- a/forui/lib/src/widgets/select_menu_tile.dart
+++ b/forui/lib/src/widgets/select_menu_tile.dart
@@ -60,7 +60,7 @@ class FSelectMenuTile<T> extends FormField<Set<T>> with FTileMixin, FFormFieldPr
   /// See [tileAnchor] for changing the tile's anchor.
   ///
   /// Defaults to [Alignment.topRight].
-  final Alignment menuAnchor;
+  final AlignmentGeometry menuAnchor;
 
   /// The point on the tile that connects with the menu, at the menu's anchor.
   ///
@@ -68,7 +68,7 @@ class FSelectMenuTile<T> extends FormField<Set<T>> with FTileMixin, FFormFieldPr
   /// See [menuAnchor] for changing the menu's anchor.
   ///
   /// Defaults to [Alignment.bottomRight].
-  final Alignment tileAnchor;
+  final AlignmentGeometry tileAnchor;
 
   /// {@macro forui.widgets.FPopover.shift}
   final Offset Function(Size, FPortalChildBox, FPortalBox) shift;

--- a/forui/lib/src/widgets/slider/slider.dart
+++ b/forui/lib/src/widgets/slider/slider.dart
@@ -159,6 +159,7 @@ class FSlider extends StatelessWidget with FFormFieldProperties<FSliderSelection
               description: description,
               errorBuilder: errorBuilder,
               marks: marks,
+              textDirection: Directionality.maybeOf(context) ?? TextDirection.ltr,
               constraints: constraints,
               mainAxisExtent: trackMainAxisExtent,
               onSaved: onSaved,
@@ -201,6 +202,7 @@ class _Slider extends StatefulWidget {
   final Widget? description;
   final Widget Function(BuildContext, String) errorBuilder;
   final List<FSliderMark> marks;
+  final TextDirection textDirection;
   final BoxConstraints constraints;
   final double? mainAxisExtent;
   final FormFieldSetter<FSliderSelection>? onSaved;
@@ -217,6 +219,7 @@ class _Slider extends StatefulWidget {
     required this.description,
     required this.errorBuilder,
     required this.marks,
+    required this.textDirection,
     required this.constraints,
     required this.mainAxisExtent,
     required this.onSaved,
@@ -230,7 +233,7 @@ class _Slider extends StatefulWidget {
   State<_Slider> createState() => _SliderState();
 
   double get _mainAxisExtent {
-    final insets = style.labelLayoutStyle.childPadding;
+    final insets = style.labelLayoutStyle.childPadding.resolve(textDirection);
     final extent = switch (mainAxisExtent) {
       final extent? => extent,
       _ when layout.vertical => constraints.maxHeight - insets.top - insets.bottom,
@@ -260,6 +263,7 @@ class _Slider extends StatefulWidget {
       ..add(EnumProperty('layout', layout))
       ..add(ObjectFlagProperty.has('errorBuilder', errorBuilder))
       ..add(IterableProperty('marks', marks))
+      ..add(EnumProperty('textDirection', textDirection))
       ..add(DiagnosticsProperty('constraints', constraints))
       ..add(DoubleProperty('mainAxisExtent', mainAxisExtent))
       ..add(ObjectFlagProperty.has('onSaved', onSaved))

--- a/forui/lib/src/widgets/slider/slider_mark.dart
+++ b/forui/lib/src/widgets/slider/slider_mark.dart
@@ -72,7 +72,7 @@ final class FSliderMarkStyle with Diagnosticable, _$FSliderMarkStyleFunctions {
 
   /// The label's anchor to which the [labelOffset] is applied.
   @override
-  final Alignment labelAnchor;
+  final AlignmentGeometry labelAnchor;
 
   /// The label's offset from the slider, along its cross axis, in logical pixels. The top-left corner is always the
   /// origin, regardless of the layout.

--- a/forui/lib/src/widgets/slider/slider_styles.dart
+++ b/forui/lib/src/widgets/slider/slider_styles.dart
@@ -165,14 +165,14 @@ final class FSliderStyle with Diagnosticable, _$FSliderStyleFunctions {
   /// Defaults to [Alignment.bottomCenter] on primarily touch devices and [Alignment.centerLeft] on non-primarily touch
   /// devices.
   @override
-  final Alignment tooltipTipAnchor;
+  final AlignmentGeometry tooltipTipAnchor;
 
   /// The anchor of the thumb to which the [tooltipTipAnchor] is aligned to.
   ///
   /// Defaults to [Alignment.topCenter] on primarily touch devices and [Alignment.centerRight] on non-primarily touch
   /// devices.
   @override
-  final Alignment tooltipThumbAnchor;
+  final AlignmentGeometry tooltipThumbAnchor;
 
   /// Creates a [FSliderStyle].
   FSliderStyle({

--- a/forui/lib/src/widgets/tabs/tabs_style.dart
+++ b/forui/lib/src/widgets/tabs/tabs_style.dart
@@ -26,7 +26,7 @@ final class FTabsStyle with Diagnosticable, _$FTabsStyleFunctions {
 
   /// The padding.
   @override
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// The [TextStyle] of the label.
   @override

--- a/forui/lib/src/widgets/text_field/field.dart
+++ b/forui/lib/src/widgets/text_field/field.dart
@@ -10,33 +10,44 @@ class Field extends FormField<String> {
     _State state,
     FTextField parent,
     FTextFieldStateStyle stateStyle,
-    EdgeInsets contentPadding,
-  ) =>
-  // counterTextStyle does not need to be set since it only affects counterText, not counter.
-  InputDecoration(
-    isDense: true,
-    prefixIcon: parent.prefixBuilder?.call(state.context, stateStyle, null),
-    suffixIcon: parent.suffixBuilder?.call(state.context, stateStyle, null),
-    // See https://stackoverflow.com/questions/70771410/flutter-how-can-i-remove-the-content-padding-for-error-in-textformfield
-    prefix: Padding(padding: EdgeInsets.only(left: parent.prefixBuilder == null ? contentPadding.left : 0)),
-    prefixIconConstraints: const BoxConstraints(),
-    suffixIconConstraints: const BoxConstraints(),
-    contentPadding: contentPadding.copyWith(left: 0),
-    hintText: parent.hint,
-    hintStyle: stateStyle.hintTextStyle,
-    disabledBorder: OutlineInputBorder(
-      borderSide: BorderSide(color: stateStyle.unfocusedStyle.color, width: stateStyle.unfocusedStyle.width),
-      borderRadius: stateStyle.unfocusedStyle.radius,
-    ),
-    enabledBorder: OutlineInputBorder(
-      borderSide: BorderSide(color: stateStyle.unfocusedStyle.color, width: stateStyle.unfocusedStyle.width),
-      borderRadius: stateStyle.unfocusedStyle.radius,
-    ),
-    focusedBorder: OutlineInputBorder(
-      borderSide: BorderSide(color: stateStyle.focusedStyle.color, width: stateStyle.focusedStyle.width),
-      borderRadius: stateStyle.focusedStyle.radius,
-    ),
-  );
+    EdgeInsetsGeometry contentPadding,
+  ) {
+    final textDirection = Directionality.maybeOf(state.context) ?? TextDirection.ltr;
+    final padding = contentPadding.resolve(textDirection);
+
+    return InputDecoration(
+      isDense: true,
+      prefixIcon: parent.prefixBuilder?.call(state.context, stateStyle, null),
+      suffixIcon: parent.suffixBuilder?.call(state.context, stateStyle, null),
+      // See https://stackoverflow.com/questions/70771410/flutter-how-can-i-remove-the-content-padding-for-error-in-textformfield
+      prefix: Padding(
+        padding: switch (textDirection) {
+          TextDirection.ltr => EdgeInsets.only(left: parent.prefixBuilder == null ? padding.left : 0),
+          TextDirection.rtl => EdgeInsets.only(right: parent.prefixBuilder == null ? padding.right : 0),
+        },
+      ),
+      prefixIconConstraints: const BoxConstraints(),
+      suffixIconConstraints: const BoxConstraints(),
+      contentPadding: switch (textDirection) {
+        TextDirection.ltr => padding.copyWith(left: 0),
+        TextDirection.rtl => padding.copyWith(right: 0),
+      },
+      hintText: parent.hint,
+      hintStyle: stateStyle.hintTextStyle,
+      disabledBorder: OutlineInputBorder(
+        borderSide: BorderSide(color: stateStyle.unfocusedStyle.color, width: stateStyle.unfocusedStyle.width),
+        borderRadius: stateStyle.unfocusedStyle.radius,
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderSide: BorderSide(color: stateStyle.unfocusedStyle.color, width: stateStyle.unfocusedStyle.width),
+        borderRadius: stateStyle.unfocusedStyle.radius,
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderSide: BorderSide(color: stateStyle.focusedStyle.color, width: stateStyle.focusedStyle.width),
+        borderRadius: stateStyle.focusedStyle.radius,
+      ),
+    );
+  }
 
   final FTextField parent;
 

--- a/forui/lib/src/widgets/text_field/text_field_style.dart
+++ b/forui/lib/src/widgets/text_field/text_field_style.dart
@@ -25,7 +25,7 @@ final class FTextFieldStyle with Diagnosticable, _$FTextFieldStyleFunctions {
   ///
   /// Defaults to `const EdgeInsets.symmetric(horizontal: 14, vertical: 14)`.
   @override
-  final EdgeInsets contentPadding;
+  final EdgeInsetsGeometry contentPadding;
 
   /// Configures padding to edges surrounding a [Scrollable] when this text field scrolls into view.
   ///

--- a/forui/lib/src/widgets/tile/tile_content.dart
+++ b/forui/lib/src/widgets/tile/tile_content.dart
@@ -133,9 +133,9 @@ class FTileContent extends StatelessWidget {
 
 /// A [FTile] content's style.
 final class FTileContentStyle with Diagnosticable, _$FTileContentStyleFunctions {
-  /// The content's padding. Defaults to `EdgeInsets.only(left: 15, top: 13, right: 10, bottom: 13)`.
+  /// The content's padding. Defaults to `EdgeInsetsDirectional.only(15, 13, 10, 13)`.
   @override
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// The horizontal spacing between the prefix icon and title and the subtitle. Defaults to 10.
   ///
@@ -182,7 +182,7 @@ final class FTileContentStyle with Diagnosticable, _$FTileContentStyleFunctions 
     required this.enabledStyle,
     required this.enabledHoveredStyle,
     required this.disabledStyle,
-    this.padding = const EdgeInsets.only(left: 15, top: 13, right: 10, bottom: 13),
+    this.padding = const EdgeInsetsDirectional.fromSTEB(15, 13, 10, 13),
     this.prefixIconSpacing = 10,
     this.titleSpacing = 3,
     this.middleSpacing = 4,

--- a/forui/lib/src/widgets/tile/tile_group.dart
+++ b/forui/lib/src/widgets/tile/tile_group.dart
@@ -392,7 +392,7 @@ class FTileGroupStyle extends FLabelStateStyles with Diagnosticable, _$FTileGrou
 
   /// The group's border radius.
   @override
-  final BorderRadius borderRadius;
+  final BorderRadiusGeometry borderRadius;
 
   /// The tile's style.
   @override

--- a/forui/lib/src/widgets/tile/tile_render_object.dart
+++ b/forui/lib/src/widgets/tile/tile_render_object.dart
@@ -52,7 +52,7 @@ class _RenderTile extends RenderBox
 
   @override
   void performLayout() {
-    final EdgeInsets(:left, :top, :right, :bottom) = _style.padding;
+    final EdgeInsets(:left, :top, :right, :bottom) = _style.padding.resolve(_textDirection);
     var constraints = this.constraints.loosen().copyWith(maxWidth: this.constraints.maxWidth - left - right);
     var height = 0.0;
 

--- a/forui/lib/src/widgets/time_field/input/time_input.dart
+++ b/forui/lib/src/widgets/time_field/input/time_input.dart
@@ -111,5 +111,5 @@ class _TimeFieldState extends InputState<TimeInput, FTime?> {
 
   @override
   @protected
-  String get invalidDateError => localizations.timeFieldInvalidDateError;
+  String get errorMessage => localizations.timeFieldInvalidDateError;
 }

--- a/forui/lib/src/widgets/time_field/picker/properties.dart
+++ b/forui/lib/src/widgets/time_field/picker/properties.dart
@@ -7,8 +7,8 @@ import 'package:forui/forui.dart';
 
 @internal
 class FTimeFieldPickerProperties with Diagnosticable {
-  final Alignment anchor;
-  final Alignment inputAnchor;
+  final AlignmentGeometry anchor;
+  final AlignmentGeometry inputAnchor;
   final Offset Function(Size, FPortalChildBox, FPortalBox) shift;
   final FHidePopoverRegion hideOnTapOutside;
   final bool directionPadding;

--- a/forui/lib/src/widgets/time_picker/picker.dart
+++ b/forui/lib/src/widgets/time_picker/picker.dart
@@ -14,8 +14,8 @@ abstract class TimePicker extends StatelessWidget {
   final FTimePickerStyle style;
   final DateFormat format;
   final int padding;
-  final EdgeInsetsDirectional start;
-  final EdgeInsetsDirectional end;
+  final EdgeInsetsGeometry start;
+  final EdgeInsetsGeometry end;
   final int hourInterval;
   final int minuteInterval;
 

--- a/forui/lib/src/widgets/tooltip.dart
+++ b/forui/lib/src/widgets/tooltip.dart
@@ -82,10 +82,10 @@ class FTooltip extends StatefulWidget {
   final FTooltipStyle? style;
 
   /// The anchor of the follower to which the [childAnchor] is aligned to. Defaults to [Alignment.bottomCenter].
-  final Alignment tipAnchor;
+  final AlignmentGeometry tipAnchor;
 
   /// The anchor of the target to which the [tipAnchor] is aligned to. Defaults to [Alignment.topCenter].
-  final Alignment childAnchor;
+  final AlignmentGeometry childAnchor;
 
   /// The shifting strategy used to shift a tooltip's tip when it overflows out of the viewport. Defaults to
   /// [FPortalShift.flip].

--- a/forui/test/src/widgets/date_field/input/date_input_controller_localization_test.dart
+++ b/forui/test/src/widgets/date_field/input/date_input_controller_localization_test.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/cupertino.dart';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:forui/src/widgets/date_field/input/date_input_controller.dart';
 import 'package:intl/intl.dart';
 
 import 'package:forui/forui.dart';
 import 'package:forui/src/localizations/localization.dart';
+import 'package:forui/src/widgets/date_field/input/date_input_controller.dart';
 import '../../../test_scaffold.dart';
 
 final _date = DateTime(2024, 12, 25);


### PR DESCRIPTION
**Describe the changes**
This PR replaces most fields signatures to their more generic super-types:
* `Alignment` to `AlignmentGeomtry`
* `BorderRadius` to `BorderRadiussGeomtry`
* `EdgeInsets` to `EdgeInsetsGeomtry`

This allows directional variants to be passed in.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [x] I have included the relevant samples.
- [x] I have updated the documentation accordingly.
- [x] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.