### PR TITLE
Allow hiding FAutocomplete popover via nullable content builders

### DIFF
--- a/docs_snippets/lib/examples/widgets/autocomplete.dart
+++ b/docs_snippets/lib/examples/widgets/autocomplete.dart
@@ -186,7 +186,7 @@ class AsyncErrorAutocompletePage extends Example {
     },
     contentBuilder: (context, query, values) => [for (final fruit in values) .item(value: fruit)],
     // {@highlight}
-    contentErrorBuilder: (context, error, trace) => Padding(
+    contentErrorBuilder: (context, style, error, trace) => Padding(
       padding: const .all(14.0),
       child: Icon(FIcons.circleX, size: 15, color: context.theme.colors.primary),
     ),

--- a/docs_snippets/lib/usages/widgets/autocomplete.dart
+++ b/docs_snippets/lib/usages/widgets/autocomplete.dart
@@ -95,7 +95,7 @@ final autocomplete = FAutocomplete(
   contentBuilder: (context, query, values) => [for (final value in values) .item(value: value)],
   contentEmptyBuilder: FAutocomplete.defaultContentEmptyBuilder,
   contentLoadingBuilder: FAutocomplete.defaultContentLoadingBuilder,
-  contentErrorBuilder: (context, error, stackTrace) => const Text('Error'),
+  contentErrorBuilder: (context, style, error, stackTrace) => const Text('Error'),
   contentDivider: .none,
   filter: (query) => ['Apple', 'Banana'].where((item) => item.toLowerCase().startsWith(query.toLowerCase())),
   // {@endcategory}
@@ -198,7 +198,7 @@ final builder = FAutocomplete.builder(
   contentScrollController: null,
   contentEmptyBuilder: FAutocomplete.defaultContentEmptyBuilder,
   contentLoadingBuilder: FAutocomplete.defaultContentLoadingBuilder,
-  contentErrorBuilder: (context, error, stackTrace) => const Text('Error'),
+  contentErrorBuilder: (context, style, error, stackTrace) => const Text('Error'),
   contentPhysics: const ClampingScrollPhysics(),
   contentDivider: .none,
   // {@endcategory}

--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 
 ### `FAutocomplete`
+* Add `FAutocomplete.defaultContentErrorBuilder` and default `contentErrorBuilder` to it.
+
+* **Breaking** Add `FAutocompleteContentStyle` parameter to `FAutocomplete.contentErrorBuilder` callback.
+
+* Change `FAutocomplete.contentLoadingBuilder` to nullable; pass `null` to hide the popover while loading.
+* Change `FAutocomplete.contentEmptyBuilder` to nullable; pass `null` to hide the popover when there are no results.
+* Change `FAutocomplete.contentErrorBuilder`; pass `null` to hide the popover when there is an error.
+
 * Fix `FAutocomplete` not showing context menu by default.
 
 ### `FButton`

--- a/forui/lib/src/widgets/autocomplete/autocomplete.dart
+++ b/forui/lib/src/widgets/autocomplete/autocomplete.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
@@ -45,12 +44,6 @@ typedef FAutocompletePopoverBuilder =
 /// * [FAutocompleteController] for customizing the behavior of an autocomplete.
 /// * [FAutocompleteStyle] for customizing the appearance of an autocomplete.
 class FAutocomplete extends StatefulWidget with FFormFieldProperties<String> {
-  /// The default loading builder that shows a spinner when an asynchronous search is pending.
-  static Widget defaultContentLoadingBuilder(BuildContext _, FAutocompleteContentStyle style) => Padding(
-    padding: const .all(13),
-    child: FCircularProgress(style: style.progressStyle),
-  );
-
   /// The default empty builder that shows a localized message when there are no results.
   static Widget defaultContentEmptyBuilder(BuildContext context, FAutocompleteContentStyle style) {
     final localizations = FLocalizations.of(context) ?? FDefaultLocalizations();
@@ -59,6 +52,23 @@ class FAutocomplete extends StatefulWidget with FFormFieldProperties<String> {
       child: Text(localizations.autocompleteNoResults, style: style.emptyTextStyle),
     );
   }
+
+  /// The default loading builder that shows a spinner when an asynchronous search is pending.
+  static Widget defaultContentLoadingBuilder(BuildContext _, FAutocompleteContentStyle style) => Padding(
+    padding: const .all(13),
+    child: FCircularProgress(style: style.progressStyle),
+  );
+
+  /// The default error builder that shows the error message when [filter] fails.
+  static Widget defaultContentErrorBuilder(
+    BuildContext context,
+    FAutocompleteContentStyle style,
+    Object? error,
+    StackTrace stackTrace,
+  ) => Padding(
+    padding: const .symmetric(horizontal: 8, vertical: 14),
+    child: Text('$error', style: style.emptyTextStyle),
+  );
 
   /// Defines how the autocomplete's state is controlled.
   ///
@@ -339,7 +349,9 @@ class FAutocomplete extends StatefulWidget with FFormFieldProperties<String> {
   final FutureOr<Iterable<String>> Function(String text) filter;
 
   /// The builder that is called when the select is empty. Defaults to [defaultContentEmptyBuilder].
-  final Widget Function(BuildContext context, FAutocompleteContentStyle style) contentEmptyBuilder;
+  ///
+  /// Pass `null` to hide the popover entirely when there are no results.
+  final Widget Function(BuildContext context, FAutocompleteContentStyle style)? contentEmptyBuilder;
 
   /// The content's scroll controller.
   final ScrollController? contentScrollController;
@@ -354,10 +366,16 @@ class FAutocomplete extends StatefulWidget with FFormFieldProperties<String> {
   final FAutoCompleteContentBuilder contentBuilder;
 
   /// A callback that is used to show a loading indicator while the results is processed.
-  final Widget Function(BuildContext context, FAutocompleteContentStyle style) contentLoadingBuilder;
+  ///
+  /// Pass `null` to hide the popover entirely while loading.
+  final Widget Function(BuildContext context, FAutocompleteContentStyle style)? contentLoadingBuilder;
 
-  /// A callback that is used to show an error message when [filter] is asynchronous and fails.
-  final Widget Function(BuildContext context, Object? error, StackTrace stackTrace)? contentErrorBuilder;
+  /// A callback that is used to show an error message when [filter] is asynchronous and fails. Defaults to
+  /// [defaultContentErrorBuilder].
+  ///
+  /// Pass `null` to hide the popover entirely when there is an error.
+  final Widget Function(BuildContext context, FAutocompleteContentStyle style, Object? error, StackTrace stackTrace)?
+  contentErrorBuilder;
 
   /// Creates a [FAutocomplete] from the given [items].
   ///
@@ -449,11 +467,13 @@ class FAutocomplete extends StatefulWidget with FFormFieldProperties<String> {
     ScrollController? contentScrollController,
     ScrollPhysics contentPhysics = const ClampingScrollPhysics(),
     FItemDivider contentDivider = .none,
-    Widget Function(BuildContext context, FAutocompleteContentStyle style) contentEmptyBuilder =
+    Widget Function(BuildContext context, FAutocompleteContentStyle style)? contentEmptyBuilder =
         defaultContentEmptyBuilder,
-    Widget Function(BuildContext context, FAutocompleteContentStyle style) contentLoadingBuilder =
+    Widget Function(BuildContext context, FAutocompleteContentStyle style)? contentLoadingBuilder =
         defaultContentLoadingBuilder,
-    Widget Function(BuildContext context, Object? error, StackTrace stackTrace)? contentErrorBuilder,
+    Widget Function(BuildContext context, FAutocompleteContentStyle style, Object? error, StackTrace stackTrace)?
+        contentErrorBuilder =
+        defaultContentErrorBuilder,
     Key? key,
   }) : this.builder(
          filter: filter ?? (query) => items.where((item) => item.toLowerCase().startsWith(query.toLowerCase())),
@@ -638,7 +658,7 @@ class FAutocomplete extends StatefulWidget with FFormFieldProperties<String> {
     this.contentDivider = .none,
     this.contentEmptyBuilder = defaultContentEmptyBuilder,
     this.contentLoadingBuilder = defaultContentLoadingBuilder,
-    this.contentErrorBuilder,
+    this.contentErrorBuilder = defaultContentErrorBuilder,
     super.key,
   });
 
@@ -769,7 +789,7 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
     _popoverFocus = FocusScopeNode(debugLabel: 'FAutocomplete popover');
     _popoverController = widget.popoverControl.create(_handleOnPopoverChange, this);
     _controller = widget.control.create(_update, widget.filter);
-    _controller.loadSuggestions(_data = widget.filter(_controller.text));
+    _controller.loadSuggestions(_data = widget.filter(_controller.text)).ignore();
   }
 
   @override
@@ -786,7 +806,7 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
     final (controller, updated) = widget.control.update(old.control, _controller, _update, widget.filter);
     if (updated) {
       _controller = controller;
-      _controller.loadSuggestions(widget.filter(_controller.text));
+      _controller.loadSuggestions(widget.filter(_controller.text)).ignore();
     }
     _popoverController = widget.popoverControl
         .update(old.popoverControl, _popoverController, _handleOnPopoverChange, this)
@@ -811,22 +831,18 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
       return;
     }
 
-    if (_fieldFocus.hasFocus && !_popoverController.status.isForwardOrCompleted) {
-      final current = ++_monotonic;
-      SchedulerBinding.instance.addPostFrameCallback((_) {
-        if (current == _monotonic) {
-          _popoverController.show();
-        }
-      });
-    }
-
     setState(() {
       _previous = _controller.text;
-      _controller.loadSuggestions(_data = widget.filter(_controller.text));
+      _controller.loadSuggestions(_data = widget.filter(_controller.text)).ignore();
     });
 
     if (widget.control case FAutocompleteManagedControl(:final onChange?)) {
       onChange(_controller.value);
+    }
+
+    // Skip if text changed programmatically while the field isn't focused.
+    if (_fieldFocus.hasFocus) {
+      _toggle();
     }
   }
 
@@ -838,7 +854,7 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
         _controller.selection = TextSelection(baseOffset: 0, extentOffset: _controller.text.length);
       }
       _tapFocus = false;
-      _popoverController.show();
+      _toggle();
       // Hide the popover when the textfield loses focus and there are no completions to prevent focus from being trapped
       // in the empty popover.
     } else if (!_fieldFocus.hasFocus && _popoverFocus.descendants.isEmpty) {
@@ -846,6 +862,34 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
     }
 
     _restore = null;
