### PR TITLE
Adds generics support to FAutocomplete

### DIFF
--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.21.0 (Next)
 
+### `FAutocomplete`
+* Add support for generic autocomplete options via `FAutocomplete<T>`.
+* Add `FAutocomplete.displayStringForOption` and `FAutocomplete.onSelect`.
+
+
 ### `FTypography`
 * Add `FTypography.defaultFontFamily` static constant.
 

--- a/forui/lib/src/foundation/typeahead_controller.dart
+++ b/forui/lib/src/foundation/typeahead_controller.dart
@@ -123,6 +123,7 @@ class FTypeaheadController<T> extends TextEditingController {
     text ??= this.text;
     if (text.isEmpty) {
       current = null;
+      currentData = null;
       return;
     }
 

--- a/forui/lib/src/foundation/typeahead_controller.dart
+++ b/forui/lib/src/foundation/typeahead_controller.dart
@@ -7,14 +7,35 @@ import 'package:flutter/widgets.dart';
 typedef FTypeaheadControllerTextStyles =
     (TextStyle textStyle, TextStyle composingStyle, TextStyle? completionStyle) Function(BuildContext context);
 
+/// A suggestion used by [FTypeaheadController].
+class FTypeaheadSuggestion<T> {
+  /// The text shown in the field and used for matching.
+  final String text;
+
+  /// The suggestion's underlying data.
+  final T data;
+
+  /// Creates a [FTypeaheadSuggestion].
+  const FTypeaheadSuggestion({required this.text, required this.data});
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is FTypeaheadSuggestion && runtimeType == other.runtimeType && text == other.text && data == other.data);
+
+  @override
+  int get hashCode => text.hashCode ^ data.hashCode;
+}
+
 /// A [TextEditingController] with typeahead support.
 ///
 /// A typeahead controller manages suggestions and provides inline completions as the user types. When the current text
 /// matches the beginning of a suggestion, the remaining text is shown as a completion that can be accepted.
 class FTypeaheadController extends TextEditingController {
   final FTypeaheadControllerTextStyles _textStyles;
-  List<String> _suggestions;
+  List<FTypeaheadSuggestion<Object?>> _suggestions;
   ({String completion, String replacement})? _current;
+  Object? _currentData;
 
   /// A monotonic counter to ensure that only latest suggestions are processed. This prevents stale data from being
   /// processed when the suggestions are provided async.
@@ -24,10 +45,10 @@ class FTypeaheadController extends TextEditingController {
   /// Creates a [FTypeaheadController] with an optional initial text and completion.
   FTypeaheadController({
     required FTypeaheadControllerTextStyles textStyles,
-    List<String> suggestions = const [],
+    List<Object> suggestions = const [],
     super.text,
   }) : _textStyles = textStyles,
-       _suggestions = suggestions {
+       _suggestions = _normalizeSuggestions(suggestions) {
     findCompletion();
   }
 
@@ -35,9 +56,9 @@ class FTypeaheadController extends TextEditingController {
   FTypeaheadController.fromValue(
     super.value, {
     required FTypeaheadControllerTextStyles textStyles,
-    List<String> suggestions = const [],
+    List<Object> suggestions = const [],
   }) : _textStyles = textStyles,
-       _suggestions = suggestions,
+       _suggestions = _normalizeSuggestions(suggestions),
        super.fromValue() {
     findCompletion();
   }
@@ -93,32 +114,34 @@ class FTypeaheadController extends TextEditingController {
     }
 
     for (final suggestion in _suggestions) {
-      if (suggestion.toLowerCase().startsWith(text.toLowerCase())) {
-        current = (completion: suggestion.substring(text.length), replacement: suggestion);
+      if (suggestion.text.toLowerCase().startsWith(text.toLowerCase())) {
+        current = (completion: suggestion.text.substring(text.length), replacement: suggestion.text);
+        currentData = suggestion.data;
         return;
       }
     }
 
     current = null;
+    currentData = null;
   }
 
   /// Loads suggestions from a [Future] or an [Iterable].
-  Future<void> loadSuggestions(FutureOr<Iterable<String>> suggestions) async {
+  Future<void> loadSuggestions(FutureOr<Iterable<Object>> suggestions) async {
     final monotonic = ++_monotonic;
     switch (suggestions) {
-      case final Future<Iterable<String>> future:
+      case final Future<Iterable<Object>> future:
         final iterable = await future;
         if (!_disposed && monotonic == _monotonic) {
           _loadSuggestions(iterable);
         }
 
-      case final Iterable<String> iterable:
+      case final Iterable<Object> iterable:
         _loadSuggestions(iterable);
     }
   }
 
-  void _loadSuggestions(Iterable<String> iterable) {
-    final suggestions = [...iterable];
+  void _loadSuggestions(Iterable<Object> iterable) {
+    final suggestions = _normalizeSuggestions(iterable);
     if (!listEquals(_suggestions, suggestions)) {
       _suggestions = suggestions;
       findCompletion();
@@ -129,7 +152,7 @@ class FTypeaheadController extends TextEditingController {
   /// The suggestions from which a completion is derived.
   ///
   /// For example, if the user types "appl", the suggestions might include "apple", "application", etc.
-  List<String> get suggestions => _suggestions;
+  List<String> get suggestions => [for (final suggestion in _suggestions) suggestion.text];
 
   /// Updates the current [text] to the given `newText`, and removes existing selection and composing range held by the
   /// controller.
@@ -168,9 +191,16 @@ class FTypeaheadController extends TextEditingController {
   /// The current completion and corresponding replacement text, or null if no completion is available.
   ({String completion, String replacement})? get current => _current;
 
+  /// The underlying data of the current completion, or null if no completion is available.
+  Object? get currentData => _currentData;
+
   @protected
   @nonVirtual
   set current(({String completion, String replacement})? value) => _current = value;
+
+  @protected
+  @nonVirtual
+  set currentData(Object? value) => _currentData = value;
 
   @override
   @mustCallSuper
@@ -181,4 +211,17 @@ class FTypeaheadController extends TextEditingController {
       _disposed = true;
     }
   }
+
+  static List<FTypeaheadSuggestion<Object?>> _normalizeSuggestions(Iterable<Object> suggestions) => [
+    for (final suggestion in suggestions)
+      switch (suggestion) {
+        final String text => FTypeaheadSuggestion(text: text, data: text),
+        final FTypeaheadSuggestion<Object?> suggestion => suggestion,
+        _ => throw ArgumentError.value(
+          suggestion,
+          'suggestions',
+          'Suggestions must be String or FTypeaheadSuggestion instances.',
+        ),
+      },
+  ];
 }

--- a/forui/lib/src/foundation/typeahead_controller.dart
+++ b/forui/lib/src/foundation/typeahead_controller.dart
@@ -31,11 +31,17 @@ class FTypeaheadSuggestion<T> {
 ///
 /// A typeahead controller manages suggestions and provides inline completions as the user types. When the current text
 /// matches the beginning of a suggestion, the remaining text is shown as a completion that can be accepted.
-class FTypeaheadController extends TextEditingController {
+class FTypeaheadController<T> extends TextEditingController {
+  /// The default converter used to derive display text from a suggestion.
+  static String defaultDisplayStringForOption(Object? option) => option.toString();
+
   final FTypeaheadControllerTextStyles _textStyles;
-  List<FTypeaheadSuggestion<Object?>> _suggestions;
+  List<FTypeaheadSuggestion<T>> _suggestions;
   ({String completion, String replacement})? _current;
-  Object? _currentData;
+  T? _currentData;
+
+  /// Converts a suggestion into the display text used for matching and completion.
+  String Function(T option) displayStringForOption;
 
   /// A monotonic counter to ensure that only latest suggestions are processed. This prevents stale data from being
   /// processed when the suggestions are provided async.
@@ -45,10 +51,13 @@ class FTypeaheadController extends TextEditingController {
   /// Creates a [FTypeaheadController] with an optional initial text and completion.
   FTypeaheadController({
     required FTypeaheadControllerTextStyles textStyles,
-    List<Object> suggestions = const [],
+    String Function(T option)? displayStringForOption,
+    List<T> suggestions = const [],
     super.text,
   }) : _textStyles = textStyles,
-       _suggestions = _normalizeSuggestions(suggestions) {
+       displayStringForOption = displayStringForOption ?? _defaultDisplayStringForOption,
+       _suggestions = [] {
+    _suggestions = _normalizeSuggestions(suggestions);
     findCompletion();
   }
 
@@ -56,10 +65,13 @@ class FTypeaheadController extends TextEditingController {
   FTypeaheadController.fromValue(
     super.value, {
     required FTypeaheadControllerTextStyles textStyles,
-    List<Object> suggestions = const [],
+    String Function(T option)? displayStringForOption,
+    List<T> suggestions = const [],
   }) : _textStyles = textStyles,
-       _suggestions = _normalizeSuggestions(suggestions),
+       displayStringForOption = displayStringForOption ?? _defaultDisplayStringForOption,
+       _suggestions = [],
        super.fromValue() {
+    _suggestions = _normalizeSuggestions(suggestions);
     findCompletion();
   }
 
@@ -90,6 +102,7 @@ class FTypeaheadController extends TextEditingController {
   void complete() {
     if (current case (completion: final _, :final replacement)) {
       current = null;
+      currentData = null;
       rawValue = TextEditingValue(
         text: replacement,
         selection: .collapsed(offset: replacement.length),
@@ -126,21 +139,21 @@ class FTypeaheadController extends TextEditingController {
   }
 
   /// Loads suggestions from a [Future] or an [Iterable].
-  Future<void> loadSuggestions(FutureOr<Iterable<Object>> suggestions) async {
+  Future<void> loadSuggestions(FutureOr<Iterable<T>> suggestions) async {
     final monotonic = ++_monotonic;
     switch (suggestions) {
-      case final Future<Iterable<Object>> future:
+      case final Future<Iterable<T>> future:
         final iterable = await future;
         if (!_disposed && monotonic == _monotonic) {
           _loadSuggestions(iterable);
         }
 
-      case final Iterable<Object> iterable:
+      case final Iterable<T> iterable:
         _loadSuggestions(iterable);
     }
   }
 
-  void _loadSuggestions(Iterable<Object> iterable) {
+  void _loadSuggestions(Iterable<T> iterable) {
     final suggestions = _normalizeSuggestions(iterable);
     if (!listEquals(_suggestions, suggestions)) {
       _suggestions = suggestions;
@@ -152,7 +165,7 @@ class FTypeaheadController extends TextEditingController {
   /// The suggestions from which a completion is derived.
   ///
   /// For example, if the user types "appl", the suggestions might include "apple", "application", etc.
-  List<String> get suggestions => [for (final suggestion in _suggestions) suggestion.text];
+  List<T> get suggestions => [for (final suggestion in _suggestions) suggestion.data];
 
   /// Updates the current [text] to the given `newText`, and removes existing selection and composing range held by the
   /// controller.
@@ -192,7 +205,7 @@ class FTypeaheadController extends TextEditingController {
   ({String completion, String replacement})? get current => _current;
 
   /// The underlying data of the current completion, or null if no completion is available.
-  Object? get currentData => _currentData;
+  T? get currentData => _currentData;
 
   @protected
   @nonVirtual
@@ -200,7 +213,7 @@ class FTypeaheadController extends TextEditingController {
 
   @protected
   @nonVirtual
-  set currentData(Object? value) => _currentData = value;
+  set currentData(T? value) => _currentData = value;
 
   @override
   @mustCallSuper
@@ -212,16 +225,10 @@ class FTypeaheadController extends TextEditingController {
     }
   }
 
-  static List<FTypeaheadSuggestion<Object?>> _normalizeSuggestions(Iterable<Object> suggestions) => [
+  List<FTypeaheadSuggestion<T>> _normalizeSuggestions(Iterable<T> suggestions) => [
     for (final suggestion in suggestions)
-      switch (suggestion) {
-        final String text => FTypeaheadSuggestion(text: text, data: text),
-        final FTypeaheadSuggestion<Object?> suggestion => suggestion,
-        _ => throw ArgumentError.value(
-          suggestion,
-          'suggestions',
-          'Suggestions must be String or FTypeaheadSuggestion instances.',
-        ),
-      },
+      FTypeaheadSuggestion(text: displayStringForOption(suggestion), data: suggestion),
   ];
+
+  static String _defaultDisplayStringForOption<T>(T option) => defaultDisplayStringForOption(option);
 }

--- a/forui/lib/src/widgets/autocomplete/autocomplete.dart
+++ b/forui/lib/src/widgets/autocomplete/autocomplete.dart
@@ -20,10 +20,10 @@ typedef FAutocompleteContentBuilder<T> =
     List<FAutocompleteItemMixin> Function(BuildContext context, String query, Iterable<T> values);
 
 /// A builder that wraps [FAutocomplete]'s popover content.
-typedef FAutocompletePopoverBuilder =
+typedef FAutocompletePopoverBuilder<T> =
     Widget Function(
       BuildContext context,
-      FAutocompleteController controller,
+      FAutocompleteController<T> controller,
       FPopoverController popoverController,
       Widget content,
     );
@@ -258,7 +258,7 @@ class FAutocomplete<T> extends StatefulWidget with FFormFieldProperties<String> 
   /// A builder that wraps the entire popover content with arbitrary widgets.
   ///
   /// Defaults to returning the content as-is.
-  final FAutocompletePopoverBuilder popoverBuilder;
+  final FAutocompletePopoverBuilder<T> popoverBuilder;
 
   @override
   final FormFieldSetter<String>? onSaved;
@@ -432,7 +432,7 @@ class FAutocomplete<T> extends StatefulWidget with FFormFieldProperties<String> 
     FFieldIconBuilder<FAutocompleteStyle>? prefixBuilder,
     FFieldIconBuilder<FAutocompleteStyle>? suffixBuilder,
     bool Function(TextEditingValue value) clearable = FTextField.defaultClearable,
-    FAutocompletePopoverBuilder popoverBuilder = FPopover.defaultPopoverBuilder,
+    FAutocompletePopoverBuilder<T> popoverBuilder = FPopover.defaultPopoverBuilder,
     FormFieldSetter<String>? onSaved,
     VoidCallback? onReset,
     FormFieldValidator<String>? validator,
@@ -774,7 +774,7 @@ class FAutocomplete<T> extends StatefulWidget with FFormFieldProperties<String> 
 }
 
 class _State<T> extends State<FAutocomplete<T>> with TickerProviderStateMixin {
-  late FAutocompleteController _controller;
+  late FAutocompleteController<T> _controller;
   late FPopoverController _popoverController;
   late FutureOr<Iterable<T>> _data;
   late FocusNode _fieldFocus;
@@ -793,7 +793,7 @@ class _State<T> extends State<FAutocomplete<T>> with TickerProviderStateMixin {
     _fieldFocus.addListener(_focus);
     _popoverFocus = FocusScopeNode(debugLabel: 'FAutocomplete popover');
     _popoverController = widget.popoverControl.create(_handleOnPopoverChange, this);
-    _controller = widget.control.create(_update, widget.filter);
+    _controller = widget.control.create(_update, widget.filter, widget.displayStringForOption);
     _loadSuggestions(_data = widget.filter(_controller.text));
   }
 
@@ -808,11 +808,18 @@ class _State<T> extends State<FAutocomplete<T>> with TickerProviderStateMixin {
       _fieldFocus = widget.focusNode ?? .new(debugLabel: 'FAutocomplete field');
     }
 
-    final (controller, updated) = widget.control.update(old.control, _controller, _update, widget.filter);
+    final (controller, updated) = widget.control.update(
+      old.control,
+      _controller,
+      _update,
+      widget.filter,
+      widget.displayStringForOption,
+    );
     if (updated) {
       _controller = controller;
-      _loadSuggestions(widget.filter(_controller.text));
     }
+    _controller.displayStringForOption = widget.displayStringForOption;
+    _loadSuggestions(widget.filter(_controller.text));
     _popoverController = widget.popoverControl
         .update(old.popoverControl, _popoverController, _handleOnPopoverChange, this)
         .$1;
@@ -879,16 +886,7 @@ class _State<T> extends State<FAutocomplete<T>> with TickerProviderStateMixin {
     }
   }
 
-  void _loadSuggestions(FutureOr<Iterable<T>> suggestions) {
-    _controller.loadSuggestions(switch (suggestions) {
-      final Future<Iterable<T>> future => future.then(_toTypeaheadSuggestions),
-      final Iterable<T> iterable => _toTypeaheadSuggestions(iterable),
-    });
-  }
-
-  List<FTypeaheadSuggestion<T>> _toTypeaheadSuggestions(Iterable<T> values) => [
-    for (final value in values) FTypeaheadSuggestion(text: widget.displayStringForOption(value), data: value),
-  ];
+  void _loadSuggestions(FutureOr<Iterable<T>> suggestions) => _controller.loadSuggestions(suggestions);
 
   void _selectText(String text, {T? option}) {
     _previous = text;

--- a/forui/lib/src/widgets/autocomplete/autocomplete.dart
+++ b/forui/lib/src/widgets/autocomplete/autocomplete.dart
@@ -571,10 +571,10 @@ class FAutocomplete<T> extends StatefulWidget with FFormFieldProperties<String> 
 
   /// Creates a [FAutocomplete] that uses the given [filter] to determine the results and the [contentBuilder] to build
   /// the content.
-  FAutocomplete.builder({
+  const FAutocomplete.builder({
     required this.filter,
     required this.contentBuilder,
-    FAutocompleteControl<T>? control,
+    this.control = const FAutocompleteControl.managed(),
     this.popoverControl = const .managed(),
     this.size = .md,
     this.style = const .context(),
@@ -663,7 +663,7 @@ class FAutocomplete<T> extends StatefulWidget with FFormFieldProperties<String> 
     this.contentLoadingBuilder = defaultContentLoadingBuilder,
     this.contentErrorBuilder,
     super.key,
-  }) : control = control ?? _defaultControl<T>();
+  });
 
   @override
   State<FAutocomplete<T>> createState() => _State<T>();
@@ -1030,7 +1030,8 @@ class _State<T> extends State<FAutocomplete<T>> with TickerProviderStateMixin {
                     _popoverController.hide();
                   }
 
-                  _selectText(suggestion.text, option: suggestion.data as T?);
+                  final data = suggestion.data;
+                  _selectText(suggestion.text, option: data is T ? data : null);
                 },
                 onFocus: (suggestion) {
                   _restore ??= _controller.text;

--- a/forui/lib/src/widgets/autocomplete/autocomplete.dart
+++ b/forui/lib/src/widgets/autocomplete/autocomplete.dart
@@ -571,10 +571,10 @@ class FAutocomplete<T> extends StatefulWidget with FFormFieldProperties<String> 
 
   /// Creates a [FAutocomplete] that uses the given [filter] to determine the results and the [contentBuilder] to build
   /// the content.
-  const FAutocomplete.builder({
+  FAutocomplete.builder({
     required this.filter,
     required this.contentBuilder,
-    this.control = const FAutocompleteControl.managed(),
+    FAutocompleteControl<T>? control,
     this.popoverControl = const .managed(),
     this.size = .md,
     this.style = const .context(),
@@ -663,7 +663,7 @@ class FAutocomplete<T> extends StatefulWidget with FFormFieldProperties<String> 
     this.contentLoadingBuilder = defaultContentLoadingBuilder,
     this.contentErrorBuilder,
     super.key,
-  });
+  }) : control = control ?? _defaultControl<T>();
 
   @override
   State<FAutocomplete<T>> createState() => _State<T>();

--- a/forui/lib/src/widgets/autocomplete/autocomplete.dart
+++ b/forui/lib/src/widgets/autocomplete/autocomplete.dart
@@ -16,8 +16,8 @@ import 'package:forui/src/widgets/autocomplete/skip_delegate_traversal_policy.da
 import 'package:forui/src/widgets/popover/popover_controller.dart';
 
 /// A builder for [FAutocomplete]'s results.
-typedef FAutoCompleteContentBuilder =
-    List<FAutocompleteItemMixin> Function(BuildContext context, String query, Iterable<String> values);
+typedef FAutocompleteContentBuilder<T> =
+    List<FAutocompleteItemMixin> Function(BuildContext context, String query, Iterable<T> values);
 
 /// A builder that wraps [FAutocomplete]'s popover content.
 typedef FAutocompletePopoverBuilder =
@@ -44,7 +44,10 @@ typedef FAutocompletePopoverBuilder =
 /// * https://forui.dev/docs/form/autocomplete for working examples.
 /// * [FAutocompleteController] for customizing the behavior of an autocomplete.
 /// * [FAutocompleteStyle] for customizing the appearance of an autocomplete.
-class FAutocomplete extends StatefulWidget with FFormFieldProperties<String> {
+class FAutocomplete<T> extends StatefulWidget with FFormFieldProperties<String> {
+  static String _defaultDisplayStringForOption(Object? option) => option.toString();
+  static FAutocompleteControl<T> _defaultControl<T>() => FAutocompleteControl<T>.managed();
+
   /// The default loading builder that shows a spinner when an asynchronous search is pending.
   static Widget defaultContentLoadingBuilder(BuildContext _, FAutocompleteContentStyle style) => Padding(
     padding: const .all(13),
@@ -63,7 +66,7 @@ class FAutocomplete extends StatefulWidget with FFormFieldProperties<String> {
   /// Defines how the autocomplete's state is controlled.
   ///
   /// Defaults to [FAutocompleteControl.managed].
-  final FAutocompleteControl control;
+  final FAutocompleteControl<T> control;
 
   /// Defines how the autocomplete's popover content is controlled.
   ///
@@ -335,8 +338,16 @@ class FAutocomplete extends StatefulWidget with FFormFieldProperties<String> {
   /// Defaults to false.
   final bool rightArrowToComplete;
 
+  /// Converts an option into the string shown in the field and used for matching.
+  ///
+  /// Defaults to `option.toString()`.
+  final String Function(T option) displayStringForOption;
+
+  /// Called when a suggestion is explicitly selected from the autocomplete.
+  final ValueChanged<T>? onSelect;
+
   /// A callback that produces a list of items based on the query either synchronously or asynchronously.
-  final FutureOr<Iterable<String>> Function(String text) filter;
+  final FutureOr<Iterable<T>> Function(String text) filter;
 
   /// The builder that is called when the select is empty. Defaults to [defaultContentEmptyBuilder].
   final Widget Function(BuildContext context, FAutocompleteContentStyle style) contentEmptyBuilder;
@@ -351,7 +362,7 @@ class FAutocomplete extends StatefulWidget with FFormFieldProperties<String> {
   final FItemDivider contentDivider;
 
   /// A callback builds the list of items based on search results returned by [filter].
-  final FAutoCompleteContentBuilder contentBuilder;
+  final FAutocompleteContentBuilder<T> contentBuilder;
 
   /// A callback that is used to show a loading indicator while the results is processed.
   final Widget Function(BuildContext context, FAutocompleteContentStyle style) contentLoadingBuilder;
@@ -363,8 +374,8 @@ class FAutocomplete extends StatefulWidget with FFormFieldProperties<String> {
   ///
   /// For more control over the appearance of items, use [FAutocomplete.builder].
   FAutocomplete({
-    required List<String> items,
-    FAutocompleteControl control = const .managed(),
+    required List<T> items,
+    FAutocompleteControl<T>? control,
     FPopoverControl popoverControl = const .managed(),
     FTextFieldSizeVariant size = .md,
     FAutocompleteStyleDelta style = const .context(),
@@ -444,8 +455,10 @@ class FAutocomplete extends StatefulWidget with FFormFieldProperties<String> {
     bool? retainFocus,
     FFieldBuilder<FAutocompleteStyle> builder = FTextField.defaultBuilder,
     bool rightArrowToComplete = false,
-    FutureOr<Iterable<String>> Function(String query)? filter,
-    FAutoCompleteContentBuilder? contentBuilder,
+    String Function(T option) displayStringForOption = _defaultDisplayStringForOption,
+    ValueChanged<T>? onSelect,
+    FutureOr<Iterable<T>> Function(String query)? filter,
+    FAutocompleteContentBuilder<T>? contentBuilder,
     ScrollController? contentScrollController,
     ScrollPhysics contentPhysics = const ClampingScrollPhysics(),
     FItemDivider contentDivider = .none,
@@ -456,10 +469,16 @@ class FAutocomplete extends StatefulWidget with FFormFieldProperties<String> {
     Widget Function(BuildContext context, Object? error, StackTrace stackTrace)? contentErrorBuilder,
     Key? key,
   }) : this.builder(
-         filter: filter ?? (query) => items.where((item) => item.toLowerCase().startsWith(query.toLowerCase())),
+         filter:
+             filter ??
+             (query) =>
+                 items.where((item) => displayStringForOption(item).toLowerCase().startsWith(query.toLowerCase())),
          contentBuilder:
-             contentBuilder ?? (context, query, values) => [for (final value in values) .item(value: value)],
-         control: control,
+             contentBuilder ??
+             (context, query, values) => [
+               for (final value in values) .item(value: displayStringForOption(value), data: value),
+             ],
+         control: control ?? _defaultControl<T>(),
          popoverControl: popoverControl,
          size: size,
          style: style,
@@ -539,6 +558,8 @@ class FAutocomplete extends StatefulWidget with FFormFieldProperties<String> {
          retainFocus: retainFocus,
          builder: builder,
          rightArrowToComplete: rightArrowToComplete,
+         displayStringForOption: displayStringForOption,
+         onSelect: onSelect,
          contentScrollController: contentScrollController,
          contentPhysics: contentPhysics,
          contentDivider: contentDivider,
@@ -550,10 +571,10 @@ class FAutocomplete extends StatefulWidget with FFormFieldProperties<String> {
 
   /// Creates a [FAutocomplete] that uses the given [filter] to determine the results and the [contentBuilder] to build
   /// the content.
-  const FAutocomplete.builder({
+  FAutocomplete.builder({
     required this.filter,
     required this.contentBuilder,
-    this.control = const .managed(),
+    FAutocompleteControl<T>? control,
     this.popoverControl = const .managed(),
     this.size = .md,
     this.style = const .context(),
@@ -633,6 +654,8 @@ class FAutocomplete extends StatefulWidget with FFormFieldProperties<String> {
     this.retainFocus,
     this.builder = FTextField.defaultBuilder,
     this.rightArrowToComplete = false,
+    this.displayStringForOption = _defaultDisplayStringForOption,
+    this.onSelect,
     this.contentScrollController,
     this.contentPhysics = const ClampingScrollPhysics(),
     this.contentDivider = .none,
@@ -640,10 +663,10 @@ class FAutocomplete extends StatefulWidget with FFormFieldProperties<String> {
     this.contentLoadingBuilder = defaultContentLoadingBuilder,
     this.contentErrorBuilder,
     super.key,
-  });
+  }) : control = control ?? _defaultControl<T>();
 
   @override
-  State<FAutocomplete> createState() => _State();
+  State<FAutocomplete<T>> createState() => _State<T>();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -737,6 +760,8 @@ class FAutocomplete extends StatefulWidget with FFormFieldProperties<String> {
       ..add(FlagProperty('retainFocus', value: retainFocus, ifTrue: 'retainFocus'))
       ..add(ObjectFlagProperty.has('builder', builder))
       ..add(FlagProperty('rightArrowToComplete', value: rightArrowToComplete, ifTrue: 'rightArrowToComplete'))
+      ..add(ObjectFlagProperty.has('displayStringForOption', displayStringForOption))
+      ..add(ObjectFlagProperty.has('onSelect', onSelect))
       ..add(ObjectFlagProperty.has('filter', filter))
       ..add(ObjectFlagProperty.has('contentEmptyBuilder', contentEmptyBuilder))
       ..add(DiagnosticsProperty('contentScrollController', contentScrollController))
@@ -748,10 +773,10 @@ class FAutocomplete extends StatefulWidget with FFormFieldProperties<String> {
   }
 }
 
-class _State extends State<FAutocomplete> with TickerProviderStateMixin {
+class _State<T> extends State<FAutocomplete<T>> with TickerProviderStateMixin {
   late FAutocompleteController _controller;
   late FPopoverController _popoverController;
-  late FutureOr<Iterable<String>> _data;
+  late FutureOr<Iterable<T>> _data;
   late FocusNode _fieldFocus;
   late FocusScopeNode _popoverFocus;
   bool _tapFocus = false;
@@ -769,11 +794,11 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
     _popoverFocus = FocusScopeNode(debugLabel: 'FAutocomplete popover');
     _popoverController = widget.popoverControl.create(_handleOnPopoverChange, this);
     _controller = widget.control.create(_update, widget.filter);
-    _controller.loadSuggestions(_data = widget.filter(_controller.text));
+    _loadSuggestions(_data = widget.filter(_controller.text));
   }
 
   @override
-  void didUpdateWidget(covariant FAutocomplete old) {
+  void didUpdateWidget(covariant FAutocomplete<T> old) {
     super.didUpdateWidget(old);
     // DO NOT REORDER
     if (widget.focusNode != old.focusNode) {
@@ -786,7 +811,7 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
     final (controller, updated) = widget.control.update(old.control, _controller, _update, widget.filter);
     if (updated) {
       _controller = controller;
-      _controller.loadSuggestions(widget.filter(_controller.text));
+      _loadSuggestions(widget.filter(_controller.text));
     }
     _popoverController = widget.popoverControl
         .update(old.popoverControl, _popoverController, _handleOnPopoverChange, this)
@@ -822,7 +847,7 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
 
     setState(() {
       _previous = _controller.text;
-      _controller.loadSuggestions(_data = widget.filter(_controller.text));
+      _loadSuggestions(_data = widget.filter(_controller.text));
     });
 
     if (widget.control case FAutocompleteManagedControl(:final onChange?)) {
@@ -851,6 +876,25 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
   void _handleOnPopoverChange() {
     if (_popoverController case FPopoverManagedControl(:final onChange?)) {
       onChange(_popoverController.status.isForwardOrCompleted);
+    }
+  }
+
+  void _loadSuggestions(FutureOr<Iterable<T>> suggestions) {
+    _controller.loadSuggestions(switch (suggestions) {
+      final Future<Iterable<T>> future => future.then(_toTypeaheadSuggestions),
+      final Iterable<T> iterable => _toTypeaheadSuggestions(iterable),
+    });
+  }
+
+  List<FTypeaheadSuggestion<T>> _toTypeaheadSuggestions(Iterable<T> values) => [
+    for (final value in values) FTypeaheadSuggestion(text: widget.displayStringForOption(value), data: value),
+  ];
+
+  void _selectText(String text, {T? option}) {
+    _previous = text;
+    _controller.text = text;
+    if (option != null) {
+      widget.onSelect?.call(option);
     }
   }
 
@@ -973,7 +1017,7 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
             popoverBuilder: (_, popoverController) => TextFieldTapRegion(
               child: InheritedAutocompleteController(
                 popover: popoverController,
-                onPress: (value) {
+                onPress: (suggestion) {
                   final retainFocus =
                       widget.retainFocus ??
                       switch (defaultTargetPlatform) {
@@ -988,19 +1032,17 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
                     _popoverController.hide();
                   }
 
-                  _previous = value;
-                  _controller.text = value;
+                  _selectText(suggestion.text, option: suggestion.data as T?);
                 },
-                onFocus: (value) {
+                onFocus: (suggestion) {
                   _restore ??= _controller.text;
-                  _previous = value;
-                  _controller.text = value;
+                  _selectText(suggestion.text);
                 },
                 child: widget.popoverBuilder(
                   context,
                   _controller,
                   _popoverController,
-                  Content(
+                  Content<T>(
                     controller: _controller,
                     style: style.contentStyle,
                     enabled: widget.enabled,
@@ -1023,13 +1065,13 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
                 bindings: {
                   const SingleActivator(.escape): _popoverController.hide,
                   const SingleActivator(.arrowDown): () => _popoverFocus.descendants.firstOrNull?.requestFocus(),
-                  if (_controller.current case (:final replacement, completion: final _))
-                    const SingleActivator(.tab): () => _complete(replacement),
+                  if (_controller.current case (completion: final _, replacement: final _))
+                    const SingleActivator(.tab): _complete,
                   if (_controller.current case (
-                    :final replacement,
                     completion: final _,
+                    replacement: final _,
                   ) when widget.rightArrowToComplete)
-                    const SingleActivator(.arrowRight): () => _complete(replacement),
+                    const SingleActivator(.arrowRight): _complete,
                 },
                 child: widget.builder(context, style, variants, field),
               ),
@@ -1040,12 +1082,21 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
     );
   }
 
-  void _complete(String replacement) {
+  void _complete() {
+    final current = _controller.current;
+    if (current == null) {
+      return;
+    }
+    final option = _controller.currentData;
+
     if (widget.autoHide) {
       _popoverController.hide();
     }
-    _previous = replacement;
+    _previous = current.replacement;
     _controller.complete();
+    if (option case final T selected) {
+      widget.onSelect?.call(selected);
+    }
   }
 }
 

--- a/forui/lib/src/widgets/autocomplete/autocomplete_content.dart
+++ b/forui/lib/src/widgets/autocomplete/autocomplete_content.dart
@@ -37,7 +37,7 @@ class ContentData extends InheritedWidget {
 
 @internal
 class Content<T> extends StatelessWidget {
-  final FAutocompleteController controller;
+  final FAutocompleteController<T> controller;
   final FAutocompleteContentStyle style;
   final bool enabled;
   final ScrollController? scrollController;

--- a/forui/lib/src/widgets/autocomplete/autocomplete_content.dart
+++ b/forui/lib/src/widgets/autocomplete/autocomplete_content.dart
@@ -36,16 +36,16 @@ class ContentData extends InheritedWidget {
 }
 
 @internal
-class Content extends StatelessWidget {
+class Content<T> extends StatelessWidget {
   final FAutocompleteController controller;
   final FAutocompleteContentStyle style;
   final bool enabled;
   final ScrollController? scrollController;
   final ScrollPhysics physics;
   final FItemDivider divider;
-  final FutureOr<Iterable<String>> data;
+  final FutureOr<Iterable<T>> data;
   final Widget Function(BuildContext context, FAutocompleteContentStyle style) loadingBuilder;
-  final FAutoCompleteContentBuilder builder;
+  final FAutocompleteContentBuilder<T> builder;
   final Widget Function(BuildContext context, FAutocompleteContentStyle style) emptyBuilder;
   final Widget Function(BuildContext context, Object? error, StackTrace stackTrace)? errorBuilder;
 
@@ -69,8 +69,8 @@ class Content extends StatelessWidget {
     mainAxisSize: .min,
     children: [
       switch (data) {
-        final Iterable<String> data => _content(context, data),
-        final Future<Iterable<String>> future => FutureBuilder(
+        final Iterable<T> data => _content(context, data),
+        final Future<Iterable<T>> future => FutureBuilder(
           future: future,
           builder: (context, snapshot) => switch (snapshot.connectionState) {
             ConnectionState.waiting => Center(child: loadingBuilder(context, style)),
@@ -86,7 +86,7 @@ class Content extends StatelessWidget {
     ],
   );
 
-  Widget _content(BuildContext context, Iterable<String> values) {
+  Widget _content(BuildContext context, Iterable<T> values) {
     final children = builder(context, controller.text, values);
     if (children.isEmpty) {
       return Center(child: emptyBuilder(context, style));

--- a/forui/lib/src/widgets/autocomplete/autocomplete_controller.dart
+++ b/forui/lib/src/widgets/autocomplete/autocomplete_controller.dart
@@ -10,10 +10,13 @@ import 'package:forui/src/widgets/autocomplete/autocomplete.dart';
 part 'autocomplete_controller.control.dart';
 
 /// A controller for managing autocomplete functionality in a text field.
-class FAutocompleteController extends FTypeaheadController {
+class FAutocompleteController<T> extends FTypeaheadController<T> {
+  static String _defaultDisplayStringForOption<T>(T option) => option.toString();
+
   /// Creates a [FAutocompleteController] with an optional initial text and suggestions.
-  FAutocompleteController({super.text, super.suggestions})
+  FAutocompleteController({super.text, super.suggestions = const [], String Function(T option)? displayStringForOption})
     : super(
+        displayStringForOption: displayStringForOption ?? _defaultDisplayStringForOption,
         textStyles: (context) {
           final AutocompleteFieldScope(:style, :variants) = .of(context);
           return (
@@ -25,24 +28,30 @@ class FAutocompleteController extends FTypeaheadController {
       );
 
   /// Creates a [FAutocompleteController] from a [TextEditingValue].
-  FAutocompleteController.fromValue(super.value, {super.suggestions = const []})
-    : super.fromValue(
-        textStyles: (context) {
-          final AutocompleteFieldScope(:style, :variants) = .of(context);
-          return (
-            style.contentTextStyle.resolve(variants),
-            style.composingTextStyle.resolve(variants),
-            style.typeaheadTextStyle.resolve(variants),
-          );
-        },
-      );
+  FAutocompleteController.fromValue(
+    super.value, {
+    super.suggestions = const [],
+    String Function(T option)? displayStringForOption,
+  }) : super.fromValue(
+         displayStringForOption: displayStringForOption ?? _defaultDisplayStringForOption,
+         textStyles: (context) {
+           final AutocompleteFieldScope(:style, :variants) = .of(context);
+           return (
+             style.contentTextStyle.resolve(variants),
+             style.composingTextStyle.resolve(variants),
+             style.typeaheadTextStyle.resolve(variants),
+           );
+         },
+       );
 }
 
-class _ProxyController extends FAutocompleteController {
+class _ProxyController<T> extends FAutocompleteController<T> {
   TextEditingValue? _unsynced;
   ValueChanged<TextEditingValue> _onChange;
 
-  _ProxyController(super.value, this._onChange) : _unsynced = value, super.fromValue();
+  _ProxyController(super.value, this._onChange, {required super.displayStringForOption})
+    : _unsynced = value,
+      super.fromValue();
 
   void update(TextEditingValue newValue, ValueChanged<TextEditingValue> onChange) {
     _onChange = onChange;
@@ -102,7 +111,7 @@ class InheritedAutocompleteController extends InheritedWidget {
 sealed class FAutocompleteControl<T> with Diagnosticable, _$FAutocompleteControlMixin<T> {
   /// Creates a [FAutocompleteControl].
   const factory FAutocompleteControl.managed({
-    FAutocompleteController? controller,
+    FAutocompleteController<T>? controller,
     TextEditingValue? initial,
     ValueChanged<TextEditingValue>? onChange,
   }) = FAutocompleteManagedControl;
@@ -115,11 +124,12 @@ sealed class FAutocompleteControl<T> with Diagnosticable, _$FAutocompleteControl
 
   const FAutocompleteControl._();
 
-  (FAutocompleteController, bool) _update(
+  (FAutocompleteController<T>, bool) _update(
     FAutocompleteControl<T> old,
-    FAutocompleteController controller,
+    FAutocompleteController<T> controller,
     VoidCallback callback,
     FutureOr<Iterable<T>> Function(String) filter,
+    String Function(T option) displayStringForOption,
   );
 }
 
@@ -130,7 +140,7 @@ sealed class FAutocompleteControl<T> with Diagnosticable, _$FAutocompleteControl
 class FAutocompleteManagedControl<T> extends FAutocompleteControl<T> with _$FAutocompleteManagedControlMixin<T> {
   /// The controller.
   @override
-  final FAutocompleteController? controller;
+  final FAutocompleteController<T>? controller;
 
   /// The initial value. Defaults to null.
   ///
@@ -152,8 +162,10 @@ class FAutocompleteManagedControl<T> extends FAutocompleteControl<T> with _$FAut
       super._();
 
   @override
-  FAutocompleteController createController(FutureOr<Iterable<T>> Function(String) _) =>
-      controller ?? .fromValue(initial);
+  FAutocompleteController<T> createController(
+    FutureOr<Iterable<T>> Function(String) _,
+    String Function(T option) displayStringForOption,
+  ) => controller ?? .fromValue(initial, displayStringForOption: displayStringForOption);
 }
 
 class _Lifted<T> extends FAutocompleteControl<T> with _$_LiftedMixin<T> {
@@ -165,16 +177,15 @@ class _Lifted<T> extends FAutocompleteControl<T> with _$_LiftedMixin<T> {
   const _Lifted({required this.value, required this.onChange}) : super._();
 
   @override
-  FAutocompleteController createController(FutureOr<Iterable<T>> Function(String) _) =>
-      _ProxyController(value, onChange);
+  FAutocompleteController<T> createController(
+    FutureOr<Iterable<T>> Function(String) _,
+    String Function(T option) displayStringForOption,
+  ) => _ProxyController(value, onChange, displayStringForOption: displayStringForOption);
 
   @override
-  void _updateController(FAutocompleteController controller, FutureOr<Iterable<T>> Function(String) filter) {
+  void _updateController(FAutocompleteController<T> controller, FutureOr<Iterable<T>> Function(String) filter) {
     (controller as _ProxyController)
       ..update(value, onChange)
-      ..loadSuggestions(switch (filter(controller.text)) {
-        final Future<Iterable<T>> future => future.then((values) => values.cast<Object>()),
-        final Iterable<T> iterable => iterable.cast<Object>(),
-      });
+      ..loadSuggestions(filter(controller.text));
   }
 }

--- a/forui/lib/src/widgets/autocomplete/autocomplete_controller.dart
+++ b/forui/lib/src/widgets/autocomplete/autocomplete_controller.dart
@@ -72,8 +72,8 @@ class InheritedAutocompleteController extends InheritedWidget {
   }
 
   final FPopoverController popover;
-  final ValueChanged<String> onPress;
-  final ValueChanged<String> onFocus;
+  final ValueChanged<FTypeaheadSuggestion<Object?>> onPress;
+  final ValueChanged<FTypeaheadSuggestion<Object?>> onFocus;
 
   const InheritedAutocompleteController({
     required this.popover,
@@ -99,7 +99,7 @@ class InheritedAutocompleteController extends InheritedWidget {
 /// A [FAutocompleteControl] defines how a [FAutocomplete] is controlled.
 ///
 /// {@macro forui.foundation.doc_templates.control}
-sealed class FAutocompleteControl with Diagnosticable, _$FAutocompleteControlMixin {
+sealed class FAutocompleteControl<T> with Diagnosticable, _$FAutocompleteControlMixin<T> {
   /// Creates a [FAutocompleteControl].
   const factory FAutocompleteControl.managed({
     FAutocompleteController? controller,
@@ -116,10 +116,10 @@ sealed class FAutocompleteControl with Diagnosticable, _$FAutocompleteControlMix
   const FAutocompleteControl._();
 
   (FAutocompleteController, bool) _update(
-    FAutocompleteControl old,
+    FAutocompleteControl<T> old,
     FAutocompleteController controller,
     VoidCallback callback,
-    FutureOr<Iterable<String>> Function(String) filter,
+    FutureOr<Iterable<T>> Function(String) filter,
   );
 }
 
@@ -127,7 +127,7 @@ sealed class FAutocompleteControl with Diagnosticable, _$FAutocompleteControlMix
 /// for common configurations.
 ///
 /// {@macro forui.foundation.doc_templates.managed}
-class FAutocompleteManagedControl extends FAutocompleteControl with _$FAutocompleteManagedControlMixin {
+class FAutocompleteManagedControl<T> extends FAutocompleteControl<T> with _$FAutocompleteManagedControlMixin<T> {
   /// The controller.
   @override
   final FAutocompleteController? controller;
@@ -152,11 +152,11 @@ class FAutocompleteManagedControl extends FAutocompleteControl with _$FAutocompl
       super._();
 
   @override
-  FAutocompleteController createController(FutureOr<Iterable<String>> Function(String) _) =>
+  FAutocompleteController createController(FutureOr<Iterable<T>> Function(String) _) =>
       controller ?? .fromValue(initial);
 }
 
-class _Lifted extends FAutocompleteControl with _$_LiftedMixin {
+class _Lifted<T> extends FAutocompleteControl<T> with _$_LiftedMixin<T> {
   @override
   final TextEditingValue value;
   @override
@@ -165,13 +165,16 @@ class _Lifted extends FAutocompleteControl with _$_LiftedMixin {
   const _Lifted({required this.value, required this.onChange}) : super._();
 
   @override
-  FAutocompleteController createController(FutureOr<Iterable<String>> Function(String) _) =>
+  FAutocompleteController createController(FutureOr<Iterable<T>> Function(String) _) =>
       _ProxyController(value, onChange);
 
   @override
-  void _updateController(FAutocompleteController controller, FutureOr<Iterable<String>> Function(String) filter) {
+  void _updateController(FAutocompleteController controller, FutureOr<Iterable<T>> Function(String) filter) {
     (controller as _ProxyController)
       ..update(value, onChange)
-      ..loadSuggestions(filter(controller.text));
+      ..loadSuggestions(switch (filter(controller.text)) {
+        final Future<Iterable<T>> future => future.then((values) => values.cast<Object>()),
+        final Iterable<T> iterable => iterable.cast<Object>(),
+      });
   }
 }

--- a/forui/lib/src/widgets/autocomplete/autocomplete_item.dart
+++ b/forui/lib/src/widgets/autocomplete/autocomplete_item.dart
@@ -51,6 +51,7 @@ mixin FAutocompleteItemMixin on Widget {
   /// This function is a shorthand for [FAutocompleteItem.new].
   static FAutocompleteItem item({
     required String value,
+    Object? data,
     FItemStyleDelta style = const .context(),
     bool? enabled,
     Widget? prefix,
@@ -60,6 +61,7 @@ mixin FAutocompleteItemMixin on Widget {
     Key? key,
   }) => .item(
     value: value,
+    data: data,
     style: style,
     enabled: enabled,
     prefix: prefix,
@@ -75,11 +77,12 @@ mixin FAutocompleteItemMixin on Widget {
   static FAutocompleteItem rawItem({
     required Widget child,
     required String value,
+    Object? data,
     FItemStyleDelta style = const .context(),
     bool? enabled,
     Widget? prefix,
     Key? key,
-  }) => .raw(value: value, style: style, enabled: enabled, prefix: prefix, key: key, child: child);
+  }) => .raw(value: value, data: data, style: style, enabled: enabled, prefix: prefix, key: key, child: child);
 }
 
 /// A section in a [FAutocomplete] that can contain multiple [FAutocompleteItem]s.
@@ -324,6 +327,9 @@ abstract class FAutocompleteItem extends StatelessWidget with FAutocompleteItemM
   /// The value.
   final String value;
 
+  /// The underlying data associated with this item.
+  final Object? data;
+
   /// True if the item is enabled. Disabled items cannot be selected, and is skipped during traversal.
   ///
   /// Defaults to the value inherited from the parent [FAutocompleteSection] or [FAutocomplete].
@@ -339,6 +345,7 @@ abstract class FAutocompleteItem extends StatelessWidget with FAutocompleteItemM
   /// {@endtemplate}
   factory FAutocompleteItem({
     required String value,
+    Object? data,
     FItemStyleDelta style,
     bool? enabled,
     Widget? prefix,
@@ -356,6 +363,7 @@ abstract class FAutocompleteItem extends StatelessWidget with FAutocompleteItemM
   /// For even more control over the item's appearance, use [FAutocompleteItem.raw].
   factory FAutocompleteItem.item({
     required String value,
+    Object? data,
     FItemStyleDelta style,
     bool? enabled,
     Widget? prefix,
@@ -374,13 +382,21 @@ abstract class FAutocompleteItem extends StatelessWidget with FAutocompleteItemM
   factory FAutocompleteItem.raw({
     required Widget child,
     required String value,
+    Object? data,
     FItemStyleDelta style,
     bool? enabled,
     Widget? prefix,
     Key? key,
   }) = _RawAutocompleteItem;
 
-  const FAutocompleteItem._({required this.value, this.style = const .context(), this.enabled, this.prefix, super.key});
+  const FAutocompleteItem._({
+    required this.value,
+    this.data,
+    this.style = const .context(),
+    this.enabled,
+    this.prefix,
+    super.key,
+  });
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -388,6 +404,7 @@ abstract class FAutocompleteItem extends StatelessWidget with FAutocompleteItemM
     properties
       ..add(DiagnosticsProperty('style', style))
       ..add(DiagnosticsProperty('value', value))
+      ..add(DiagnosticsProperty('data', data))
       ..add(FlagProperty('enabled', value: enabled, ifTrue: 'enabled', ifFalse: 'disabled'));
   }
 }
@@ -399,6 +416,7 @@ class _AutocompleteItem extends FAutocompleteItem {
 
   _AutocompleteItem({
     required super.value,
+    super.data,
     super.style,
     super.enabled,
     super.prefix,
@@ -419,10 +437,10 @@ class _AutocompleteItem extends FAutocompleteItem {
     return FItem(
       style: style,
       enabled: enabled,
-      onPress: () => onPress(value),
+      onPress: () => onPress(FTypeaheadSuggestion(text: value, data: data ?? value)),
       onFocusChange: (focused) {
         if (focused) {
-          onFocus(value);
+          onFocus(FTypeaheadSuggestion(text: value, data: data ?? value));
         }
       },
       prefix: prefix,
@@ -439,6 +457,7 @@ class _RawAutocompleteItem extends FAutocompleteItem {
   const _RawAutocompleteItem({
     required this.child,
     required super.value,
+    super.data,
     super.style,
     super.enabled,
     super.prefix,
@@ -455,10 +474,10 @@ class _RawAutocompleteItem extends FAutocompleteItem {
     return FItem.raw(
       style: style,
       enabled: enabled,
-      onPress: () => onPress(value),
+      onPress: () => onPress(FTypeaheadSuggestion(text: value, data: data ?? value)),
       onFocusChange: (focused) {
         if (focused) {
-          onFocus(value);
+          onFocus(FTypeaheadSuggestion(text: value, data: data ?? value));
         }
       },
       prefix: prefix,

--- a/forui/test/src/foundation/typeahead/typeahead_controller_golden_test.dart
+++ b/forui/test/src/foundation/typeahead/typeahead_controller_golden_test.dart
@@ -9,10 +9,10 @@ import 'package:forui/forui.dart';
 import '../../test_scaffold.dart';
 
 void main() {
-  late FTypeaheadController controller;
+  late FTypeaheadController<String> controller;
 
   setUp(() {
-    controller = FTypeaheadController(
+    controller = FTypeaheadController<String>(
       textStyles: (context) => (
         const TextStyle(color: Colors.black),
         const TextStyle(color: Colors.blue),

--- a/forui/test/src/foundation/typeahead/typeahead_controller_test.dart
+++ b/forui/test/src/foundation/typeahead/typeahead_controller_test.dart
@@ -9,10 +9,10 @@ import 'package:forui/forui.dart';
 const initial = ['apple', 'banana', 'cherry'];
 
 void main() {
-  late FTypeaheadController controller;
+  late FTypeaheadController<String> controller;
 
   setUp(() {
-    controller = FTypeaheadController(
+    controller = FTypeaheadController<String>(
       textStyles: (context) => (const TextStyle(), const TextStyle(), const TextStyle()),
       text: 'm',
       suggestions: initial,
@@ -126,7 +126,7 @@ void main() {
     });
 
     test('ignores async iterable when disposed', () async {
-      final controller = FTypeaheadController(
+      final controller = FTypeaheadController<String>(
         textStyles: (context) => (const TextStyle(), const TextStyle(), const TextStyle()),
         text: 'm',
         suggestions: initial,

--- a/forui/test/src/widgets/autocomplete/autocomplete_test.dart
+++ b/forui/test/src/widgets/autocomplete/autocomplete_test.dart
@@ -39,11 +39,11 @@ class _Fruit {
 void main() {
   const key = ValueKey('autocomplete');
 
-  late FAutocompleteController controller;
+  late FAutocompleteController<String> controller;
   late FPopoverController popoverController;
 
   setUp(() {
-    controller = FAutocompleteController();
+    controller = FAutocompleteController<String>();
     popoverController = FPopoverController(vsync: const TestVSync());
   });
 

--- a/forui/test/src/widgets/autocomplete/autocomplete_test.dart
+++ b/forui/test/src/widgets/autocomplete/autocomplete_test.dart
@@ -26,6 +26,16 @@ const fruits = [
   'Watermelon',
 ];
 
+class _Fruit {
+  final int id;
+  final String name;
+
+  const _Fruit(this.id, this.name);
+
+  @override
+  String toString() => 'Fruit($id, $name)';
+}
+
 void main() {
   const key = ValueKey('autocomplete');
 
@@ -107,6 +117,65 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(changedValue?.text, 'app');
+    });
+  });
+
+  group('generic items', () {
+    const genericFruits = [_Fruit(1, 'Apple'), _Fruit(2, 'Banana')];
+    const duplicateNamedFruits = [_Fruit(1, 'Apple'), _Fruit(2, 'Apple'), _Fruit(3, 'Banana')];
+
+    testWidgets('uses displayStringForOption for filtering and selection', (tester) async {
+      _Fruit? selected;
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FAutocomplete<_Fruit>(
+            key: key,
+            items: genericFruits,
+            displayStringForOption: (fruit) => fruit.name,
+            onSelect: (fruit) => selected = fruit,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byKey(key), 'app');
+      await tester.pumpAndSettle();
+
+      expect(find.text('Apple'), findsOneWidget);
+
+      await tester.tap(find.text('Apple'));
+      await tester.pumpAndSettle();
+
+      expect(selected, genericFruits.first);
+      expect(find.text('Apple'), findsOneWidget);
+    });
+
+    testWidgets('selects the tapped duplicate item', (tester) async {
+      _Fruit? selected;
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FAutocomplete<_Fruit>(
+            key: key,
+            items: duplicateNamedFruits,
+            displayStringForOption: (fruit) => fruit.name,
+            contentBuilder: (context, query, values) => [
+              for (final fruit in values)
+                FAutocompleteItem.item(value: fruit.name, data: fruit, title: Text('${fruit.name} #${fruit.id}')),
+            ],
+            onSelect: (fruit) => selected = fruit,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byKey(key), 'app');
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Apple #2'));
+      await tester.pumpAndSettle();
+
+      expect(selected, duplicateNamedFruits[1]);
+      expect(find.text('Apple'), findsOneWidget);
     });
   });
 


### PR DESCRIPTION
Example usage:

```
class Fruit {
  final String name;
  final int calories;

  const Fruit(this.name, this.calories);

  @override
  String toString() => '$name calories $calories';
}

const fruits = [
  Fruit('Apple', 52),
  Fruit('Apple', 42),
  Fruit('Banana', 89),
  Fruit('Orange', 47),
  Fruit('Grape', 69),
  Fruit('Strawberry', 32),
  Fruit('Pineapple', 50),
];


          FAutocomplete<Fruit>.builder(
            hint: 'Type to search fruits',
            onSelect: (fruit) {
              print('Selected: ${fruit.name} with ${fruit.calories} calories');
            },
            filter: (query) async {
              await Future.delayed(const Duration(seconds: 3));
              return query.isEmpty
                  ? fruits
                  : fruits.where((fruit) => fruit.name.toLowerCase().startsWith(query.toLowerCase()));
            },
            displayStringForOption: (fruit) => fruit.name,
            contentBuilder: (context, query, values) => [
              for (final fruit in values)
                .item(value: fruit.name, subtitle: Text('${fruit.calories} calories'), data: fruit),
            ],
          )
```

Some info:

- no existing stuff is broken because if filter returns the array of strings - what was there by default, the generic type is implied to be String
- `displayStringForOption` default implementation returns `toString()`, which when casted on "legacy" implementation - only Strings would return those Strings as toString on string returns itself. If I didn't include this method in the snippet the placeholder string would display the name of fruit with calories, but obviously in placeholder i want just a name
- optional `onSelect` allows us to know what user clicked from the autocompletion list and is invoked also when user presses "tab"
- AI reviewer complained that the constructor of FAutocomplete or related object can no longer be constant constructor, but I don't see a single reasonable implementation of any form widget being constant.

Some screenshots:

<img width="452" height="950" alt="Screenshot 2026-04-12 at 14 22 08" src="https://github.com/user-attachments/assets/82e4c608-3583-474b-9e46-28664a35c7db" />

<img width="452" height="950" alt="Screenshot 2026-04-12 at 14 22 10" src="https://github.com/user-attachments/assets/687a59d4-93d2-496c-a48c-71414ef3211c" />

<img width="452" height="950" alt="Screenshot 2026-04-12 at 14 22 13" src="https://github.com/user-attachments/assets/2ab3393f-fefb-4c8c-bc3b-259134fa602f" />



