### PR TITLE
feat(tabs): add onTap function

### DIFF
--- a/forui/lib/src/widgets/tabs/tabs.dart
+++ b/forui/lib/src/widgets/tabs/tabs.dart
@@ -72,6 +72,9 @@ class FTabs extends StatefulWidget {
   /// Handler for when a tab is changed.
   final ValueChanged<int>? onChange;
 
+  /// Triggered when the tab is clicked
+  final ValueChanged<int>? onTap;
+
   /// The tabs.
   final List<FTabEntry> children;
 
@@ -90,6 +93,7 @@ class FTabs extends StatefulWidget {
     this.controller,
     this.style,
     this.onChange,
+    this.onTap,
     super.key,
   }) : assert(children.isNotEmpty, 'Must have at least 1 tab provided.'),
        assert(0 <= initialIndex && initialIndex < children.length, 'initialIndex must be within the range of tabs.'),
@@ -110,6 +114,7 @@ class FTabs extends StatefulWidget {
       ..add(DiagnosticsProperty('physics', physics))
       ..add(ObjectFlagProperty.has('onPress', onChange))
       ..add(IterableProperty('children', children));
+      ..add(ObjectFlagProperty.has('onTap', onTap));
   }
 
   @override
@@ -176,6 +181,7 @@ class _FTabsState extends State<FTabs> with SingleTickerProviderStateMixin {
               dividerColor: Colors.transparent,
               labelStyle: style.selectedLabelTextStyle,
               unselectedLabelStyle: style.unselectedLabelTextStyle,
+              onTap: widget.onTap,
             ),
           ),
           SizedBox(height: style.spacing),


### PR DESCRIPTION
This function is triggered on click.

**Describe the changes**
When I use it with TabBarView,the onChange function is only triggered after the tab animation ends, hence the addition of the onTab function.

origin:
```dart
  Widget _getTabBar() {
    return FTabs(
      onChange: (value) {
        navigationIndexChanged(value);
      },
      children:
          tabList
              .map((e) => FTabEntry(label: Text(e), child: Container()))
              .toList(),
    );
  }

  Widget _getTabBarView(BuildContext context) {
    return TabBarView(
      controller: tabController,
      children: [for (int i = 0; i < tabList.length; i++) _getList(context)],
    );
  }
```

https://github.com/user-attachments/assets/19e5b0ba-0d62-49d8-b7f0-24d20c174314


use onTap:

https://github.com/user-attachments/assets/559ee044-b626-45f7-b7b9-3c6d82a9500f



**Checklist**
- [√] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [  ] I have included the relevant unit/golden tests.
- [  ] I have included the relevant samples.
- [  ] I have updated the documentation accordingly.
- [  ] I have added the required flutters_hook for widget controllers.
- [  ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.