### PR TITLE
Make FPaginationController pages, siblings & showEdges mutable

### DIFF
--- a/.github/workflows/docs_deploy.yaml
+++ b/.github/workflows/docs_deploy.yaml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
 

--- a/.github/workflows/docs_preview_build.yaml
+++ b/.github/workflows/docs_preview_build.yaml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
       - working-directory: ./docs

--- a/.github/workflows/docs_preview_deploy.yaml
+++ b/.github/workflows/docs_preview_deploy.yaml
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
       - name: Deploy docs to Cloudflare Workers

--- a/docs/package.json
+++ b/docs/package.json
@@ -87,13 +87,5 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3",
     "wrangler": "^4.75.0"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "sharp",
-      "unrs-resolver",
-      "workerd"
-    ]
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -87,5 +87,13 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3",
     "wrangler": "^4.75.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp",
+      "unrs-resolver",
+      "workerd"
+    ]
   }
 }

--- a/docs_snippets/lib/examples/widgets/tabs.dart
+++ b/docs_snippets/lib/examples/widgets/tabs.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_redundant_argument_values
+
 import 'package:flutter/material.dart';
 
 import 'package:auto_route/auto_route.dart';
@@ -67,9 +69,9 @@ class SwipeableTabsPage extends Example {
       height: 350,
       child: FTabs(
         // {@highlight}
-        // Swiping between tabs requires expands to be true and a non-null
-        // contentPhysics (defaults to BouncingScrollPhysics).
+        // Swiping between tabs requires expands to be true and contentPhysics to not be NeverScrollableScrollPhysics.
         expands: true,
+        contentPhysics: const BouncingScrollPhysics(),
         // {@endhighlight}
         children: [
           .entry(

--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -31,6 +31,10 @@
 * **Breaking** Rename `FItemStyle.decoration` to `FItemStyle.contentDecoration`.
 
 
+### `FPagination`
+* Add settable `FPaginationController.pages`, `FPaginationController.siblings`, and `FPaginationController.showEdges`.
+
+
 ## 0.21.1
 
 ### `FHeader`

--- a/forui/lib/src/widgets/item/item.dart
+++ b/forui/lib/src/widgets/item/item.dart
@@ -189,8 +189,8 @@ class FItem extends StatelessWidget with FItemMixin {
   /// else [title] and [subtitle] are truncated.
   ///
   /// ## Why isn't my [title] [subtitle], or [details] rendered?
-  /// Using widgets that try to fill the available space, such as [Expanded] or [FTextField], as [details] will cause
-  /// the [title] and [subtitle] to never be rendered.
+  /// Using widgets that try to fill the available space, such as [Expanded] or [FTextField], will cause the [title]/
+  /// [subtitle]/[details] to never be rendered.
   ///
   /// Use [FItem.raw] in these cases.
   /// {@endtemplate}

--- a/forui/lib/src/widgets/pagination/pagination_controller.dart
+++ b/forui/lib/src/widgets/pagination/pagination_controller.dart
@@ -8,8 +8,45 @@ part 'pagination_controller.control.dart';
 
 /// A controller that controls which page is selected.
 class FPaginationController extends ValueNotifier<int> {
+  int _pages;
+  int _siblings;
+  bool _showEdges;
+
+  /// Creates a [FPaginationController].
+  ///
+  /// # Contract:
+  /// * Throws [AssertionError] if 0 <= [page] and [page] < [pages].
+  FPaginationController({required int pages, int page = 0, int siblings = 1, bool showEdges = true})
+    : assert(0 < pages, 'pages ($pages) should be > 0'),
+      assert(0 <= siblings, 'siblings ($siblings) >= 0'),
+      assert(0 <= page && page < pages, 'initialPage ($page) must be between 0 and pages ($pages), exclusive.'),
+      _pages = pages,
+      _siblings = siblings,
+      _showEdges = showEdges,
+      super(page);
+
   /// The total number of pages.
-  final int pages;
+  ///
+  /// Setting this clamps [value] to `pages - 1` if it would otherwise be out of range.
+  ///
+  /// # Contract:
+  /// * Throws [AssertionError] if [pages] <= 0.
+  int get pages => _pages;
+
+  set pages(int pages) {
+    assert(0 < pages, 'pages ($pages) should be > 0');
+    if (_pages == pages) {
+      return;
+    }
+
+    _pages = pages;
+    if (pages <= super.value) {
+      // This already notifies listeners, so we don't need to call notifyListeners again.
+      super.value = pages - 1;
+    } else {
+      notifyListeners();
+    }
+  }
 
   /// The number of sibling pages displayed beside the current page number. Defaults to 1.
   ///
@@ -18,23 +55,32 @@ class FPaginationController extends ValueNotifier<int> {
   ///
   /// # Contract:
   /// * Throws [AssertionError] if [siblings] < 0.
-  final int siblings;
+  int get siblings => _siblings;
+
+  set siblings(int siblings) {
+    assert(0 <= siblings, 'siblings ($siblings) >= 0');
+    if (_siblings == siblings) {
+      return;
+    }
+
+    _siblings = siblings;
+    notifyListeners();
+  }
 
   /// Whether to show the first and last pages in the pagination. Defaults to `true`.
   ///
   /// If `true`, the pagination will always display the first and last page, regardless of the current page.
   /// This can be useful for allowing users to quickly navigate to the beginning or end of the paginated content.
-  final bool showEdges;
+  bool get showEdges => _showEdges;
 
-  /// Creates a [FPaginationController].
-  ///
-  /// # Contract:
-  /// * Throws [AssertionError] if 0 <= [page] and [page] < [pages].
-  FPaginationController({required this.pages, int page = 0, this.siblings = 1, this.showEdges = true})
-    : assert(0 < pages, 'pages ($pages) should be > 0'),
-      assert(0 <= siblings, 'siblings ($siblings) >= 0'),
-      assert(0 <= page && page < pages, 'initialPage ($page) must be between 0 and pages ($pages), exclusive.'),
-      super(page);
+  set showEdges(bool showEdges) {
+    if (_showEdges == showEdges) {
+      return;
+    }
+
+    _showEdges = showEdges;
+    notifyListeners();
+  }
 
   /// Moves to the next page if the current page is less than the total number of pages.
   void next() {
@@ -101,12 +147,9 @@ extension InternalFPaginationController on FPaginationController {
 class _ProxyController extends FPaginationController {
   int _unsynced;
   ValueChanged<int> _onChange;
-  int _pages;
-  int _siblings;
-  bool _showEdges;
 
-  _ProxyController(this._unsynced, this._onChange, this._pages, this._siblings, this._showEdges)
-    : super(page: _unsynced, pages: _pages, siblings: _siblings, showEdges: _showEdges);
+  _ProxyController(this._unsynced, this._onChange, int pages, int siblings, bool showEdges)
+    : super(page: _unsynced, pages: pages, siblings: siblings, showEdges: showEdges);
 
   void update(int page, ValueChanged<int> onChange, int pages, int siblings, bool showEdges) {
     final changed = _pages != pages || _siblings != siblings || _showEdges != showEdges;
@@ -123,15 +166,6 @@ class _ProxyController extends FPaginationController {
       notifyListeners();
     }
   }
-
-  @override
-  int get pages => _pages;
-
-  @override
-  int get siblings => _siblings;
-
-  @override
-  bool get showEdges => _showEdges;
 
   @override
   set _rawValue(int value) {

--- a/forui/lib/src/widgets/pagination/pagination_controller.dart
+++ b/forui/lib/src/widgets/pagination/pagination_controller.dart
@@ -15,7 +15,9 @@ class FPaginationController extends ValueNotifier<int> {
   /// Creates a [FPaginationController].
   ///
   /// # Contract:
-  /// * Throws [AssertionError] if 0 <= [page] and [page] < [pages].
+  /// * Throws [AssertionError] if [pages] <= 0.
+  /// * Throws [AssertionError] if [siblings] < 0.
+  /// * Throws [AssertionError] if [page] is not in the range `0 <= page < pages`.
   FPaginationController({required int pages, int page = 0, int siblings = 1, bool showEdges = true})
     : assert(0 < pages, 'pages ($pages) should be > 0'),
       assert(0 <= siblings, 'siblings ($siblings) >= 0'),
@@ -152,6 +154,9 @@ class _ProxyController extends FPaginationController {
     : super(page: _unsynced, pages: pages, siblings: siblings, showEdges: showEdges);
 
   void update(int page, ValueChanged<int> onChange, int pages, int siblings, bool showEdges) {
+    assert(0 < pages, 'pages ($pages) should be > 0');
+    assert(0 <= siblings, 'siblings ($siblings) >= 0');
+    assert(0 <= page && page < pages, 'page ($page) must be between 0 and pages ($pages), exclusive.');
     final changed = _pages != pages || _siblings != siblings || _showEdges != showEdges;
     _onChange = onChange;
     _pages = pages;

--- a/forui/lib/src/widgets/tile/tile.dart
+++ b/forui/lib/src/widgets/tile/tile.dart
@@ -170,8 +170,8 @@ class FTile extends StatelessWidget with FTileMixin {
   /// else [title] and [subtitle] are truncated.
   ///
   /// ## Why isn't my [title] [subtitle], or [details] rendered?
-  /// Using widgets that try to fill the available space, such as [Expanded] or [FTextField], as [details] will cause
-  /// the [title] and [subtitle] to never be rendered.
+  /// Using widgets that try to fill the available space, such as [Expanded] or [FTextField], will cause the [title]/
+  /// [subtitle]/[details] to never be rendered.
   ///
   /// Use [FTile.raw] in these cases.
   /// {@endtemplate}

--- a/forui/test/src/widgets/pagination/pagination_controller_test.dart
+++ b/forui/test/src/widgets/pagination/pagination_controller_test.dart
@@ -92,4 +92,89 @@ void main() {
       expect(controller.minPagesDisplayedAtEdges, expected);
     });
   }
+
+  group('pages setter', () {
+    test('grows and notifies', () {
+      var notifyCount = 0;
+      final controller = FPaginationController(pages: 5, page: 2)
+        ..addListener(() => notifyCount++)
+        ..pages = 10;
+
+      expect(controller.pages, 10);
+      expect(controller.value, 2);
+      expect(notifyCount, 1);
+    });
+
+    test('shrinks and clamps value', () {
+      var notifyCount = 0;
+      final controller = FPaginationController(pages: 10, page: 8)
+        ..addListener(() => notifyCount++)
+        ..pages = 5;
+
+      expect(controller.pages, 5);
+      expect(controller.value, 4);
+      expect(notifyCount, 1);
+    });
+
+    test('no-op when unchanged', () {
+      var notifyCount = 0;
+      FPaginationController(pages: 5)
+        ..addListener(() => notifyCount++)
+        ..pages = 5;
+
+      expect(notifyCount, 0);
+    });
+
+    test('asserts pages > 0', () {
+      final controller = FPaginationController(pages: 5);
+      expect(() => controller.pages = 0, throwsA(isA<AssertionError>()));
+    });
+  });
+
+  group('siblings setter', () {
+    test('changes and notifies', () {
+      var notifyCount = 0;
+      final controller = FPaginationController(pages: 10)
+        ..addListener(() => notifyCount++)
+        ..siblings = 2;
+
+      expect(controller.siblings, 2);
+      expect(notifyCount, 1);
+    });
+
+    test('no-op when unchanged', () {
+      var notifyCount = 0;
+      FPaginationController(pages: 10)
+        ..addListener(() => notifyCount++)
+        ..siblings = 1;
+
+      expect(notifyCount, 0);
+    });
+
+    test('asserts siblings >= 0', () {
+      final controller = FPaginationController(pages: 10);
+      expect(() => controller.siblings = -1, throwsA(isA<AssertionError>()));
+    });
+  });
+
+  group('showEdges setter', () {
+    test('changes and notifies', () {
+      var notifyCount = 0;
+      final controller = FPaginationController(pages: 10)
+        ..addListener(() => notifyCount++)
+        ..showEdges = false;
+
+      expect(controller.showEdges, false);
+      expect(notifyCount, 1);
+    });
+
+    test('no-op when unchanged', () {
+      var notifyCount = 0;
+      FPaginationController(pages: 10)
+        ..addListener(() => notifyCount++)
+        ..showEdges = true;
+
+      expect(notifyCount, 0);
+    });
+  });
 }

--- a/forui/test/src/widgets/pagination/pagination_test.dart
+++ b/forui/test/src/widgets/pagination/pagination_test.dart
@@ -32,6 +32,50 @@ void main() {
       await tester.pumpAndSettle(const Duration(milliseconds: 500));
       expect(page, 6);
     });
+
+    testWidgets('pages, siblings, showEdges update on rebuild', (tester) async {
+      var page = 0;
+      var pages = 1;
+      var siblings = 1;
+      var showEdges = true;
+
+      Future<void> rebuild() => tester.pumpWidget(
+        TestScaffold(
+          child: FPagination(
+            control: .lifted(
+              page: page,
+              pages: pages,
+              siblings: siblings,
+              showEdges: showEdges,
+              onChange: (value) => page = value,
+            ),
+          ),
+        ),
+      );
+
+      await rebuild();
+      expect(find.text('10'), findsNothing);
+
+      pages = 10;
+      await rebuild();
+      await tester.pumpAndSettle();
+      expect(find.text('1'), findsOneWidget);
+      expect(find.text('10'), findsOneWidget);
+
+      page = 4;
+      siblings = 2;
+      await rebuild();
+      await tester.pumpAndSettle();
+      expect(find.text('3'), findsOneWidget);
+      expect(find.text('7'), findsOneWidget);
+
+      showEdges = false;
+      page = 5;
+      await rebuild();
+      await tester.pumpAndSettle();
+      expect(find.text('1'), findsNothing);
+      expect(find.text('10'), findsNothing);
+    });
   });
 
   group('managed', () {


### PR DESCRIPTION
**Describe the changes**

- Make `FPaginationController.pages`, `siblings`, and `showEdges` settable so existing controllers can be reconfigured without being recreated.
- Improve `FItem`/`FTile` docs to clarify that greedy widgets in any slot (not just `details`) can cause siblings to disappear.

Closes #978.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [x] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.