### PR TITLE
Add tooltip demo widget

### DIFF
--- a/demo/lib/main.dart
+++ b/demo/lib/main.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide Tooltip;
 import 'package:forui/forui.dart';
 
-import 'widgets/select.dart';
+import 'widgets/tooltip.dart';
 
 void main() {
   runApp(const Application());
@@ -29,7 +29,7 @@ class Application extends StatelessWidget {
         ),
       ),
       home: const FScaffold(
-        child: Select(),
+        child: Tooltip(),
       ),
     );
   }

--- a/demo/lib/widgets/tooltip.dart
+++ b/demo/lib/widgets/tooltip.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/widgets.dart';
+import 'package:forui/forui.dart';
+
+class Tooltip extends StatelessWidget {
+  const Tooltip({super.key});
+
+  @override
+  Widget build(BuildContext context) => Center(
+    child: FTooltipGroup(
+      child: Row(
+        mainAxisSize: .min,
+        spacing: 2,
+        children: [
+          FTooltip(
+            tipBuilder: (context, _) => const Text('Bold'),
+            child: FButton.icon(
+              variant: .ghost,
+              size: .sm,
+              onPress: () {},
+              child: const Icon(FIcons.bold),
+            ),
+          ),
+          FTooltip(
+            tipBuilder: (context, _) => const Text('Italic'),
+            child: FButton.icon(
+              variant: .ghost,
+              size: .sm,
+              onPress: () {},
+              child: const Icon(FIcons.italic),
+            ),
+          ),
+          FTooltip(
+            tipBuilder: (context, _) => const Text('Underline'),
+            child: FButton.icon(
+              variant: .ghost,
+              size: .sm,
+              onPress: () {},
+              child: const Icon(FIcons.underline),
+            ),
+          ),
+          FTooltip(
+            tipBuilder: (context, _) => const Text('Strikethrough'),
+            child: FButton.icon(
+              variant: .ghost,
+              size: .sm,
+              onPress: () {},
+              child: const Icon(FIcons.strikethrough),
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
**Describe the changes**
Adds a `Tooltip` demo widget to the `demo/` app showcasing `FTooltipGroup` with four ghost icon buttons (bold, italic, underline, strikethrough), each wrapped in an `FTooltip`. `demo/lib/main.dart` is switched over to render the new widget.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.