+  }
+
+  void _toggle() {
+    final token = ++_monotonic;
+    final data = _data;
+
+    _apply(token, _content(data));
+    if (data is Future<Iterable<String>>) {
+      data.then(
+        (values) => _apply(token, _content(values)),
+        onError: (_, _) => _apply(token, widget.contentErrorBuilder != null),
+      );
+    }
+  }
+
+  bool _content(FutureOr<Iterable<String>> data) => switch (data) {
+    final Iterable<String> values => values.isNotEmpty || widget.contentEmptyBuilder != null,
+    Future<Iterable<String>>() => widget.contentLoadingBuilder != null,
+  };
+
+  void _apply(int token, bool show) {
+    if (mounted && token == _monotonic) {
+      if (show) {
+        _popoverController.show();
+      } else {
+        _popoverController.hide();
+      }
+    }
   }
 
   void _handleOnPopoverChange() {
@@ -904,7 +948,7 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
         showCursor: widget.showCursor,
         maxLength: widget.maxLength,
         maxLengthEnforcement: widget.maxLengthEnforcement,
-        onTap: _popoverController.show,
+        onTap: _toggle,
         onTapAlwaysCalled: true,
         onEditingComplete: widget.onEditingComplete,
         onSubmit: (value) {
@@ -1008,10 +1052,10 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
                     physics: widget.contentPhysics,
                     divider: widget.contentDivider,
                     data: _data,
-                    loadingBuilder: widget.contentLoadingBuilder,
+                    loadingBuilder: widget.contentLoadingBuilder ?? (_, _) => const SizedBox.shrink(),
                     builder: widget.contentBuilder,
-                    emptyBuilder: widget.contentEmptyBuilder,
-                    errorBuilder: widget.contentErrorBuilder,
+                    emptyBuilder: widget.contentEmptyBuilder ?? (_, _) => const SizedBox.shrink(),
+                    errorBuilder: widget.contentErrorBuilder ?? (_, _, _, _) => const SizedBox.shrink(),
                   ),
                 ),
               ),

