### PR TITLE
Fix whitespace underline in code snippets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ COLOR_GREEN := \033[0;32m
 COLOR_BLUE := \033[0;34m
 COLOR_RESET := \033[0m
 
-.PHONY: help bootstrap bs install i generate g build_runner br l10n l
+.PHONY: help bootstrap bs install i generate g build_runner br l10n l snippets s
 
 help:
 	@echo "Usage: make <target>"
@@ -13,6 +13,7 @@ help:
 	@echo "  generate (g)        Generate all code (build_runner and l10n)"
 	@echo "  build_runner (br)   Run build_runner"
 	@echo "  l10n (l)            Generate localization files"
+	@echo "  snippets (s)        Generate snippet JSON files"
 
 bootstrap: install generate
 	@echo ""
@@ -27,7 +28,7 @@ install:
 	@echo "$(COLOR_GREEN)✓ Install complete$(COLOR_RESET)"
 i: install
 
-generate: build_runner l10n
+generate: build_runner l10n snippets
 	@echo ""
 	@echo "$(COLOR_GREEN)✓ Generate complete$(COLOR_RESET)"
 g: generate
@@ -52,3 +53,10 @@ l10n:
 	@cd forui && flutter gen-l10n
 	@echo "$(COLOR_GREEN)✓ l10n complete$(COLOR_RESET)"
 l: l10n
+
+snippets:
+	@echo ""
+	@echo "$(COLOR_BLUE)cd docs_snippets && dart run tool/snippet_generator/main.dart$(COLOR_RESET)"
+	@cd docs_snippets && dart run tool/snippet_generator/main.dart
+	@echo "$(COLOR_GREEN)✓ Snippets complete$(COLOR_RESET)"
+s: snippets

--- a/docs/components/code-snippet/utils.ts
+++ b/docs/components/code-snippet/utils.ts
@@ -61,13 +61,29 @@ function splitIntoGroups(
     const allPoints = [tokenStart, ...splitPoints, tokenEnd];
 
     for (let i = 0; i < allPoints.length - 1; i++) {
-      const start = allPoints[i];
-      const end = allPoints[i + 1];
-      const content = token.content.slice(start - tokenStart, end - tokenStart);
+      let start = allPoints[i];
+      let content = token.content.slice(start - tokenStart, allPoints[i + 1] - tokenStart);
 
       if (!content) continue;
 
-      const segmentAnnotations = findAnnotationsForOffset(start, end, annotations);
+      const segmentAnnotations = findAnnotationsForOffset(start, allPoints[i + 1], annotations);
+
+      // Strip leading whitespace from annotated segments so indentation isn't linked/underlined.
+      if (segmentAnnotations.length > 0) {
+        const startWithWhitespace = content.match(/^\s+/);
+
+        if (startWithWhitespace) {
+          if (!currentGroup || currentGroup.annotations.length !== 0) {
+            currentGroup = { tokens: [], annotations: [] };
+            groups.push(currentGroup);
+          }
+          currentGroup.tokens.push({ content: startWithWhitespace[0], offset: start, variants: token.variants });
+
+          start += startWithWhitespace[0].length;
+          content = content.slice(startWithWhitespace[0].length);
+          if (!content) continue;
+        }
+      }
 
       // Start new group if annotations changed
       if (!currentGroup || !annotationsMatch(currentGroup.annotations, segmentAnnotations)) {


### PR DESCRIPTION
**Describe the changes**

Fixes #860. Strip leading whitespace from annotated segments so indentation in code snippets isn't underlined when part of a link annotation. Also adds `snippets` target to Makefile to automatically generate snippet JSON files.

**After:**
<img width="403" height="291" alt="Screenshot 2026-03-17 at 11 04 17 AM" src="https://github.com/user-attachments/assets/f460b66a-47d2-4df7-91f0-cba897cefd0b" />

**Before:**
<img width="391" height="276" alt="Screenshot 2026-03-17 at 11 04 28 AM" src="https://github.com/user-attachments/assets/eb7946bf-75d1-418d-a458-1bce960381bd" />

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [x] I have included the relevant samples.
- [x] I have updated the documentation accordingly.
- [x] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.