### PR TITLE
Fix typo in style object assignment

### DIFF
--- a/docs/app/docs/form/select-group/page.mdx
+++ b/docs/app/docs/form/select-group/page.mdx
@@ -63,7 +63,7 @@ dart run forui style create select-group
 ```dart copy
 FSelectGroup<Value>(
   controller: FSelectGroupController(), // or FSelectGroupController.radio()
-  style: FFSelectGroup(...),
+  style: FSelectGroupStyle(...),
   label: const Text('Sidebar'),
   description: const Text('Select the items you want to display in the sidebar.'),
   onChange: (all) => print(all),

--- a/docs/app/docs/navigation/bottom-navigation-bar/page.mdx
+++ b/docs/app/docs/navigation/bottom-navigation-bar/page.mdx
@@ -80,7 +80,7 @@ dart run forui style create bottom-navigation-bar
 
 ```dart copy
 FBottomNavigationBar(
-  style: FBottomNavigationBar(),
+  style: FBottomNavigationBarStyle(...),
   index: 0,
   onChange: (index) => {},
   children: [


### PR DESCRIPTION
**Describe the changes**

Fix typo in style object assignment in the following documentation.

- `FBottomNavigationBar`
- `FSelectGroup`

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.