--- a/forui/lib/src/widgets/autocomplete/autocomplete.dart
+++ b/forui/lib/src/widgets/autocomplete/autocomplete.dart
@@ -883,12 +883,19 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
   };
 
   void _apply(int token, bool show) {
-    if (mounted && token == _monotonic) {
-      if (show) {
-        _popoverController.show();
-      } else {
-        _popoverController.hide();
-      }
+    if (!mounted || token != _monotonic) {
+      return;
+    }
+
+    // Don't re-show after unfocus: a pending async filter completing must not reopen the popover.
+    if (show && !_fieldFocus.hasFocus) {
+      return;
+    }
+
+    if (show) {
+      _popoverController.show();
+    } else {
+      _popoverController.hide();
     }
   }
 

--- a/forui/lib/src/widgets/autocomplete/autocomplete_content.dart
+++ b/forui/lib/src/widgets/autocomplete/autocomplete_content.dart
@@ -47,7 +47,8 @@ class Content extends StatelessWidget {
   final Widget Function(BuildContext context, FAutocompleteContentStyle style) loadingBuilder;
   final FAutoCompleteContentBuilder builder;
   final Widget Function(BuildContext context, FAutocompleteContentStyle style) emptyBuilder;
-  final Widget Function(BuildContext context, Object? error, StackTrace stackTrace)? errorBuilder;
+  final Widget Function(BuildContext context, FAutocompleteContentStyle style, Object? error, StackTrace stackTrace)
+  errorBuilder;
 
   const Content({
     required this.controller,
@@ -73,12 +74,8 @@ class Content extends StatelessWidget {
         final Future<Iterable<String>> future => FutureBuilder(
           future: future,
           builder: (context, snapshot) => switch (snapshot.connectionState) {
-            ConnectionState.waiting => Center(child: loadingBuilder(context, style)),
-            _ when snapshot.hasError && errorBuilder != null => errorBuilder!.call(
-              context,
-              snapshot.error,
-              snapshot.stackTrace!,
-            ),
+            .waiting => Center(child: loadingBuilder(context, style)),
+            _ when snapshot.hasError => errorBuilder(context, style, snapshot.error, snapshot.stackTrace!),
             _ => _content(context, snapshot.data ?? []),
           },
         ),

--- a/forui/test/src/widgets/autocomplete/autocomplete_test.dart
+++ b/forui/test/src/widgets/autocomplete/autocomplete_test.dart
@@ -715,6 +715,36 @@ void main() {
 
       expect(popoverController.status.isForwardOrCompleted, false);
     });
+
+    testWidgets('async resolution after unfocus does not re-show popover', (tester) async {
+      final completer = Completer<Iterable<String>>();
+      final focus = autoDispose(FocusNode());
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FAutocomplete.builder(
+            key: key,
+            popoverControl: .managed(controller: popoverController),
+            focusNode: focus,
+            filter: (_) => completer.future,
+            contentBuilder: (_, _, values) => [for (final v in values) .item(value: v)],
+            contentLoadingBuilder: (_, _) => const Text('loading'),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(key));
+      await tester.pumpAndSettle();
+      expect(popoverController.status.isForwardOrCompleted, true);
+
+      focus.unfocus();
+      await tester.pumpAndSettle();
+      expect(popoverController.status.isForwardOrCompleted, false);
+
+      completer.complete(fruits);
+      await tester.pumpAndSettle();
+      expect(popoverController.status.isForwardOrCompleted, false);
+    });
   });
 
   group('contentErrorBuilder', () {

--- a/forui/test/src/widgets/autocomplete/autocomplete_test.dart
+++ b/forui/test/src/widgets/autocomplete/autocomplete_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -556,6 +557,217 @@ void main() {
       });
     });
   }
