### PR TITLE
Fix CLI generating duplicate styles when -all flag specified

### DIFF
--- a/forui/bin/commands/style/create/generate.dart
+++ b/forui/bin/commands/style/create/generate.dart
@@ -118,7 +118,7 @@ extension Generation on StyleCreateCommand {
     final paths = <String, List<String>>{};
     final existing = <String>{};
 
-    for (final style in all ? registry.keys.toList() : arguments) {
+    for (final style in all ? Style.values.asNameMap().keys : arguments) {
       final fileName = registry[style.toLowerCase()]!.type.substring(1).toSnakeCase();
       final path =
           '${configuration.root.path}${Platform.pathSeparator}${output.endsWith('.dart') ? output : '$output${Platform.pathSeparator}$fileName.dart'}';


### PR DESCRIPTION
**Describe the changes**
<!-- 
A clear and concise description of the changes. Please [link an issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
if applicable. 
-->

**Checklist**
- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.