### PR TITLE
Fix `FTextFormField` not passing correct value to validator when no controller is provided

### DIFF
--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -165,6 +165,7 @@ We have refactored `FTile`'s implementation to be simpler & its styling to be ea
 * Fix `FSelect.search(...)` always focusing on 1st item even when there is a selected item.
 * Fix `FSelect.search(...)` expanding items unnecessarily.
 * Fix `FTappable` persisting pressed effect even after pointer is moved outside the widget.
+* Fix `FTextFormField` not passing correct value to validator when no controller is provided.
 
 
 ## 0.12.0

--- a/forui/lib/src/widgets/text_field/text_form_field.dart
+++ b/forui/lib/src/widgets/text_field/text_form_field.dart
@@ -637,7 +637,10 @@ class _FormField extends FormField<String> {
               showCursor: field.showCursor,
               maxLength: field.maxLength,
               maxLengthEnforcement: field.maxLengthEnforcement,
-              onChange: field.onChange,
+              onChange: (value) {
+                state.didChange(value);
+                field.onChange?.call(value);
+              },
               onTap: field.onTap,
               onTapAlwaysCalled: field.onTapAlwaysCalled,
               onEditingComplete: field.onEditingComplete,

--- a/forui/test/src/widgets/text_field/text_form_field_test.dart
+++ b/forui/test/src/widgets/text_field/text_form_field_test.dart
@@ -98,7 +98,7 @@ void main() {
                 null,
                 autoDispose(TextEditingController(text: 'initial')),
                 AutovalidateMode.always,
-                    (value) => value == 'some-value' ? null : 'Invalid value',
+                (value) => value == 'some-value' ? null : 'Invalid value',
                 null,
               ),
             ),

--- a/forui/test/src/widgets/text_field/text_form_field_test.dart
+++ b/forui/test/src/widgets/text_field/text_form_field_test.dart
@@ -10,20 +10,43 @@ void main() {
     for (final (type, field) in [
       (
         'normal',
-        (text, controller, saved) => FTextFormField(initialText: text, controller: controller, onSaved: saved),
+        (text, controller, autovalidate, validator, saved) => FTextFormField(
+          initialText: text,
+          controller: controller,
+          autovalidateMode: autovalidate ?? AutovalidateMode.disabled,
+          validator: validator,
+          onSaved: saved,
+        ),
       ),
       (
         'email',
-        (text, controller, saved) => FTextFormField.email(initialText: text, controller: controller, onSaved: saved),
+        (text, controller, autovalidate, validator, saved) => FTextFormField.email(
+          initialText: text,
+          controller: controller,
+          autovalidateMode: autovalidate ?? AutovalidateMode.disabled,
+          validator: validator,
+          onSaved: saved,
+        ),
       ),
       (
         'password',
-        (text, controller, saved) => FTextFormField.password(initialText: text, controller: controller, onSaved: saved),
+        (text, controller, autovalidate, validator, saved) => FTextFormField.password(
+          initialText: text,
+          controller: controller,
+          autovalidateMode: autovalidate ?? AutovalidateMode.disabled,
+          validator: validator,
+          onSaved: saved,
+        ),
       ),
       (
         'multiline',
-        (text, controller, saved) =>
-            FTextFormField.multiline(initialText: text, controller: controller, onSaved: saved),
+        (text, controller, autovalidate, validator, saved) => FTextFormField.multiline(
+          initialText: text,
+          controller: controller,
+          autovalidateMode: autovalidate ?? AutovalidateMode.disabled,
+          validator: validator,
+          onSaved: saved,
+        ),
       ),
     ]) {
       testWidgets('$type - set initial text using initialText', (tester) async {
@@ -32,7 +55,7 @@ void main() {
         String? initial;
         await tester.pumpWidget(
           TestScaffold.app(
-            child: Form(key: key, child: field('initial', null, (value) => initial = value)),
+            child: Form(key: key, child: field('initial', null, null, null, (value) => initial = value)),
           ),
         );
 
@@ -50,7 +73,13 @@ void main() {
           TestScaffold.app(
             child: Form(
               key: key,
-              child: field(null, autoDispose(TextEditingController(text: 'initial')), (value) => initial = value),
+              child: field(
+                null,
+                autoDispose(TextEditingController(text: 'initial')),
+                null,
+                null,
+                (value) => initial = value,
+              ),
             ),
           ),
         );
@@ -59,6 +88,58 @@ void main() {
         await tester.pumpAndSettle(const Duration(seconds: 5));
 
         expect(initial, 'initial');
+      });
+
+      testWidgets('$type - with controller, validator called with correct value', (tester) async {
+        await tester.pumpWidget(
+          TestScaffold.app(
+            child: Form(
+              child: field(
+                null,
+                autoDispose(TextEditingController(text: 'initial')),
+                AutovalidateMode.always,
+                    (value) => value == 'some-value' ? null : 'Invalid value',
+                null,
+              ),
+            ),
+          ),
+        );
+
+        await tester.enterText(find.byType(FTextFormField), 'other-value');
+        await tester.pumpAndSettle();
+
+        expect(find.text('Invalid value'), findsOneWidget);
+
+        await tester.enterText(find.byType(FTextFormField), 'some-value');
+        await tester.pumpAndSettle();
+
+        expect(find.text('Invalid value'), findsNothing);
+      });
+
+      testWidgets('$type - without controller, validator called with correct value', (tester) async {
+        await tester.pumpWidget(
+          TestScaffold.app(
+            child: Form(
+              child: field(
+                null,
+                null,
+                AutovalidateMode.always,
+                (value) => value == 'some-value' ? null : 'Invalid value',
+                null,
+              ),
+            ),
+          ),
+        );
+
+        await tester.enterText(find.byType(FTextFormField), 'other-value');
+        await tester.pumpAndSettle();
+
+        expect(find.text('Invalid value'), findsOneWidget);
+
+        await tester.enterText(find.byType(FTextFormField), 'some-value');
+        await tester.pumpAndSettle();
+
+        expect(find.text('Invalid value'), findsNothing);
       });
     }
   });


### PR DESCRIPTION
**Describe the changes**
Fixes #582 

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.