+
+  group('contentEmptyBuilder', () {
+    testWidgets('default shows popover with localized message when results are empty', (tester) async {
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FAutocomplete(
+            key: key,
+            popoverControl: .managed(controller: popoverController),
+            items: fruits,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byKey(key), 'zzz');
+      await tester.pumpAndSettle();
+
+      expect(popoverController.status.isForwardOrCompleted, true);
+      expect(find.text(FDefaultLocalizations().autocompleteNoResults), findsOne);
+    });
+
+    testWidgets('null hides popover when results are empty', (tester) async {
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FAutocomplete(
+            key: key,
+            popoverControl: .managed(controller: popoverController),
+            items: fruits,
+            contentEmptyBuilder: null,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byKey(key), 'zzz');
+      await tester.pumpAndSettle();
+
+      expect(popoverController.status.isForwardOrCompleted, false);
+    });
+
+    testWidgets('null reshows popover when results become non-empty', (tester) async {
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FAutocomplete(
+            key: key,
+            popoverControl: .managed(controller: popoverController),
+            items: fruits,
+            contentEmptyBuilder: null,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byKey(key), 'zzz');
+      await tester.pumpAndSettle();
+      expect(popoverController.status.isForwardOrCompleted, false);
+
+      await tester.enterText(find.byKey(key), 'App');
+      await tester.pumpAndSettle();
+      expect(popoverController.status.isForwardOrCompleted, true);
+    });
+
+    testWidgets('non-null shows popover when results are empty', (tester) async {
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FAutocomplete(
+            key: key,
+            popoverControl: .managed(controller: popoverController),
+            items: fruits,
+            contentEmptyBuilder: (_, _) => const Text('no results'),
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byKey(key), 'zzz');
+      await tester.pumpAndSettle();
+
+      expect(popoverController.status.isForwardOrCompleted, true);
+      expect(find.text('no results'), findsOne);
+    });
+
+    testWidgets('null hides popover after async resolution to empty', (tester) async {
+      final completer = Completer<Iterable<String>>();
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FAutocomplete.builder(
+            key: key,
+            popoverControl: .managed(controller: popoverController),
+            filter: (_) => completer.future,
+            contentBuilder: (_, _, values) => [for (final v in values) .item(value: v)],
+            contentLoadingBuilder: (_, _) => const Text('loading'),
+            contentEmptyBuilder: null,
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(key));
+      await tester.pumpAndSettle();
+      expect(popoverController.status.isForwardOrCompleted, true);
+      expect(find.text('loading'), findsOne);
+
+      completer.complete(const <String>[]);
+      await tester.pumpAndSettle();
+      expect(popoverController.status.isForwardOrCompleted, false);
+    });
+  });
+
+  group('contentLoadingBuilder', () {
+    testWidgets('default shows popover with spinner during async load', (tester) async {
+      final completer = Completer<Iterable<String>>();
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FAutocomplete.builder(
+            key: key,
+            popoverControl: .managed(controller: popoverController),
+            filter: (_) => completer.future,
+            contentBuilder: (_, _, values) => [for (final v in values) .item(value: v)],
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(key));
+      // Don't pumpAndSettle — the spinner loops forever. Pump enough to run the show animation.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(popoverController.status.isForwardOrCompleted, true);
+      expect(find.byType(FCircularProgress), findsOne);
+
+      // Resolve the future so the spinner stops before teardown.
+      completer.complete(const <String>[]);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('null hides popover during async load', (tester) async {
+      final completer = Completer<Iterable<String>>();
+      addTearDown(() {
+        if (!completer.isCompleted) {
+          completer.complete(const <String>[]);
+        }
+      });
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FAutocomplete.builder(
+            key: key,
+            popoverControl: .managed(controller: popoverController),
+            filter: (_) => completer.future,
+            contentBuilder: (_, _, values) => [for (final v in values) .item(value: v)],
+            contentLoadingBuilder: null,
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(key));
+      await tester.pumpAndSettle();
+
+      expect(popoverController.status.isForwardOrCompleted, false);
+    });
+  });
+
+  group('contentErrorBuilder', () {
+    testWidgets('default keeps popover shown on async failure', (tester) async {
+      final completer = Completer<Iterable<String>>();
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FAutocomplete.builder(
+            key: key,
+            popoverControl: .managed(controller: popoverController),
+            filter: (_) => completer.future,
+            contentBuilder: (_, _, values) => [for (final v in values) .item(value: v)],
+            contentLoadingBuilder: (_, _) => const Text('loading'),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(key));
+      await tester.pumpAndSettle();
+
+      completer.completeError('boom', .current);
+      await tester.pumpAndSettle();
+
+      expect(popoverController.status.isForwardOrCompleted, true);
+    });
+
+    testWidgets('null hides popover on async failure', (tester) async {
+      final completer = Completer<Iterable<String>>();
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FAutocomplete.builder(
+            key: key,
+            popoverControl: .managed(controller: popoverController),
+            filter: (_) => completer.future,
+            contentBuilder: (_, _, values) => [for (final v in values) .item(value: v)],
+            contentLoadingBuilder: (_, _) => const Text('loading'),
+            contentErrorBuilder: null,
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(key));
+      await tester.pumpAndSettle();
+      expect(popoverController.status.isForwardOrCompleted, true);
+
+      completer.completeError('boom', StackTrace.current);
+      await tester.pumpAndSettle();
+
+      expect(popoverController.status.isForwardOrCompleted, false);
+    });
+  });
 
   group('design system', skip: !Platform.isMacOS, () {
     for (final (theme, themeName) in [


### PR DESCRIPTION
**Describe the changes**

Resolves #968. Returning ``SizedBox.shrink()`` from ``FAutocomplete``'s content builders previously left a visible popover frame because the popover's padding and decoration still rendered. This PR makes the three content builders nullable so ``null`` opts out of showing the popover entirely in that state.

- ``FAutocomplete.contentLoadingBuilder``, ``contentEmptyBuilder``, ``contentErrorBuilder`` are now nullable. Pass ``null`` to hide the popover for that state.
- Adds ``FAutocomplete.defaultContentErrorBuilder``; ``contentErrorBuilder`` defaults to it (previously was implicitly ``null``).
- Aligns ``contentErrorBuilder`` signature with the loading/empty builders by adding the ``FAutocompleteContentStyle`` parameter. **Breaking** for callers with custom error builders — add ``style`` as the second argument.
- ``_State`` now decides popover visibility from one place (``_show`` + ``_hasContent``), choosing show vs hide based on the data state and which builder is non-null. Future-typed filters also re-evaluate on resolution and on error.
- ``FTypeaheadController.loadSuggestions``'s returned ``Future<void>`` is now observed via ``.ignore()`` at the three call sites so a filter future erroring doesn't leak as an unhandled async error.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [x] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.