### PR TITLE
Add autocomplete demo widget

### DIFF
--- a/demo/lib/main.dart
+++ b/demo/lib/main.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/material.dart' hide Tooltip;
+import 'package:flutter/material.dart' hide Autocomplete, Tooltip;
 import 'package:forui/forui.dart';
 
-import 'widgets/accordion.dart';
+import 'widgets/autocomplete.dart';
 
 void main() {
   runApp(const Application());
@@ -29,7 +29,7 @@ class Application extends StatelessWidget {
         ),
       ),
       home: const FScaffold(
-        child: Accordion(),
+        child: Autocomplete(),
       ),
     );
   }

--- a/demo/lib/widgets/autocomplete.dart
+++ b/demo/lib/widgets/autocomplete.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/widgets.dart';
+import 'package:forui/forui.dart';
+
+const _fruits = [
+  'Apple',
+  'Banana',
+  'Blueberry',
+  'Grapes',
+  'Lemon',
+  'Mango',
+  'Kiwi',
+  'Orange',
+  'Peach',
+  'Pear',
+  'Pineapple',
+  'Plum',
+  'Raspberry',
+  'Strawberry',
+  'Watermelon',
+];
+
+class Autocomplete extends StatelessWidget {
+  const Autocomplete({super.key});
+
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.all(32),
+    child: SizedBox(
+      width: 350,
+      child: FAutocomplete(
+        label: const Text('Fruit'),
+        hint: 'Type a fruit',
+        items: _fruits,
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
**Describe the changes**
Adds an `FAutocomplete` demo to the spotlight demo app: a simple fruits-list autocomplete using the same `Padding(32) → SizedBox(350)` shell as `select.dart`. `demo/lib/main.dart` is switched to spotlight the new widget (and `Autocomplete` is added to the `material.dart` `hide` list to avoid the Flutter `Autocomplete` clash).

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests.
- [x] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.