### PR TITLE
Fix nested FPopover barrier dismissal

### DIFF
--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -99,6 +99,8 @@ We've changed `FLineCalendar`'s default styling to be more aesthetically pleasin
 * **Breaking** Remove `FPopoverControl.lifted(motion: ...)`. Configure motion via `FPopoverStyle` instead.
 * **Breaking** Remove `FPopoverController(motion: ...)`. Configure motion via `FPopoverStyle` instead.
 
+* Fix root and nested popovers with barriers incorrectly being dismissed with a single tap.
+
 
 ### `FPopoverMenu`
 * Add `FPopoverMenu.faded`.

--- a/forui/lib/src/widgets/popover/popover.dart
+++ b/forui/lib/src/widgets/popover/popover.dart
@@ -458,7 +458,11 @@ class _State extends State<FPopover> with TickerProviderStateMixin {
     var child = widget.builder(context, _controller, widget.child);
 
     if (widget.hideRegion == .excludeChild) {
-      child = TapRegion(groupId: _groupId, onTapOutside: (_) => _hide(), child: child);
+      child = TapRegion(
+        groupId: _groupId,
+        onTapOutside: style.barrierFilter != null ? null : (_) => _hide(),
+        child: child,
+      );
     }
 
     return BackdropGroup(
@@ -475,17 +479,19 @@ class _State extends State<FPopover> with TickerProviderStateMixin {
         offset: widget.offset,
         barrier: style.barrierFilter == null
             ? null
-            : (cutout) => FAnimatedModalBarrier(
-                cutout: widget.cutout ? cutout : null,
-                cutoutBuilder: widget.cutoutBuilder,
-                animation: _controller.fade,
-                filter: style.barrierFilter!,
-                semanticsLabel: widget.barrierSemanticsLabel ?? localizations.barrierLabel,
-                barrierSemanticsDismissible: widget.barrierSemanticsDismissible,
-                semanticsOnTapHint: localizations.barrierOnTapHint(localizations.popoverSemanticsLabel),
-                // The actual dismissal logic is handled in the TapRegion below.
-                onDismiss: widget.hideRegion == .none ? null : () {},
-              ),
+            : (cutout) => TapRegion(
+              groupId: widget.groupId,
+              child: FAnimatedModalBarrier(
+                  cutout: widget.cutout ? cutout : null,
+                  cutoutBuilder: widget.cutoutBuilder,
+                  animation: _controller.fade,
+                  filter: style.barrierFilter!,
+                  semanticsLabel: widget.barrierSemanticsLabel ?? localizations.barrierLabel,
+                  barrierSemanticsDismissible: widget.barrierSemanticsDismissible,
+                  semanticsOnTapHint: localizations.barrierOnTapHint(localizations.popoverSemanticsLabel),
+                  onDismiss: widget.hideRegion == .none ? null : _hide,
+                ),
+            ),
         portalBuilder: (context, _) {
           Widget popover = ScaleTransition(
             alignment: popoverAnchor.resolve(direction),
@@ -501,7 +507,7 @@ class _State extends State<FPopover> with TickerProviderStateMixin {
                   onFocusChange: widget.onFocusChange,
                   child: TapRegion(
                     groupId: _groupId,
-                    onTapOutside: widget.hideRegion == .none ? null : (_) => _hide(),
+                    onTapOutside: widget.hideRegion == .none || style.barrierFilter != null ? null : (_) => _hide(),
                     child: DecoratedBox(
                       decoration: style.decoration,
                       child: widget.popoverBuilder(context, _controller),

--- a/forui/lib/src/widgets/popover/popover.dart
+++ b/forui/lib/src/widgets/popover/popover.dart
@@ -480,8 +480,8 @@ class _State extends State<FPopover> with TickerProviderStateMixin {
         barrier: style.barrierFilter == null
             ? null
             : (cutout) => TapRegion(
-              groupId: widget.groupId,
-              child: FAnimatedModalBarrier(
+                groupId: widget.groupId,
+                child: FAnimatedModalBarrier(
                   cutout: widget.cutout ? cutout : null,
                   cutoutBuilder: widget.cutoutBuilder,
                   animation: _controller.fade,
@@ -491,7 +491,7 @@ class _State extends State<FPopover> with TickerProviderStateMixin {
                   semanticsOnTapHint: localizations.barrierOnTapHint(localizations.popoverSemanticsLabel),
                   onDismiss: widget.hideRegion == .none ? null : _hide,
                 ),
-            ),
+              ),
         portalBuilder: (context, _) {
           Widget popover = ScaleTransition(
             alignment: popoverAnchor.resolve(direction),

--- a/forui/test/src/widgets/popover/popover_test.dart
+++ b/forui/test/src/widgets/popover/popover_test.dart
@@ -148,14 +148,14 @@ void main() {
 
     expect(find.text('popover'), findsOneWidget);
 
-    await tester.tapAt(.zero);
+    await tester.tap(find.byType(FAnimatedModalBarrier));
     await tester.pumpAndSettle();
 
     expect(count, 1);
     expect(find.text('popover'), findsNothing);
   });
 
-  testWidgets('tap outside does not hide popover', (tester) async {
+  testWidgets('tap outside with barrier and no hide region does not hide popover', (tester) async {
     var count = 0;
     await tester.pumpWidget(
       TestScaffold.app(
@@ -270,6 +270,128 @@ void main() {
 
     expect(count, 1);
     expect(find.text('follower'), findsNothing);
+  });
+
+  group('nested popovers', () {
+    Widget nested({required bool outer, required bool inner}) => TestScaffold.app(
+      child: FPopover(
+        groupId: 'nested',
+        style: outer
+            ? .delta(
+                barrierFilter: (a) => .blur(sigmaX: a * 5, sigmaY: a * 5),
+              )
+            : const .context(),
+        popoverBuilder: (context, _) => Container(
+          width: 280,
+          height: 220,
+          color: const Color(0xFFFFF4E5),
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: .start,
+            children: [
+              const Text('A body'),
+              const SizedBox(height: 12),
+              FPopover(
+                groupId: 'nested',
+                style: inner
+                    ? .delta(
+                        barrierFilter: (a) => .blur(sigmaX: a * 5, sigmaY: a * 5),
+                      )
+                    : const .context(),
+                popoverBuilder: (context, _) => Container(
+                  width: 200,
+                  height: 120,
+                  color: const Color(0xFFE5F0FF),
+                  padding: const EdgeInsets.all(16),
+                  child: const Text('B body'),
+                ),
+                builder: (_, controller, _) => FButton(onPress: controller.toggle, child: const Text('open B')),
+              ),
+            ],
+          ),
+        ),
+        builder: (_, controller, _) => FButton(onPress: controller.toggle, child: const Text('open A')),
+      ),
+    );
+
+    Future<void> openBoth(WidgetTester tester) async {
+      await tester.tap(find.text('open A'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('open B'));
+      await tester.pumpAndSettle();
+    }
+
+    Future<void> tapBarrier(WidgetTester tester, {bool topmost = false}) async {
+      final barrier = topmost ? find.byType(FAnimatedModalBarrier).last : find.byType(FAnimatedModalBarrier);
+      await tester.tapAt(tester.getTopLeft(barrier) + const Offset(5, 5));
+    }
+
+    testWidgets('both have barriers', (tester) async {
+      await tester.pumpWidget(nested(outer: true, inner: true));
+      await openBoth(tester);
+
+      expect(find.text('A body'), findsOneWidget);
+      expect(find.text('B body'), findsOneWidget);
+
+      await tester.tap(find.text('B body'));
+      await tester.pumpAndSettle();
+      expect(find.text('A body'), findsOneWidget);
+      expect(find.text('B body'), findsOneWidget);
+
+      await tapBarrier(tester, topmost: true);
+      await tester.pumpAndSettle();
+      expect(find.text('A body'), findsOneWidget);
+      expect(find.text('B body'), findsNothing);
+
+      await tapBarrier(tester);
+      await tester.pumpAndSettle();
+      expect(find.text('A body'), findsNothing);
+    });
+
+    testWidgets('parent has barrier, nested does not', (tester) async {
+      await tester.pumpWidget(nested(outer: true, inner: false));
+      await openBoth(tester);
+
+      expect(find.text('A body'), findsOneWidget);
+      expect(find.text('B body'), findsOneWidget);
+
+      await tester.tap(find.text('B body'));
+      await tester.pumpAndSettle();
+      expect(find.text('A body'), findsOneWidget);
+      expect(find.text('B body'), findsOneWidget);
+
+      await tester.tap(find.text('A body'));
+      await tester.pumpAndSettle();
+      expect(find.text('A body'), findsOneWidget);
+      expect(find.text('B body'), findsOneWidget);
+
+      await tapBarrier(tester);
+      await tester.pumpAndSettle();
+      expect(find.text('A body'), findsNothing);
+      expect(find.text('B body'), findsNothing);
+    });
+
+    testWidgets('parent does not have barrier, nested does', (tester) async {
+      await tester.pumpWidget(nested(outer: false, inner: true));
+      await openBoth(tester);
+
+      expect(find.text('A body'), findsOneWidget);
+      expect(find.text('B body'), findsOneWidget);
+
+      await tester.tap(find.text('B body'));
+      await tester.pumpAndSettle();
+      expect(find.text('A body'), findsOneWidget);
+      expect(find.text('B body'), findsOneWidget);
+
+      await tapBarrier(tester);
+      await tester.pumpAndSettle();
+      expect(find.text('A body'), findsOneWidget);
+      expect(find.text('B body'), findsNothing);
+
+      await tester.tapAt(const Offset(5, 5));
+      await tester.pumpAndSettle();
+      expect(find.text('A body'), findsNothing);
+    });
   });
 
   group('focus', () {


### PR DESCRIPTION
**Describe the changes**

Fixes #960.

When a popover with a barrier opened a nested popover, any tap dismissed the entire chain on a single touch, even when the user was interacting with the inner popover. The root cause: each popover wraps its content in a `TapRegion` to detect outside taps, but `TapRegion` decides inside/outside from the *render-tree* hit path. Because the inner popover lives in a separate `OverlayPortal` layer, the outer popover's `TapRegion` saw every interaction with the inner popover as "outside its group" and fired `onTapOutside`.

This PR:

- Wraps each popover's `FAnimatedModalBarrier` in a `TapRegion(groupId: widget.groupId)` so that, when popovers share a `groupId`, taps on any barrier in the chain are observed as "inside the shared group" by every member's content `TapRegion`. No member's `onTapOutside` double-fires.
- Wires the barrier's `onDismiss` (previously a no-op) to the popover's `_hide` method. Suppresses the popover-content `TapRegion`'s `onTapOutside` when a barrier is present, so the two dismissal paths don't double-fire.
- Adds three nested-popover tests in `popover_test.dart` covering all three barrier configurations (both have barriers, only outer, only inner).

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)