### PR TITLE
Add missing mount check in _FTappableState

### DIFF
--- a/forui/lib/src/foundation/tappable/tappable.dart
+++ b/forui/lib/src/foundation/tappable/tappable.dart
@@ -419,6 +419,7 @@ class _FTappableState<T extends FTappable> extends State<T> {
                 onPointerDown: _entries == null ? (event) => _start(event.buttons) : null,
                 onPointerMove: _entries == null
                     ? (event) async {
+                        // Check if it's mounted due to a non-deterministic race condition, https://github.com/duobaseio/forui/issues/482.
                         if (!mounted) {
                           return;
                         }

--- a/forui/lib/src/foundation/tappable/tappable.dart
+++ b/forui/lib/src/foundation/tappable/tappable.dart
@@ -419,6 +419,10 @@ class _FTappableState<T extends FTappable> extends State<T> {
                 onPointerDown: _entries == null ? (event) => _start(event.buttons) : null,
                 onPointerMove: _entries == null
                     ? (event) async {
+                        if (!mounted) {
+                          return;
+                        }
+
                         // Avoid unnecessary state updates.
                         if (!_current.contains(FTappableVariant.pressed)) {
                           return;


### PR DESCRIPTION
**Describe the changes**
<!-- 
A clear and concise description of the changes. Please [link an issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
if applicable. 
-->
Adds a missing `mounted` check, similar to the one added by https://github.com/duobaseio/forui/issues/482.


**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.