### PR TITLE
Add FDialog.resizeToAvoidInsets to opt out of view inset padding

### DIFF
--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -8,6 +8,10 @@
 * Add `ThemeExtension` support via `FColors(extensions: ...)`, `FColors.extension<T>()`, and `FColors.extensions`.
 
 
+### `FDialog`
+* Add `FDialog.resizeToAvoidInsets` to opt out of view insets padding.
+
+
 ### `FStyle` & `FThemeData`
 * Add `FThemeData.hapticFeedback`.
 

--- a/forui/lib/src/widgets/dialog/dialog.dart
+++ b/forui/lib/src/widgets/dialog/dialog.dart
@@ -278,6 +278,12 @@ class FDialog extends StatefulWidget {
   /// The dialog's box constraints. Defaults to `BoxConstraints(minWidth: 280, maxWidth: 560)`.
   final BoxConstraints constraints;
 
+  /// Whether the dialog should avoid the system's view insets, typically the keyboard.  Defaults to true.
+  ///
+  /// Set this to false to avoid the dialog from becoming overly compressed on web & embedded platforms where the view
+  /// insets comes from the surrounding host/browser environment.
+  final bool resizeToAvoidInsets;
+
   /// The builder for the dialog's content.
   final Widget Function(BuildContext context, FDialogStyle style) builder;
 
@@ -322,6 +328,7 @@ class FDialog extends StatefulWidget {
     this.animation,
     this.semanticsLabel,
     this.constraints = const BoxConstraints(minWidth: 280, maxWidth: 560),
+    this.resizeToAvoidInsets = true,
     Widget? image,
     Widget? title,
     Widget? body,
@@ -359,6 +366,7 @@ class FDialog extends StatefulWidget {
     this.animation,
     this.semanticsLabel,
     this.constraints = const BoxConstraints(minWidth: 280, maxWidth: 560),
+    this.resizeToAvoidInsets = true,
     Widget? image,
     Widget? title,
     Widget? body,
@@ -391,6 +399,7 @@ class FDialog extends StatefulWidget {
     this.animation,
     this.semanticsLabel,
     this.constraints = const BoxConstraints(minWidth: 280, maxWidth: 560),
+    this.resizeToAvoidInsets = true,
     super.key,
   });
 
@@ -405,6 +414,7 @@ class FDialog extends StatefulWidget {
       ..add(DiagnosticsProperty('animation', animation))
       ..add(StringProperty('semanticsLabel', semanticsLabel))
       ..add(DiagnosticsProperty('constraints', constraints))
+      ..add(FlagProperty('resizeToAvoidInsets', value: resizeToAvoidInsets, ifFalse: 'do not resize for view insets'))
       ..add(ObjectFlagProperty.has('builder', builder));
   }
 }
@@ -490,7 +500,9 @@ class _FDialogState extends State<FDialog> {
     }
 
     return AnimatedPadding(
-      padding: MediaQuery.viewInsetsOf(context) + style.insetPadding.resolve(direction),
+      padding:
+          (widget.resizeToAvoidInsets ? MediaQuery.viewInsetsOf(context) : EdgeInsets.zero) +
+          style.insetPadding.resolve(direction),
       duration: style.motion.insetDuration,
       curve: style.motion.insetCurve,
       child: MediaQuery.removeViewInsets(

--- a/forui/lib/src/widgets/dialog/dialog.dart
+++ b/forui/lib/src/widgets/dialog/dialog.dart
@@ -278,7 +278,7 @@ class FDialog extends StatefulWidget {
   /// The dialog's box constraints. Defaults to `BoxConstraints(minWidth: 280, maxWidth: 560)`.
   final BoxConstraints constraints;
 
-  /// Whether the dialog should avoid the system's view insets, typically the keyboard.  Defaults to true.
+  /// Whether the dialog should avoid the system's view insets, typically the keyboard. Defaults to true.
   ///
   /// Set this to false to avoid the dialog from becoming overly compressed on web & embedded platforms where the view
   /// insets comes from the surrounding host/browser environment.

--- a/forui/test/src/widgets/dialog/dialog_test.dart
+++ b/forui/test/src/widgets/dialog/dialog_test.dart
@@ -140,5 +140,47 @@ void main() {
 
       expect(tester.takeException(), null);
     });
+
+    group('resizeToAvoidInsets', () {
+      // Default style.insetPadding is EdgeInsets.symmetric(horizontal: 40, vertical: 24).
+      const styleBottomPadding = 24.0;
+      const viewInsetsBottom = 300.0;
+
+      for (final (resize, expectedBottom) in [
+        (true, viewInsetsBottom + styleBottomPadding),
+        (false, styleBottomPadding),
+      ]) {
+        testWidgets('resize=$resize -> bottom padding = $expectedBottom', (tester) async {
+          await tester.pumpWidget(
+            TestScaffold(
+              child: MediaQuery(
+                data: const MediaQueryData(viewInsets: EdgeInsets.only(bottom: viewInsetsBottom)),
+                child: FDialog(
+                  resizeToAvoidInsets: resize,
+                  title: const Text('Title'),
+                  body: const Text('Body'),
+                  actions: [FButton(onPress: () {}, child: const Text('OK'))],
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final padding = tester
+              .widget<AnimatedPadding>(find.byType(AnimatedPadding).first)
+              .padding
+              .resolve(TextDirection.ltr);
+          expect(padding.bottom, expectedBottom);
+        });
+      }
+
+      testWidgets('default is true across all constructors', (tester) async {
+        expect(FDialog(actions: const [], title: const Text('x')).resizeToAvoidInsets, true);
+        expect(FDialog.adaptive(actions: const []).resizeToAvoidInsets, true);
+        expect(const FDialog.raw(builder: _emptyBuilder).resizeToAvoidInsets, true);
+      });
+    });
   });
 }
+
+Widget _emptyBuilder(BuildContext _, FDialogStyle _) => const SizedBox.shrink();


### PR DESCRIPTION
**Describe the changes**

Adds `FDialog.resizeToAvoidInsets` (default `true`) that lets callers opt out of `MediaQuery.viewInsets` being added to the dialog's outer padding.

- Closes #1004.
- On Flutter Web/embedded environments, the host can report a large bottom view inset (e.g., a docked chat panel) that compresses `FDialog` into an unusable strip. Setting `resizeToAvoidInsets: false` keeps the dialog at its natural size.
- Available on `FDialog`, `FDialog.adaptive`, and `FDialog.raw`. Not added to `showFDialog`/`FDialogRoute` since the viewInsets handling lives entirely inside `_FDialogState.build`; callers pass it through their builder.
- Default `true` preserves existing behavior — purely additive, no `fix_data` migration needed.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [x] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)