### PR TITLE
Add checkbox and pagination demo widgets

### DIFF
--- a/demo/lib/main.dart
+++ b/demo/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
 
-import 'widgets/bottom_navigation_bar.dart';
+import 'widgets/pagination.dart';
 
 void main() {
   runApp(const Application());
@@ -29,7 +29,7 @@ class Application extends StatelessWidget {
         ),
       ),
       home: const FScaffold(
-        child: BottomNavBar(),
+        child: Pagination(),
       ),
     );
   }

--- a/demo/lib/widgets/checkbox.dart
+++ b/demo/lib/widgets/checkbox.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/widgets.dart';
+import 'package:forui/forui.dart';
+
+class Checkbox extends StatefulWidget {
+  const Checkbox({super.key});
+
+  @override
+  State<Checkbox> createState() => _CheckboxState();
+}
+
+class _CheckboxState extends State<Checkbox> {
+  bool _value = false;
+  bool _wasChecked = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final showError = !_value && _wasChecked;
+
+    return Center(
+      child: SizedBox(
+        width: 316,
+        child: Column(
+          mainAxisAlignment: .center,
+        children: [
+          FCheckbox(
+            label: const Text('Accept terms and conditions'),
+            description: const Text('You agree to our terms and conditions.'),
+            semanticsLabel: 'Accept terms and conditions',
+            error: showError ? const Text('You must accept the terms and conditions.') : null,
+            value: _value,
+            onChange: (value) => setState(() {
+              _value = value;
+              if (value) _wasChecked = true;
+            }),
+          ),
+          const SizedBox(height: 32),
+          FCheckbox(
+            label: const Text('Disabled'),
+            description: const Text('This checkbox is disabled.'),
+            enabled: false,
+            value: false,
+            onChange: (_) {},
+          ),
+        ],
+        ),
+      ),
+    );
+  }
+}

--- a/demo/lib/widgets/pagination.dart
+++ b/demo/lib/widgets/pagination.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/widgets.dart';
+import 'package:forui/forui.dart';
+
+class Pagination extends StatelessWidget {
+  const Pagination({super.key});
+
+  @override
+  Widget build(BuildContext context) => const Center(
+    child: FPagination(control: .managed(pages: 10)),
+  );
+}


### PR DESCRIPTION
**Describe the changes**

Add demo widgets for FCheckbox and FPagination to the demo app:
- **Checkbox demo**: Interactive checkbox with error state (triggers after unchecking) and a disabled variant, centered layout
- **Pagination demo**: Simple centered 10-page pagination
- Update `main.dart` to display the pagination demo

Supersedes #951 (rebased onto current main to avoid merge conflicts).

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.