### PR TITLE
Fix muffet Go version requirement in CI

### DIFF
--- a/.github/workflows/docs_deploy.yaml
+++ b/.github/workflows/docs_deploy.yaml
@@ -96,6 +96,8 @@ jobs:
 
       # Check that all relative URLs are working. We don't check GitHub links due to rate limiting.
       - uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
       - run: go install github.com/raviqqe/muffet/v2@latest
       - run: muffet ${{ steps.publish-docs.outputs.deployment-url }} --buffer-size=32768 --exclude="(\/cdn-cgi\/)|(github.com)|(discord.gg)"
         if: startsWith(github.ref, 'refs/tags/forui/') || inputs.target == 'production'

--- a/.github/workflows/docs_preview_deploy.yaml
+++ b/.github/workflows/docs_preview_deploy.yaml
@@ -115,5 +115,7 @@ jobs:
 
       # Check that all relative URLs are working
       - uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
       - run: go install github.com/raviqqe/muffet/v2@latest
       - run: muffet ${{ steps.publish-docs.outputs.preview-url }} --buffer-size=32768 --exclude="(\/cdn-cgi\/)|(github.com)|(pub.dev)|(shadcn.com)"


### PR DESCRIPTION
## Summary
- Fix muffet v2.11.2 Go version requirement (>= 1.25.0) in CI workflows
- Add `go-version: '1.25'` to `setup-go@v6` in both docs_deploy.yaml and docs_preview_deploy.yaml

## Changes
- `.github/workflows/docs_deploy.yaml`: Pin Go to 1.25 for muffet installation
- `.github/workflows/docs_preview_deploy.yaml`: Pin Go to 1.25 for muffet installation

## Testing
The "Deploy Doc Snippets" job should now pass when muffet is installed and run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)