### PR TITLE
Fix document logo hydration error

### DIFF
--- a/docs/components/ui/logo.tsx
+++ b/docs/components/ui/logo.tsx
@@ -2,6 +2,7 @@
 
 import { useTheme } from 'nextra-theme-docs';
 import Image from 'next/image';
+import { useState, useEffect } from 'react';
 
 interface Props {
   className?: string;
@@ -9,10 +10,17 @@ interface Props {
 
 export default function Logo({ className = 'w-24 h-auto' }: Props) {
   const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const logoSrc = mounted && resolvedTheme === 'dark' ? '/dark_logo.svg' : '/light_logo.svg';
 
   return (
     <Image
-      src={resolvedTheme == 'dark' ? '/dark_logo.svg' : '/light_logo.svg'}
+      src={logoSrc}
       className={className}
       width={0}
       height={0}


### PR DESCRIPTION
**Describe the changes**
A hydration error occurs when the theme is set to auto and the device is in dark mode. This is caused by the server rendering the light logo, which is a mismatch compared to the dark logo rendered by the client.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.