### PR TITLE
Fix `FTappable` persisting pressed effect even after pointer is moved outside the widget.

### DIFF
--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.13.0
+
+### Others
+* Fix `FTappable` persisting pressed effect even after pointer is moved outside the widget.
+
+
 ## 0.12.0
 
 Bumps minimum Flutter SDK version to 3.32.0.

--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.13.0
+## 0.13.0 (Next)
 
 ### Others
 * Fix `FTappable` persisting pressed effect even after pointer is moved outside the widget.

--- a/forui/test/src/foundation/tappable_test.dart
+++ b/forui/test/src/foundation/tappable_test.dart
@@ -22,8 +22,8 @@ class _StubTappable extends AnimatedTappable {
 
 class _StubTappableState extends AnimatedTappableState {
   @override
-  void onPointerUp() {
-    Future.delayed(const Duration(seconds: 1)).then((_) => super.onPointerUp());
+  void onPressedEnd() {
+    Future.delayed(const Duration(seconds: 1)).then((_) => super.onPressedEnd());
   }
 }
 
@@ -142,6 +142,29 @@ void main() {
         await tester.pumpAndSettle();
         expect(find.text(set(enabled).toString()), findsOneWidget);
         expect(key.currentState!.animation.value, 1);
+      });
+
+      testWidgets('press, hold & move outside - $enabled', (tester) async {
+        final key = GlobalKey<AnimatedTappableState>();
+
+        await tester.pumpWidget(
+          TestScaffold(
+            child: FTappable(key: key, builder: (_, states, _) => Text('$states'), onPress: enabled ? () {} : null),
+          ),
+        );
+        expect(find.text(set(enabled).toString()), findsOneWidget);
+        expect(key.currentState!.animation.value, 1);
+
+        final gesture = await tester.press(find.byType(AnimatedTappable));
+        await tester.pumpAndSettle(const Duration(milliseconds: 200));
+        expect(find.text({...set(enabled), WidgetState.pressed}.toString()), findsOneWidget);
+        expect(key.currentState!.animation.value, enabled ? 0.97 : 1.0);
+
+        await gesture.moveTo(Offset.zero);
+        await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+        expect(find.text({...set(enabled)}.toString()), findsOneWidget);
+        expect(key.currentState!.animation.value, 1.0);
       });
 
       testWidgets('shortcut', (tester) async {
@@ -333,6 +356,23 @@ void main() {
         expect(find.text({...set(enabled), WidgetState.pressed}.toString()), findsOneWidget);
 
         await gesture.up();
+        await tester.pumpAndSettle();
+        expect(find.text(set(enabled).toString()), findsOneWidget);
+      });
+
+      testWidgets('press, hold & move outside - $enabled', (tester) async {
+        await tester.pumpWidget(
+          TestScaffold(
+            child: FTappable.static(builder: (_, states, _) => Text('$states'), onPress: enabled ? () {} : null),
+          ),
+        );
+        expect(find.text(set(enabled).toString()), findsOneWidget);
+
+        final gesture = await tester.press(find.byType(FTappable));
+        await tester.pumpAndSettle(const Duration(milliseconds: 200));
+        expect(find.text({...set(enabled), WidgetState.pressed}.toString()), findsOneWidget);
+
+        await gesture.moveTo(Offset.zero);
         await tester.pumpAndSettle();
         expect(find.text(set(enabled).toString()), findsOneWidget);
       });


### PR DESCRIPTION
**Describe the changes**
<!-- 
A clear and concise description of the changes. Please [link an issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
if applicable. 
-->

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.