### PR TITLE
Update example to focus on login button demo

### DIFF
--- a/forui/example/lib/main.dart
+++ b/forui/example/lib/main.dart
@@ -14,14 +14,6 @@ void main() {
   runApp(const Application());
 }
 
-List<Widget> _pages = [
-  const Text('Home'),
-  const Text('Categories'),
-  const Text('Search'),
-  const Text('Settings'),
-  const Sandbox(),
-];
-
 class Application extends StatefulWidget {
   const Application({super.key});
 
@@ -29,45 +21,24 @@ class Application extends StatefulWidget {
   State<Application> createState() => _ApplicationState();
 }
 
-class _ApplicationState extends State<Application> with SingleTickerProviderStateMixin {
-  int index = 4;
-  bool dark = false;
-
-  FThemeData get _theme => dark ? FThemes.zinc.dark : FThemes.zinc.light;
-
-  void toggleTheme() => setState(() => dark = !dark);
-
+class _ApplicationState extends State<Application> {
   @override
-  Widget build(BuildContext context) => MaterialApp(
-    locale: const Locale('en', 'US'),
-    localizationsDelegates: FLocalizations.localizationsDelegates,
-    supportedLocales: FLocalizations.supportedLocales,
-    theme: _theme.toApproximateMaterialTheme(),
-    builder: (context, child) => FTheme(
-      data: _theme,
-      child: FToaster(child: FTooltipGroup(child: child!)),
-    ),
-    home: Builder(
-      builder: (context) {
-        return FScaffold(
-          header: FHeader(
-            title: const Text('Example'),
-            suffixes: [FHeaderAction(icon: Icon(dark ? FIcons.sun : FIcons.moon), onPress: toggleTheme)],
-          ),
-          footer: FBottomNavigationBar(
-            index: index,
-            onChange: (index) => setState(() => this.index = index),
-            children: const [
-              FBottomNavigationBarItem(icon: Icon(FIcons.house)),
-              FBottomNavigationBarItem(icon: Icon(FIcons.layoutGrid)),
-              FBottomNavigationBarItem(icon: Icon(FIcons.search)),
-              FBottomNavigationBarItem(icon: Icon(FIcons.settings)),
-              FBottomNavigationBarItem(icon: Icon(FIcons.castle)),
-            ],
-          ),
-          child: _pages[index],
-        );
-      },
-    ),
-  );
+  Widget build(BuildContext context) {
+    final theme = FThemes.zinc.light;
+
+    return MaterialApp(
+      locale: const Locale('en', 'US'),
+      localizationsDelegates: FLocalizations.localizationsDelegates,
+      supportedLocales: FLocalizations.supportedLocales,
+      theme: theme.toApproximateMaterialTheme(),
+      builder: (context, child) => FTheme(
+        data: theme,
+        child: FToaster(child: FTooltipGroup(child: child!)),
+      ),
+      home: const Scaffold(
+        backgroundColor: Colors.white,
+        body: Center(child: Sandbox()),
+      ),
+    );
+  }
 }

--- a/forui/example/lib/sandbox.dart
+++ b/forui/example/lib/sandbox.dart
@@ -1,60 +1,30 @@
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
 
-class Sandbox extends StatefulWidget {
+class Sandbox extends StatelessWidget {
   const Sandbox({super.key});
 
   @override
-  State<Sandbox> createState() => _SandboxState();
-}
-
-class _SandboxState extends State<Sandbox> {
-  @override
-  Widget build(BuildContext context) => SingleChildScrollView(
-    padding: const EdgeInsets.all(20),
-    child: Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        spacing: 20,
-        children: [
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            spacing: 10,
-            children: [
-              FBadge(child: Text('Primary')),
-              FBadge(variant: .secondary, child: Text('Secondary')),
-              FBadge(variant: .outline, child: Text('Outline')),
-              FBadge(variant: .destructive, child: Text('Destructive')),
-            ],
-          ),
-          FDateField(
-            control: .managed(initial: DateTime(2025, 12, 31)),
-            label: const Text('Start Date'),
-            description: const Text('Select a start date'),
-          ),
-          FDateField(label: const Text('End Date'), description: const Text('Select an end date')),
-          FSlider(
-            control: .managedContinuous(initial: FSliderValue(max: 0.35)),
-            marks: const [
-              .mark(value: 0, label: Text('0%')),
-              .mark(value: 0.25, tick: false),
-              .mark(value: 0.5),
-              .mark(value: 0.75, tick: false),
-              .mark(value: 1, label: Text('100%')),
-            ],
-          ),
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            spacing: 10,
-            children: [
-              FButton(onPress: () {}, child: Text('Primary')),
-              FButton(variant: .secondary, onPress: () {}, child: Text('Secondary')),
-              FButton(variant: .outline, onPress: () {}, child: Text('Outline')),
-              FButton(variant: .destructive, onPress: () {}, child: Text('Destructive')),
-            ],
-          ),
-        ],
+  Widget build(BuildContext context) => FButton(
+    mainAxisSize: .min,
+    prefix: const Icon(FIcons.mail),
+    onPress: () {},
+    style: .delta(
+      decoration: .delta([
+        .base(const .delta(color: Colors.blue)),
+        .exact({.hovered}, const .delta(color: Colors.blueAccent)),
+        .match({.pressed}, const .delta(color: Colors.black)),
+      ]),
+      contentStyle: .delta(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 13),
+        spacing: 10,
+        textStyle: .delta([
+          // .all(const .delta(decoration: .underline))
+          .exact({.hovered}, const .delta(decoration: .underline, color: Colors.red)),
+          .exact({.hovered.and(.pressed)}, const .delta(decoration: .underline)),
+        ]),
       ),
     ),
+    child: const Text('Login with Email'),
   );
 }


### PR DESCRIPTION
Summary
- trim demo app state/ navigation so the example always shows a simple scaffold with a centered sandbox
- simplify sandbox to a single `FButton` showcasing hover/press decoration deltas for underline handling
- drop unused theme toggling and pages to reduce noise and highlight the new interaction

Testing
- Not run (not requested)