### PR TITLE
Add line calendar demo widget

### DIFF
--- a/demo/lib/main.dart
+++ b/demo/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart' hide Tooltip;
 import 'package:forui/forui.dart';
 
-import 'widgets/tooltip.dart';
+import 'widgets/line_calendar.dart';
 
 void main() {
   runApp(const Application());
@@ -29,7 +29,7 @@ class Application extends StatelessWidget {
         ),
       ),
       home: const FScaffold(
-        child: Tooltip(),
+        child: LineCalendar(),
       ),
     );
   }

--- a/demo/lib/widgets/line_calendar.dart
+++ b/demo/lib/widgets/line_calendar.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/widgets.dart';
+import 'package:forui/forui.dart';
+
+class LineCalendar extends StatelessWidget {
+  const LineCalendar({super.key});
+
+  @override
+  Widget build(BuildContext context) => Center(
+    child: FLineCalendar(control: .managed()),
+  );
+}


### PR DESCRIPTION
**Describe the changes**

Adds an `FLineCalendar` demo to the `/demo/` spotlight app, following the same minimal one-widget-per-file pattern as the recent tooltip demo (#980). `demo/lib/main.dart` now hosts the new `LineCalendar` widget in place of `Tooltip`.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.