### PR TITLE
Add formFieldKey to FTextFormField

### DIFF
--- a/forui/example/lib/sandbox.dart
+++ b/forui/example/lib/sandbox.dart
@@ -9,6 +9,8 @@ class Sandbox extends StatefulWidget {
 }
 
 class _SandboxState extends State<Sandbox> {
+  final _formFieldKey = GlobalKey<FormFieldState>();
+
   @override
   Widget build(BuildContext context) => SingleChildScrollView(
     padding: const EdgeInsets.all(20),
@@ -53,14 +55,15 @@ class _SandboxState extends State<Sandbox> {
               FButton(variant: .destructive, onPress: () {}, child: Text('Destructive')),
             ],
           ),
-          FTextFormField(
-            label: const Text('TextFormField'),
-            maxLength: 6,
-            keyboardType: .number,
-            textInputAction: .send,
-            onTapOutside: (event) {
-              FocusManager.instance.primaryFocus?.unfocus();
+          FTextFormField.email(
+            formFieldKey: _formFieldKey,
+            validator: (value) => (value?.contains('@') ?? false) ? null : 'Please enter a valid email.',
+          ),
+          FButton(
+            onPress: () {
+              _formFieldKey.currentState!.validate();
             },
+            child: Text('Validate'),
           ),
         ],
       ),

--- a/forui/lib/src/widgets/text_field/text_form_field.dart
+++ b/forui/lib/src/widgets/text_field/text_form_field.dart
@@ -378,8 +378,12 @@ class FTextFormField extends StatelessWidget with FFormFieldProperties<String> {
   @override
   final Widget Function(BuildContext context, String message) errorBuilder;
 
+  ///
+  final Key? formFieldKey;
+
   /// Creates a [FTextFormField].
   const FTextFormField({
+    this.formFieldKey,
     this.control = const .managed(),
     this.size = .md,
     this.style = const .context(),
@@ -452,6 +456,7 @@ class FTextFormField extends StatelessWidget with FFormFieldProperties<String> {
 
   /// Creates a [FTextFormField] configured for emails.
   const FTextFormField.email({
+    this.formFieldKey,
     this.control = const .managed(),
     this.size = .md,
     this.style = const .context(),
@@ -528,6 +533,7 @@ class FTextFormField extends StatelessWidget with FFormFieldProperties<String> {
   /// time a new line is added. To limit the maximum height of the text field and make it scrollable, consider setting
   /// [maxLines].
   const FTextFormField.multiline({
+    this.formFieldKey,
     this.control = const .managed(),
     this.size = .md,
     this.style = const .context(),
@@ -602,6 +608,7 @@ class FTextFormField extends StatelessWidget with FFormFieldProperties<String> {
   Widget build(BuildContext context) => TextFieldControl(
     control: control,
     builder: (context, controller, _) => FormInput(
+      key: formFieldKey,
       controller: controller,
       onSaved: onSaved,
       onReset: onReset,
@@ -759,6 +766,7 @@ class FTextFormField extends StatelessWidget with FFormFieldProperties<String> {
       ..add(ObjectFlagProperty.has('validator', validator))
       ..add(EnumProperty('autovalidateMode', autovalidateMode))
       ..add(StringProperty('forceErrorText', forceErrorText))
-      ..add(ObjectFlagProperty.has('errorBuilder', errorBuilder));
+      ..add(ObjectFlagProperty.has('errorBuilder', errorBuilder))
+      ..add(DiagnosticsProperty<Key?>('formFieldKey', formFieldKey));
   }
 }


### PR DESCRIPTION

**Describe the changes**

* Add formFieldKey to FTextFormField, FTextFormField.email, and FTextFormField.multiline to allow external validation and state management, fixed #900 

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [x] I have included the relevant samples.
- [x] I have updated the documentation accordingly.
- [x] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.