### PR TITLE
docs: fix broken CLI and theme customization links

### DIFF
--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -22,7 +22,7 @@ import { Sparkles, MessagesSquare, FolderGit2 } from 'lucide-react';
 ## Why Choose Forui?
 
 - Over 40+ beautifully crafted widgets.
-- Bundled [CLI](/docs/cli) to generate themes & styling boilerplate.
+- Bundled [CLI](/docs/reference/cli) to generate themes & styling boilerplate.
 - [Well-tested](https://app.codecov.io/gh/duobaseio/forui).
 - I10n support.
 - First-class [Flutter Hooks](https://pub.dev/packages/flutter_hooks) integration via [`forui_hooks`](https://pub.dev/packages/forui_hooks).

--- a/docs/content/docs/reference/cli.mdx
+++ b/docs/content/docs/reference/cli.mdx
@@ -63,7 +63,7 @@ Usage: forui snippet ls
 Use the `style create` command to generate a style in your project. The styles are generated in `lib/theme` by default.
 
 <Callout type="info">
-    See the [docs](concepts/themes#customization) on how to use the generated styles.
+    See the [docs](/docs/guides/customizing-widget-styles) on how to use the generated styles.
 </Callout>
 
 ```shell copy
@@ -100,7 +100,7 @@ Use the `theme create` command to generate a theme in your project. The theme is
 default.
 
 <Callout type="info">
-    See the [docs](concepts/themes#customization) on how to use the generated theme.
+    See the [docs](/docs/guides/customizing-themes) on how to use the generated theme.
 </Callout>
 
 ```shell copy

--- a/forui/lib/src/theme/theme_data.dart
+++ b/forui/lib/src/theme/theme_data.dart
@@ -1350,7 +1350,7 @@ final class FThemeData with Diagnosticable, _$FThemeDataFunctions {
   /// }
   /// ```
   ///
-  /// Alternatively, consider using the [CLI](forui.dev/docs/cli).
+  /// Alternatively, consider using the [CLI](forui.dev/docs/reference/cli).
   @useResult
   FThemeData copyWith({
     String? debugLabel,


### PR DESCRIPTION
**Describe the changes**
Fixed 404s on the live site by mapping CLI commands to their respective guides

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [x] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.