### PR TITLE
Add bottom navigation bar demo

### DIFF
--- a/demo/lib/main.dart
+++ b/demo/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
 
-import 'widgets/button.dart';
+import 'widgets/bottom_navigation_bar.dart';
 
 void main() {
   runApp(const Application());
@@ -29,7 +29,7 @@ class Application extends StatelessWidget {
         ),
       ),
       home: const FScaffold(
-        child: Button(),
+        child: BottomNavBar(),
       ),
     );
   }

--- a/demo/lib/widgets/bottom_navigation_bar.dart
+++ b/demo/lib/widgets/bottom_navigation_bar.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/widgets.dart';
+import 'package:forui/forui.dart';
+
+class BottomNavBar extends StatefulWidget {
+  const BottomNavBar({super.key});
+
+  @override
+  State<BottomNavBar> createState() => _BottomNavBarState();
+}
+
+class _BottomNavBarState extends State<BottomNavBar> {
+  int _index = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SizedBox(
+        width: 350,
+        child: FBottomNavigationBar(
+          index: _index,
+          onChange: (index) => setState(() => _index = index),
+          children: const [
+            FBottomNavigationBarItem(icon: Icon(FIcons.house), label: Text('Home')),
+            FBottomNavigationBarItem(icon: Icon(FIcons.layoutGrid), label: Text('Browse')),
+            FBottomNavigationBarItem(icon: Icon(FIcons.libraryBig), label: Text('Library')),
+            FBottomNavigationBarItem(icon: Icon(FIcons.settings), label: Text('Settings')),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
**Describe the changes**

Add a demo widget showcasing `FBottomNavigationBar` in the demo app. The widget displays a centered navigation bar with 4 interactive items (Home, Browse, Library, Settings) that users can select to see state changes.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [x] I have included the relevant samples.
- [x] I have updated the documentation accordingly.
- [x] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.