### PR TITLE
Add navigation note for date scrolling

### DIFF
--- a/docs/app/docs/data/calendar/page.mdx
+++ b/docs/app/docs/data/calendar/page.mdx
@@ -20,6 +20,10 @@ controls the date selection behavior, including single date, multiple dates, and
     `FCalendar` and all `FCalendarController`s return `DateTime`s in UTC timezone, truncated to the nearest day.
 </Callout>
 
+<Callout type="info">
+  Hold `Shift` while scrolling to navigate through dates on desktop and web.
+</Callout>
+
 <Tabs items={['Preview', 'Code']}>
     <Tabs.Tab>
         <Widget name='calendar' query={{}} height={500}/>


### PR DESCRIPTION
Added a note about navigating through dates using Shift key.

**Describe the changes**
<!-- 
A clear and concise description of the changes. Please [link an issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
if applicable. 
-->

Added a note about scrolling as I didn't realize you could do so on web until I saw the Line Calendar's call out too and realized it worked on the regular Calendar widget as well. 

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [x] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.