### PR TITLE
Add accordion demo widget

### DIFF
--- a/demo/lib/main.dart
+++ b/demo/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart' hide Tooltip;
 import 'package:forui/forui.dart';
 
-import 'widgets/line_calendar.dart';
+import 'widgets/accordion.dart';
 
 void main() {
   runApp(const Application());
@@ -29,7 +29,7 @@ class Application extends StatelessWidget {
         ),
       ),
       home: const FScaffold(
-        child: LineCalendar(),
+        child: Accordion(),
       ),
     );
   }

--- a/demo/lib/widgets/accordion.dart
+++ b/demo/lib/widgets/accordion.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/widgets.dart';
+import 'package:forui/forui.dart';
+
+class Accordion extends StatelessWidget {
+  const Accordion({super.key});
+
+  @override
+  Widget build(BuildContext context) => Center(
+    child: SizedBox(
+      width: 400,
+      child: FAccordion(
+        control: .managed(max: 2),
+        children: const [
+          FAccordionItem(
+            initiallyExpanded: true,
+            title: Text('What is Forui?'),
+            child: Text('A beautiful, minimalistic, platform-agnostic UI library for Flutter.'),
+          ),
+          FAccordionItem(
+            title: Text('Touch or desktop?'),
+            child: Text('Both. Forui ships touch and desktop interactions out of the box.'),
+          ),
+          FAccordionItem(
+            title: Text('How many widgets?'),
+            child: Text('Over 50, beautifully crafted and well-tested.'),
+          ),
+        ],
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
**Describe the changes**
Adds an `Accordion` demo to the `demo/` package showcasing `FAccordion` with managed control (max 2 items expanded), three short FAQ-style entries about Forui, and "What is Forui?" expanded by default. Updates `demo/lib/main.dart` to render the new demo.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.