### PR TITLE
Fix FSelect onChange not firing when clearing

### DIFF
--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -65,6 +65,12 @@ We've adjusted `FDialog`'s styling to be more visually pleasing on touch devices
 * Fix portal not repositioning when the child widget changes size.
 
 
+## 0.20.4
+
+### `FSelect`
+* Fix `onChange` not being called when clearing via the clear button.
+
+
 ## 0.20.3
 
 ### `FToaster`

--- a/forui/lib/src/widgets/select/single/select.dart
+++ b/forui/lib/src/widgets/select/single/select.dart
@@ -743,6 +743,7 @@ abstract class _State<S extends FSelect<T>, T> extends State<S> with TickerProvi
       return;
     }
 
+    final previous = _controller.value;
     try {
       _mutating = true;
       if (_textController.text.isEmpty) {
@@ -750,6 +751,12 @@ abstract class _State<S extends FSelect<T>, T> extends State<S> with TickerProvi
       }
     } finally {
       _mutating = false;
+    }
+
+    if (previous != _controller.value) {
+      if (widget.control case FSelectManagedControl(:final onChange?)) {
+        onChange(_controller.value);
+      }
     }
   }
 

--- a/forui/pubspec.yaml
+++ b/forui/pubspec.yaml
@@ -1,6 +1,6 @@
 name: forui
 description: Beautifully designed, minimalistic widgets for desktop & touch devices.
-version: 0.20.3
+version: 0.20.4
 homepage: https://forui.dev/
 documentation: https://forui.dev/docs
 repository: https://github.com/duobaseio/forui/tree/main/forui

--- a/forui/test/src/widgets/date_field/input/input_date_field_test.dart
+++ b/forui/test/src/widgets/date_field/input/input_date_field_test.dart
@@ -45,6 +45,31 @@ void main() {
 
         expect(changed, DateTime.utc(2025, 1, 15));
       });
+
+      testWidgets('onChange called when clearing via clear button', (tester) async {
+        final values = <DateTime?>[];
+
+        await tester.pumpWidget(
+          TestScaffold.app(
+            locale: const Locale('en', 'SG'),
+            child: FDateField.input(
+              key: key,
+              clearable: true,
+              control: .managed(onChange: values.add),
+            ),
+          ),
+        );
+
+        await tester.enterText(find.byKey(key), '15/01/2025');
+        await tester.pumpAndSettle();
+
+        expect(values, [DateTime.utc(2025, 1, 15)]);
+
+        await tester.tap(find.bySemanticsLabel('Clear'));
+        await tester.pumpAndSettle();
+
+        expect(values, [DateTime.utc(2025, 1, 15), null]);
+      });
     });
 
     group('lifted', () {

--- a/forui/test/src/widgets/select/single/select_test.dart
+++ b/forui/test/src/widgets/select/single/select_test.dart
@@ -153,6 +153,35 @@ void main() {
       await tester.pumpWidget(const SizedBox());
     });
 
+    testWidgets('onChange called when clearing via clear button', (tester) async {
+      String? value = 'A';
+      final values = <String?>[];
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: StatefulBuilder(
+            builder: (context, setState) => FSelect<String>(
+              key: key,
+              clearable: true,
+              control: .lifted(
+                value: value,
+                onChange: (v) => setState(() {
+                  value = v;
+                  values.add(v);
+                }),
+              ),
+              items: letters,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.bySemanticsLabel('Clear'));
+      await tester.pumpAndSettle();
+
+      expect(values, [null]);
+    });
+
     testWidgets('showing popover does not cause error', (tester) async {
       String? value;
 
@@ -198,6 +227,26 @@ void main() {
       await tester.pump();
 
       expect(changedValue, 'A');
+    });
+
+    testWidgets('onChange called when clearing via clear button', (tester) async {
+      final values = <String?>[];
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FSelect<String>(
+            key: key,
+            clearable: true,
+            control: .managed(initial: 'A', onChange: values.add),
+            items: letters,
+          ),
+        ),
+      );
+
+      await tester.tap(find.bySemanticsLabel('Clear'));
+      await tester.pumpAndSettle();
+
+      expect(values, [null]);
     });
   });
 

--- a/forui/test/src/widgets/time_field/input/input_time_field_test.dart
+++ b/forui/test/src/widgets/time_field/input/input_time_field_test.dart
@@ -32,6 +32,31 @@ void main() {
 
       expect(changedValue, const FTime(0, 1));
     });
+
+    testWidgets('onChange called when clearing via clear button', (tester) async {
+      final values = <FTime?>[];
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          locale: const Locale('en', 'SG'),
+          child: FTimeField(
+            key: key,
+            clearable: true,
+            control: .managed(onChange: values.add),
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byKey(key), '12:30 pm');
+      await tester.pumpAndSettle();
+
+      expect(values, [const FTime(12, 30)]);
+
+      await tester.tap(find.bySemanticsLabel('Clear'));
+      await tester.pumpAndSettle();
+
+      expect(values, [const FTime(12, 30), null]);
+    });
   });
 
   group('lifted', () {


### PR DESCRIPTION
**Describe the changes**

Fixes #947

- `_updateSelectController` did not call the managed control's `onChange` callback after setting the value to `null`
  when the clear button was pressed
- Add `onChange` call with a `previous != current` guard to avoid spurious notifications
- Add clearing tests for `FSelect` (both managed and lifted), `FDateField`, and `FTimeField`
- `FDateField` and `FTimeField` are not affected — their clear goes through the value controller directly, which
  already has `onChange` wired as a listener
- Bump version to 0.20.4

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.