### PR TITLE
Fix `GestureDetector` being absorbed in focused `FItem`s.

### DIFF
--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -46,6 +46,11 @@ We've improved the styles' generated documentation. They should be much easier t
 * **Breaking** Add `FFormFieldProperties(onReset: ...)`.
 
 
+### `FItem`
+
+* Fix `GestureDetector` being absorbed in focused `FItem`s.
+
+
 ### `FPopover` & `FPopoverMenu`
 * Add `FPopoverMotion`.
 

--- a/forui/lib/src/widgets/item/item.dart
+++ b/forui/lib/src/widgets/item/item.dart
@@ -274,7 +274,6 @@ class FItem extends StatelessWidget with FItemMixin {
       child: Padding(
         padding: margin,
         child: FTappable(
-          behavior: HitTestBehavior.translucent,
           style: style.tappableStyle,
           semanticsLabel: semanticsLabel,
           autofocus: autofocus,

--- a/forui/lib/src/widgets/item/item.dart
+++ b/forui/lib/src/widgets/item/item.dart
@@ -274,6 +274,7 @@ class FItem extends StatelessWidget with FItemMixin {
       child: Padding(
         padding: margin,
         child: FTappable(
+          behavior: HitTestBehavior.translucent,
           style: style.tappableStyle,
           semanticsLabel: semanticsLabel,
           autofocus: autofocus,
@@ -288,22 +289,19 @@ class FItem extends StatelessWidget with FItemMixin {
           onSecondaryLongPress: enabled ? (onSecondaryLongPress ?? () {}) : null,
           shortcuts: shortcuts,
           actions: actions,
-          builder: (context, states, _) => Stack(
-            children: [
-              DecoratedBox(
-                decoration: style.decoration.maybeResolve(states) ?? const BoxDecoration(),
-                child: _builder(context, style, top, bottom, states, data.dividerColor, data.dividerWidth, divider),
+          builder: (context, states, _) => DecoratedBox(
+            position: DecorationPosition.foreground,
+            decoration: switch (style.focusedOutlineStyle) {
+              final outline? when states.contains(WidgetState.focused) => BoxDecoration(
+                border: Border.all(color: outline.color, width: outline.width),
+                borderRadius: outline.borderRadius,
               ),
-              if (style.focusedOutlineStyle case final outline? when states.contains(WidgetState.focused))
-                Positioned.fill(
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      border: Border.all(color: outline.color, width: outline.width),
-                      borderRadius: outline.borderRadius,
-                    ),
-                  ),
-                ),
-            ],
+              _ => const BoxDecoration(),
+            },
+            child: DecoratedBox(
+              decoration: style.decoration.maybeResolve(states) ?? const BoxDecoration(),
+              child: _builder(context, style, top, bottom, states, data.dividerColor, data.dividerWidth, divider),
+            ),
           ),
         ),
       ),

--- a/forui/test/src/widgets/item/item_test.dart
+++ b/forui/test/src/widgets/item/item_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:flutter_test/flutter_test.dart';
 
@@ -143,5 +144,30 @@ void main() {
     await tester.pumpAndSettle(const Duration(seconds: 5));
 
     expect(count, 1);
+  });
+
+  testWidgets('focus does not cause inner gesture detector to be ignored', (tester) async {
+    var outer = 0;
+    var inner = 0;
+    final focusNode = FocusNode();
+    await tester.pumpWidget(
+      TestScaffold(
+        child: FItem(
+          focusNode: focusNode,
+          title: const Text('Bluetooth'),
+          onPress: () => outer++,
+          suffix: FButton.icon(onPress: () => inner++, child: const Icon(FIcons.pencil)),
+        ),
+      ),
+    );
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+
+    await tester.tap(find.byIcon(FIcons.pencil));
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+
+    expect(inner, 1);
+    expect(outer, 0);
   });
 }

--- a/forui/test/src/widgets/item/item_test.dart
+++ b/forui/test/src/widgets/item/item_test.dart
@@ -149,7 +149,7 @@ void main() {
   testWidgets('focus does not cause inner gesture detector to be ignored', (tester) async {
     var outer = 0;
     var inner = 0;
-    final focusNode = FocusNode();
+    final focusNode = autoDispose(FocusNode());
     await tester.pumpWidget(
       TestScaffold(
         child: FItem(


### PR DESCRIPTION
**Describe the changes**
<!-- 
A clear and concise description of the changes. Please [link an issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
if applicable. 
-->

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [x] I have included the relevant samples.
- [x] I have updated the documentation accordingly.
- [x] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.