### PR TITLE
Add granular gesture callbacks to FTappable

### DIFF
--- a/docs_snippets/lib/usages/foundation/tappable.dart
+++ b/docs_snippets/lib/usages/foundation/tappable.dart
@@ -14,12 +14,35 @@ final tappable = FTappable(
   shortcuts: null,
   actions: null,
   // {@endcategory}
-  // {@category "Callbacks"}
+  // {@category "Primary gestures"}
+  onPressDown: (details) {},
+  onPressCancel: () {},
+  onPressMove: (details) {},
+  onPressUp: (details) {},
   onPress: () {},
+  onLongPressDown: (details) {},
+  onLongPressCancel: () {},
+  onLongPressStart: (details) {},
+  onLongPressMove: (details) {},
+  onLongPressEnd: (details) {},
   onLongPress: () {},
+  onDoubleTapDown: (details) {},
+  onDoubleTapCancel: () {},
   onDoubleTap: () {},
+  // {@endcategory}
+  // {@category "Secondary gestures"}
+  onSecondaryPressDown: (details) {},
+  onSecondaryPressCancel: () {},
+  onSecondaryPressUp: (details) {},
   onSecondaryPress: () {},
+  onSecondaryLongPressDown: (details) {},
+  onSecondaryLongPressCancel: () {},
+  onSecondaryLongPressStart: (details) {},
+  onSecondaryLongPressMove: (details) {},
+  onSecondaryLongPressEnd: (details) {},
   onSecondaryLongPress: () {},
+  // {@endcategory}
+  // {@category "State callbacks"}
   onHoverChange: (hovered) {},
   onVariantChange: (previous, current) {},
   // {@endcategory}
@@ -43,12 +66,35 @@ final tappableStatic = FTappable.static(
   shortcuts: null,
   actions: null,
   // {@endcategory}
-  // {@category "Callbacks"}
+  // {@category "Primary gestures"}
+  onPressDown: (details) {},
+  onPressCancel: () {},
+  onPressMove: (details) {},
+  onPressUp: (details) {},
   onPress: () {},
+  onLongPressDown: (details) {},
+  onLongPressCancel: () {},
+  onLongPressStart: (details) {},
+  onLongPressMove: (details) {},
+  onLongPressEnd: (details) {},
   onLongPress: () {},
+  onDoubleTapDown: (details) {},
+  onDoubleTapCancel: () {},
   onDoubleTap: () {},
+  // {@endcategory}
+  // {@category "Secondary gestures"}
+  onSecondaryPressDown: (details) {},
+  onSecondaryPressCancel: () {},
+  onSecondaryPressUp: (details) {},
   onSecondaryPress: () {},
+  onSecondaryLongPressDown: (details) {},
+  onSecondaryLongPressCancel: () {},
+  onSecondaryLongPressStart: (details) {},
+  onSecondaryLongPressMove: (details) {},
+  onSecondaryLongPressEnd: (details) {},
   onSecondaryLongPress: () {},
+  // {@endcategory}
+  // {@category "State callbacks"}
   onHoverChange: (hovered) {},
   onVariantChange: (previous, current) {},
   // {@endcategory}

--- a/docs_snippets/lib/usages/widgets/alert.dart
+++ b/docs_snippets/lib/usages/widgets/alert.dart
@@ -10,6 +10,7 @@ const alert = FAlert(
   // {@endcategory}
   // {@category "Core"}
   style: .context(),
+  clipBehavior: .none,
   icon: Icon(FIcons.circleAlert),
   title: Text('Alert Title'),
   subtitle: Text('Alert subtitle with more details'),

--- a/docs_snippets/lib/usages/widgets/card.dart
+++ b/docs_snippets/lib/usages/widgets/card.dart
@@ -7,6 +7,7 @@ import 'package:forui/forui.dart';
 final card = FCard(
   // {@category "Core"}
   style: const .delta(decoration: .shapeDelta(color: Color(0xFFFFFFFF))),
+  clipBehavior: .none,
   mainAxisSize: .min,
   image: const Placeholder(),
   title: const Text('Title'),
@@ -18,6 +19,7 @@ final card = FCard(
 const raw = FCard.raw(
   // {@category "Core"}
   style: .delta(decoration: .shapeDelta(color: Color(0xFFFFFFFF))),
+  clipBehavior: .none,
   child: Text('Content'),
   // {@endcategory}
 );

--- a/docs_snippets/lib/usages/widgets/dialog.dart
+++ b/docs_snippets/lib/usages/widgets/dialog.dart
@@ -8,6 +8,7 @@ final dialog = FDialog(
   // {@category "Layout"}
   direction: .vertical,
   constraints: const BoxConstraints(minWidth: 280, maxWidth: 560),
+  resizeToAvoidInsets: true,
   // {@endcategory}
   // {@category "Accessibility"}
   semanticsLabel: 'Dialog',
@@ -17,6 +18,7 @@ final dialog = FDialog(
   // {@endcategory}
   // {@category "Core"}
   style: const .delta(insetPadding: .value(.zero)),
+  clipBehavior: .none,
   image: null,
   title: const Text('Title'),
   body: const Text('Body'),
@@ -27,6 +29,7 @@ final dialog = FDialog(
 final adaptive = FDialog.adaptive(
   // {@category "Layout"}
   constraints: const BoxConstraints(minWidth: 280, maxWidth: 560),
+  resizeToAvoidInsets: true,
   // {@endcategory}
   // {@category "Accessibility"}
   semanticsLabel: 'Dialog',
@@ -36,6 +39,7 @@ final adaptive = FDialog.adaptive(
   // {@endcategory}
   // {@category "Core"}
   style: const .delta(insetPadding: .value(.zero)),
+  clipBehavior: .none,
   image: null,
   title: const Text('Title'),
   body: const Text('Body'),
@@ -46,6 +50,7 @@ final adaptive = FDialog.adaptive(
 final raw = FDialog.raw(
   // {@category "Layout"}
   constraints: const BoxConstraints(minWidth: 280, maxWidth: 560),
+  resizeToAvoidInsets: true,
   // {@endcategory}
   // {@category "Accessibility"}
   semanticsLabel: 'Dialog',
@@ -55,6 +60,7 @@ final raw = FDialog.raw(
   // {@endcategory}
   // {@category "Core"}
   style: const .delta(insetPadding: .value(.zero)),
+  clipBehavior: .none,
   builder: (context, style) => const Text('Custom content'),
   // {@endcategory}
 );

--- a/docs_snippets/lib/usages/widgets/popover.dart
+++ b/docs_snippets/lib/usages/widgets/popover.dart
@@ -37,6 +37,7 @@ final popover = FPopover(
   // {@endcategory}
   // {@category "Core"}
   style: const .delta(popoverPadding: .value(.all(5))),
+  popoverClipBehavior: .none,
   popoverBuilder: (context, controller) => const Padding(padding: .all(8), child: Text('Popover content')),
   builder: (context, controller, child) => child!,
   child: FButton(onPress: () {}, child: const Text('Show Popover')),

--- a/docs_snippets/lib/usages/widgets/toast.dart
+++ b/docs_snippets/lib/usages/widgets/toast.dart
@@ -10,6 +10,7 @@ const toast = FToast(
   // {@endcategory}
   // {@category "Core"}
   style: .delta(titleSpacing: 5),
+  clipBehavior: .none,
   icon: Icon(FIcons.info),
   title: Text('Title'),
   description: Text('Description'),

--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -74,6 +74,28 @@
   directly to change these.
 
 
+### `FTappable`
+* Add `onPressDown`.
+* Add `onPressCancel`.
+* Add `onPressMove`.
+* Add `onPressUp`.
+* Add `onLongPressDown`.
+* Add `onLongPressCancel`.
+* Add `onLongPressStart`.
+* Add `onLongPressMove`.
+* Add `onLongPressEnd`.
+* Add `onDoubleTapDown`.
+* Add `onDoubleTapCancel`.
+* Add `onSecondaryPressDown`.
+* Add `onSecondaryPressCancel`.
+* Add `onSecondaryPressUp`.
+* Add `onSecondaryLongPressDown`.
+* Add `onSecondaryLongPressCancel`.
+* Add `onSecondaryLongPressStart`.
+* Add `onSecondaryLongPressMove`.
+* Add `onSecondaryLongPressEnd`.
+
+
 ### `FToast`
 * Add `FToast.clipBehavior` to clip the toast's content to the inner path of its decoration. Defaults to `Clip.none`.
 

--- a/forui/lib/src/foundation/tappable/tappable.dart
+++ b/forui/lib/src/foundation/tappable/tappable.dart
@@ -89,63 +89,184 @@ class FTappable extends StatefulWidget {
   /// The tappable's hit test behavior. Defaults to [HitTestBehavior.translucent].
   final HitTestBehavior behavior;
 
+  /// {@template forui.foundation.FTappable.onPressDown}
+  /// A callback for when a primary pointer initially contacts the widget.
+  ///
+  /// Analogous to [GestureDetector.onTapDown].
+  /// {@endtemplate}
+  final GestureTapDownCallback? onPressDown;
+
+  /// {@template forui.foundation.FTappable.onPressCancel}
+  /// A callback for when a primary pointer that previously triggered [onPressDown] will not end up causing a tap.
+  ///
+  /// Analogous to [GestureDetector.onTapCancel].
+  /// {@endtemplate}
+  final GestureTapCancelCallback? onPressCancel;
+
+  /// {@template forui.foundation.FTappable.onPressMove}
+  /// A callback for when a primary pointer that triggered a tap has moved.
+  ///
+  /// Analogous to [GestureDetector.onTapMove].
+  /// {@endtemplate}
+  final GestureTapMoveCallback? onPressMove;
+
+  /// {@template forui.foundation.FTappable.onPressUp}
+  /// A callback for when a primary pointer that previously triggered [onPressDown] stops contacting the widget at the
+  /// same location it initially contacted.
+  ///
+  /// Analogous to [GestureDetector.onTapUp]. Fires immediately before [onPress].
+  /// {@endtemplate}
+  final GestureTapUpCallback? onPressUp;
+
   /// {@template forui.foundation.FTappable.onPress}
   /// A callback for when the widget is pressed.
   ///
-  /// The widget will be disabled if the following are null:
-  /// * [onPress]
-  /// * [onLongPress]
-  /// * [onDoubleTap]
-  /// * [onSecondaryPress]
-  /// * [onSecondaryLongPress]
+  /// The widget is disabled when every primary and secondary gesture callback (including all lifecycle variants) is
+  /// null.
   /// {@endtemplate}
   final VoidCallback? onPress;
+
+  /// {@template forui.foundation.FTappable.onLongPressDown}
+  /// A callback for when a primary pointer that might cause a long press has contacted the widget.
+  ///
+  /// Analogous to [GestureDetector.onLongPressDown].
+  ///
+  /// There is no equivalent [GestureDetector.onLongPressUp]. Use [onLongPressEnd] instead.
+  /// {@endtemplate}
+  final GestureLongPressDownCallback? onLongPressDown;
+
+  /// {@template forui.foundation.FTappable.onLongPressCancel}
+  /// A callback for when the pointer that previously triggered [onLongPressDown] will not end up causing a long press.
+  ///
+  /// Analogous to [GestureDetector.onLongPressCancel].
+  /// {@endtemplate}
+  final GestureLongPressCancelCallback? onLongPressCancel;
+
+  /// {@template forui.foundation.FTappable.onLongPressStart}
+  /// A callback for when a long press has been recognised by a primary pointer.
+  ///
+  /// Analogous to [GestureDetector.onLongPressStart]. Fires alongside [onLongPress].
+  /// {@endtemplate}
+  final GestureLongPressStartCallback? onLongPressStart;
+
+  /// {@template forui.foundation.FTappable.onLongPressMove}
+  /// A callback for when a primary pointer is moving after being recognised as a long press.
+  ///
+  /// Analogous to [GestureDetector.onLongPressMoveUpdate].
+  /// {@endtemplate}
+  final GestureLongPressMoveUpdateCallback? onLongPressMove;
+
+  /// {@template forui.foundation.FTappable.onLongPressEnd}
+  /// A callback for when a long press recognised by a primary pointer is ending.
+  ///
+  /// Analogous to [GestureDetector.onLongPressEnd].
+  /// {@endtemplate}
+  final GestureLongPressEndCallback? onLongPressEnd;
 
   /// {@template forui.foundation.FTappable.onLongPress}
   /// A callback for when the widget is long pressed.
   ///
-  /// The widget will be disabled if the following are null:
-  /// * [onPress]
-  /// * [onLongPress]
-  /// * [onDoubleTap]
-  /// * [onSecondaryPress]
-  /// * [onSecondaryLongPress]
+  /// The widget is disabled when every primary and secondary gesture callback (including all lifecycle variants) is
+  /// null.
   /// {@endtemplate}
   final VoidCallback? onLongPress;
+
+  /// {@template forui.foundation.FTappable.onDoubleTapDown}
+  /// A callback for when a pointer that might cause a double tap has contacted the widget.
+  ///
+  /// Analogous to [GestureDetector.onDoubleTapDown].
+  /// {@endtemplate}
+  final GestureTapDownCallback? onDoubleTapDown;
+
+  /// {@template forui.foundation.FTappable.onDoubleTapCancel}
+  /// A callback for when the pointer that previously triggered [onDoubleTapDown] will not end up causing a double tap.
+  ///
+  /// Analogous to [GestureDetector.onDoubleTapCancel].
+  /// {@endtemplate}
+  final GestureTapCancelCallback? onDoubleTapCancel;
 
   /// {@template forui.foundation.FTappable.onDoubleTap}
   /// A callback for when the widget is double tapped.
   ///
-  /// The widget will be disabled if the following are null:
-  /// * [onPress]
-  /// * [onLongPress]
-  /// * [onDoubleTap]
-  /// * [onSecondaryPress]
-  /// * [onSecondaryLongPress]
+  /// The widget is disabled when every primary and secondary gesture callback (including all lifecycle variants) is
+  /// null.
   /// {@endtemplate}
   final VoidCallback? onDoubleTap;
+
+  /// {@template forui.foundation.FTappable.onSecondaryPressDown}
+  /// A callback for when a secondary pointer initially contacts the widget.
+  ///
+  /// Analogous to [GestureDetector.onSecondaryTapDown].
+  /// {@endtemplate}
+  final GestureTapDownCallback? onSecondaryPressDown;
+
+  /// {@template forui.foundation.FTappable.onSecondaryPressCancel}
+  /// A callback for when a secondary pointer that previously triggered [onSecondaryPressDown] will not end up causing
+  /// a tap.
+  ///
+  /// Analogous to [GestureDetector.onSecondaryTapCancel].
+  /// {@endtemplate}
+  final GestureTapCancelCallback? onSecondaryPressCancel;
+
+  /// {@template forui.foundation.FTappable.onSecondaryPressUp}
+  /// A callback for when a secondary pointer that previously triggered [onSecondaryPressDown] stops contacting the
+  /// widget.
+  ///
+  /// Analogous to [GestureDetector.onSecondaryTapUp]. Fires immediately before [onSecondaryPress].
+  /// {@endtemplate}
+  final GestureTapUpCallback? onSecondaryPressUp;
 
   /// {@template forui.foundation.FTappable.onSecondaryPress}
   /// A callback for when the widget is pressed with a secondary button (usually right-click on desktop).
   ///
-  /// The widget will be disabled if the following are null:
-  /// * [onPress]
-  /// * [onLongPress]
-  /// * [onDoubleTap]
-  /// * [onSecondaryPress]
-  /// * [onSecondaryLongPress]
+  /// The widget is disabled when every primary and secondary gesture callback (including all lifecycle variants) is
+  /// null.
   /// {@endtemplate}
   final VoidCallback? onSecondaryPress;
+
+  /// {@template forui.foundation.FTappable.onSecondaryLongPressDown}
+  /// A callback for when a secondary pointer that might cause a long press has contacted the widget.
+  ///
+  /// Analogous to [GestureDetector.onSecondaryLongPressDown].
+  ///
+  /// There is no equivalent [GestureDetector.onSecondaryLongPressUp]. Use [onSecondaryLongPressEnd] instead.
+  /// {@endtemplate}
+  final GestureLongPressDownCallback? onSecondaryLongPressDown;
+
+  /// {@template forui.foundation.FTappable.onSecondaryLongPressCancel}
+  /// A callback for when the pointer that previously triggered [onSecondaryLongPressDown] will not end up causing a
+  /// long press.
+  ///
+  /// Analogous to [GestureDetector.onSecondaryLongPressCancel].
+  /// {@endtemplate}
+  final GestureLongPressCancelCallback? onSecondaryLongPressCancel;
+
+  /// {@template forui.foundation.FTappable.onSecondaryLongPressStart}
+  /// A callback for when a long press has been recognised by a secondary pointer.
+  ///
+  /// Analogous to [GestureDetector.onSecondaryLongPressStart]. Fires alongside [onSecondaryLongPress].
+  /// {@endtemplate}
+  final GestureLongPressStartCallback? onSecondaryLongPressStart;
+
+  /// {@template forui.foundation.FTappable.onSecondaryLongPressMove}
+  /// A callback for when a secondary pointer is moving after being recognised as a long press.
+  ///
+  /// Analogous to [GestureDetector.onSecondaryLongPressMoveUpdate].
+  /// {@endtemplate}
+  final GestureLongPressMoveUpdateCallback? onSecondaryLongPressMove;
+
+  /// {@template forui.foundation.FTappable.onSecondaryLongPressEnd}
+  /// A callback for when a long press recognised by a secondary pointer is ending.
+  ///
+  /// Analogous to [GestureDetector.onSecondaryLongPressEnd].
+  /// {@endtemplate}
+  final GestureLongPressEndCallback? onSecondaryLongPressEnd;
 
   /// {@template forui.foundation.FTappable.onSecondaryLongPress}
   /// A callback for when the widget is pressed with a secondary button (usually right-click on desktop).
   ///
-  /// The widget will be disabled if the following are null:
-  /// * [onPress]
-  /// * [onLongPress]
-  /// * [onDoubleTap]
-  /// * [onSecondaryPress]
-  /// * [onSecondaryLongPress]
+  /// The widget is disabled when every primary and secondary gesture callback (including all lifecycle variants) is
+  /// null.
   /// {@endtemplate}
   final VoidCallback? onSecondaryLongPress;
 
@@ -184,10 +305,29 @@ class FTappable extends StatefulWidget {
     FTappableVariantChangeCallback? onVariantChange,
     bool selected,
     HitTestBehavior behavior,
+    GestureTapDownCallback? onPressDown,
+    GestureTapCancelCallback? onPressCancel,
+    GestureTapMoveCallback? onPressMove,
+    GestureTapUpCallback? onPressUp,
     VoidCallback? onPress,
+    GestureLongPressDownCallback? onLongPressDown,
+    GestureLongPressCancelCallback? onLongPressCancel,
+    GestureLongPressStartCallback? onLongPressStart,
+    GestureLongPressMoveUpdateCallback? onLongPressMove,
+    GestureLongPressEndCallback? onLongPressEnd,
     VoidCallback? onLongPress,
+    GestureTapDownCallback? onDoubleTapDown,
+    GestureTapCancelCallback? onDoubleTapCancel,
     VoidCallback? onDoubleTap,
+    GestureTapDownCallback? onSecondaryPressDown,
+    GestureTapCancelCallback? onSecondaryPressCancel,
+    GestureTapUpCallback? onSecondaryPressUp,
     VoidCallback? onSecondaryPress,
+    GestureLongPressDownCallback? onSecondaryLongPressDown,
+    GestureLongPressCancelCallback? onSecondaryLongPressCancel,
+    GestureLongPressStartCallback? onSecondaryLongPressStart,
+    GestureLongPressMoveUpdateCallback? onSecondaryLongPressMove,
+    GestureLongPressEndCallback? onSecondaryLongPressEnd,
     VoidCallback? onSecondaryLongPress,
     Map<ShortcutActivator, Intent>? shortcuts,
     Map<Type, Action<Intent>>? actions,
@@ -212,10 +352,29 @@ class FTappable extends StatefulWidget {
     this.onVariantChange,
     this.selected = false,
     this.behavior = .translucent,
+    this.onPressDown,
+    this.onPressCancel,
+    this.onPressMove,
+    this.onPressUp,
     this.onPress,
+    this.onLongPressDown,
+    this.onLongPressCancel,
+    this.onLongPressStart,
+    this.onLongPressMove,
+    this.onLongPressEnd,
     this.onLongPress,
+    this.onDoubleTapDown,
+    this.onDoubleTapCancel,
     this.onDoubleTap,
+    this.onSecondaryPressDown,
+    this.onSecondaryPressCancel,
+    this.onSecondaryPressUp,
     this.onSecondaryPress,
+    this.onSecondaryLongPressDown,
+    this.onSecondaryLongPressCancel,
+    this.onSecondaryLongPressStart,
+    this.onSecondaryLongPressMove,
+    this.onSecondaryLongPressEnd,
     this.onSecondaryLongPress,
     this.actions,
     this.builder = defaultBuilder,
@@ -243,10 +402,29 @@ class FTappable extends StatefulWidget {
       ..add(ObjectFlagProperty.has('onVariantChange', onVariantChange))
       ..add(FlagProperty('selected', value: selected, ifTrue: 'selected'))
       ..add(EnumProperty('behavior', behavior))
+      ..add(ObjectFlagProperty.has('onPressDown', onPressDown))
+      ..add(ObjectFlagProperty.has('onPressCancel', onPressCancel))
+      ..add(ObjectFlagProperty.has('onPressMove', onPressMove))
+      ..add(ObjectFlagProperty.has('onPressUp', onPressUp))
       ..add(ObjectFlagProperty.has('onPress', onPress))
+      ..add(ObjectFlagProperty.has('onLongPressDown', onLongPressDown))
+      ..add(ObjectFlagProperty.has('onLongPressCancel', onLongPressCancel))
+      ..add(ObjectFlagProperty.has('onLongPressStart', onLongPressStart))
+      ..add(ObjectFlagProperty.has('onLongPressMove', onLongPressMove))
+      ..add(ObjectFlagProperty.has('onLongPressEnd', onLongPressEnd))
       ..add(ObjectFlagProperty.has('onLongPress', onLongPress))
+      ..add(ObjectFlagProperty.has('onDoubleTapDown', onDoubleTapDown))
+      ..add(ObjectFlagProperty.has('onDoubleTapCancel', onDoubleTapCancel))
       ..add(ObjectFlagProperty.has('onDoubleTap', onDoubleTap))
+      ..add(ObjectFlagProperty.has('onSecondaryPressDown', onSecondaryPressDown))
+      ..add(ObjectFlagProperty.has('onSecondaryPressCancel', onSecondaryPressCancel))
+      ..add(ObjectFlagProperty.has('onSecondaryPressUp', onSecondaryPressUp))
       ..add(ObjectFlagProperty.has('onSecondaryPress', onSecondaryPress))
+      ..add(ObjectFlagProperty.has('onSecondaryLongPressDown', onSecondaryLongPressDown))
+      ..add(ObjectFlagProperty.has('onSecondaryLongPressCancel', onSecondaryLongPressCancel))
+      ..add(ObjectFlagProperty.has('onSecondaryLongPressStart', onSecondaryLongPressStart))
+      ..add(ObjectFlagProperty.has('onSecondaryLongPressMove', onSecondaryLongPressMove))
+      ..add(ObjectFlagProperty.has('onSecondaryLongPressEnd', onSecondaryLongPressEnd))
       ..add(ObjectFlagProperty.has('onSecondaryLongPress', onSecondaryLongPress))
       ..add(DiagnosticsProperty('shortcuts', shortcuts))
       ..add(DiagnosticsProperty('actions', actions))
@@ -254,15 +432,38 @@ class FTappable extends StatefulWidget {
   }
 
   bool _animate(int buttons) =>
-      (buttons & kPrimaryButton != 0 && (onPress != null || onLongPress != null || onDoubleTap != null)) ||
-      (buttons & kSecondaryButton != 0 && (onSecondaryPress != null || onSecondaryLongPress != null));
+      (buttons & kPrimaryButton != 0 && _hasPrimaryCallback) ||
+      (buttons & kSecondaryButton != 0 && _hasSecondaryCallback);
 
-  bool get _disabled =>
-      onPress == null &&
-      onLongPress == null &&
-      onDoubleTap == null &&
-      onSecondaryPress == null &&
-      onSecondaryLongPress == null;
+  bool get _disabled => !_hasPrimaryCallback && !_hasSecondaryCallback;
+
+  bool get _hasPrimaryCallback =>
+      onPressDown != null ||
+      onPressCancel != null ||
+      onPressMove != null ||
+      onPressUp != null ||
+      onPress != null ||
+      onLongPressDown != null ||
+      onLongPressCancel != null ||
+      onLongPressStart != null ||
+      onLongPressMove != null ||
+      onLongPressEnd != null ||
+      onLongPress != null ||
+      onDoubleTapDown != null ||
+      onDoubleTapCancel != null ||
+      onDoubleTap != null;
+
+  bool get _hasSecondaryCallback =>
+      onSecondaryPressDown != null ||
+      onSecondaryPressCancel != null ||
+      onSecondaryPressUp != null ||
+      onSecondaryPress != null ||
+      onSecondaryLongPressDown != null ||
+      onSecondaryLongPressCancel != null ||
+      onSecondaryLongPressStart != null ||
+      onSecondaryLongPressMove != null ||
+      onSecondaryLongPressEnd != null ||
+      onSecondaryLongPress != null;
 }
 
 class _FTappableState<T extends FTappable> extends State<T> {
@@ -323,7 +524,16 @@ class _FTappableState<T extends FTappable> extends State<T> {
     // Update the existing registration if callbacks changed.
     if (_entry case final entry?) {
       entry
+        ..onPressDown = widget.onPressDown
+        ..onPressCancel = widget.onPressCancel
+        ..onPressMove = widget.onPressMove
+        ..onPressUp = widget.onPressUp
         ..onPress = widget.onPress
+        ..onLongPressDown = widget.onLongPressDown
+        ..onLongPressCancel = widget.onLongPressCancel
+        ..onLongPressStart = widget.onLongPressStart
+        ..onLongPressMove = widget.onLongPressMove
+        ..onLongPressEnd = widget.onLongPressEnd
         ..onLongPress = widget.onLongPress;
     }
   }
@@ -352,10 +562,19 @@ class _FTappableState<T extends FTappable> extends State<T> {
       entries.add(
         _entry = GroupEntry(
           context: context,
-          onPressStart: _start,
-          onPressCancel: _cancel,
-          onPressEnd: _end,
+          enter: _start,
+          exit: _cancel,
+          release: _end,
+          onPressDown: widget.onPressDown,
+          onPressCancel: widget.onPressCancel,
+          onPressMove: widget.onPressMove,
+          onPressUp: widget.onPressUp,
           onPress: widget.onPress,
+          onLongPressDown: widget.onLongPressDown,
+          onLongPressCancel: widget.onLongPressCancel,
+          onLongPressStart: widget.onLongPressStart,
+          onLongPressMove: widget.onLongPressMove,
+          onLongPressEnd: widget.onLongPressEnd,
           onLongPress: widget.onLongPress,
         ),
       );
@@ -444,10 +663,29 @@ class _FTappableState<T extends FTappable> extends State<T> {
                 onPointerUp: _entries == null ? (_) => _end() : null,
                 child: GestureDetector(
                   behavior: widget.behavior,
+                  onTapDown: _entries == null ? widget.onPressDown : null,
+                  onTapCancel: _entries == null ? widget.onPressCancel : null,
+                  onTapMove: _entries == null ? widget.onPressMove : null,
+                  onTapUp: _entries == null ? widget.onPressUp : null,
                   onTap: _entries == null ? widget.onPress : null,
+                  onLongPressDown: _entries == null ? widget.onLongPressDown : null,
+                  onLongPressCancel: _entries == null ? widget.onLongPressCancel : null,
+                  onLongPressStart: _entries == null ? widget.onLongPressStart : null,
+                  onLongPressMoveUpdate: _entries == null ? widget.onLongPressMove : null,
+                  onLongPressEnd: _entries == null ? widget.onLongPressEnd : null,
                   onLongPress: _entries == null ? widget.onLongPress : null,
+                  onDoubleTapDown: widget.onDoubleTapDown,
+                  onDoubleTapCancel: widget.onDoubleTapCancel,
                   onDoubleTap: widget.onDoubleTap,
+                  onSecondaryTapDown: widget.onSecondaryPressDown,
+                  onSecondaryTapCancel: widget.onSecondaryPressCancel,
+                  onSecondaryTapUp: widget.onSecondaryPressUp,
                   onSecondaryTap: widget.onSecondaryPress,
+                  onSecondaryLongPressDown: widget.onSecondaryLongPressDown,
+                  onSecondaryLongPressCancel: widget.onSecondaryLongPressCancel,
+                  onSecondaryLongPressStart: widget.onSecondaryLongPressStart,
+                  onSecondaryLongPressMoveUpdate: widget.onSecondaryLongPressMove,
+                  onSecondaryLongPressEnd: widget.onSecondaryLongPressEnd,
                   onSecondaryLongPress: widget.onSecondaryLongPress,
                   child: tappable,
                 ),
@@ -521,10 +759,29 @@ class AnimatedTappable extends FTappable {
     super.onVariantChange,
     super.selected,
     super.behavior,
+    super.onPressDown,
+    super.onPressCancel,
+    super.onPressMove,
+    super.onPressUp,
     super.onPress,
+    super.onLongPressDown,
+    super.onLongPressCancel,
+    super.onLongPressStart,
+    super.onLongPressMove,
+    super.onLongPressEnd,
     super.onLongPress,
+    super.onDoubleTapDown,
+    super.onDoubleTapCancel,
     super.onDoubleTap,
+    super.onSecondaryPressDown,
+    super.onSecondaryPressCancel,
+    super.onSecondaryPressUp,
     super.onSecondaryPress,
+    super.onSecondaryLongPressDown,
+    super.onSecondaryLongPressCancel,
+    super.onSecondaryLongPressStart,
+    super.onSecondaryLongPressMove,
+    super.onSecondaryLongPressEnd,
     super.onSecondaryLongPress,
     super.shortcuts,
     super.actions,

--- a/forui/lib/src/foundation/tappable/tappable_group.dart
+++ b/forui/lib/src/foundation/tappable/tappable_group.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 
 import 'package:forui/forui.dart';
@@ -12,6 +13,12 @@ import 'package:forui/src/foundation/tappable/tappable_group_recognizer.dart';
 ///
 /// Only primary press and long-press gestures are group-managed. Other gestures like [FTappable.onDoubleTap],
 /// [FTappable.onSecondaryPress], and [FTappable.onSecondaryLongPress] remain on individual tappables.
+///
+/// ## Long-press and slide-across
+///
+/// When [FTappable.onLongPress] fires on an entry, the gesture is *not* terminated — the pointer is still down and
+/// slide-across remains active. If the user long-presses entry A, slides to entry B, and releases on B, **both**
+/// `A.onLongPress` *and* `B.onPress` fire from the single continuous gesture.
 ///
 /// {@macro forui.foundation.doc_templates.overlay}
 class FTappableGroup extends StatefulWidget {
@@ -100,23 +107,48 @@ class TappableGroupScope extends InheritedWidget {
 @internal
 class GroupEntry {
   final BuildContext context;
-  final Future<void> Function(int) onPressStart;
-  final Future<void> Function() onPressCancel;
-  final Future<void> Function() onPressEnd;
+  final Future<void> Function(int) enter;
+  final Future<void> Function() exit;
+  final Future<void> Function() release;
+  GestureTapDownCallback? onPressDown;
+  GestureTapCancelCallback? onPressCancel;
+  GestureTapMoveCallback? onPressMove;
+  GestureTapUpCallback? onPressUp;
   VoidCallback? onPress;
+  /// [onLongPressDown] is always called together with [onPressDown] in [TappableGroupGestureRecognizer] but not the
+  /// stock [GestureDetector]. We keep this redundant field to simplify callback mapping.
+  GestureLongPressDownCallback? onLongPressDown;
+  GestureLongPressStartCallback? onLongPressStart;
+  GestureLongPressCancelCallback? onLongPressCancel;
+  GestureLongPressMoveUpdateCallback? onLongPressMove;
+  GestureLongPressEndCallback? onLongPressEnd;
   VoidCallback? onLongPress;
 
   GroupEntry({
     required this.context,
-    required this.onPressStart,
-    required this.onPressCancel,
-    required this.onPressEnd,
+    required this.enter,
+    required this.exit,
+    required this.release,
     required this.onPress,
     required this.onLongPress,
+    this.onPressDown,
+    this.onPressCancel,
+    this.onPressMove,
+    this.onPressUp,
+    this.onLongPressDown,
+    this.onLongPressCancel,
+    this.onLongPressStart,
+    this.onLongPressMove,
+    this.onLongPressEnd,
   });
 
   bool hitTest(Offset globalPosition) {
     final box = context.findRenderObject();
     return box is RenderBox && box.size.contains(box.globalToLocal(globalPosition));
+  }
+
+  Offset localPosition(Offset globalPosition) {
+    final box = context.findRenderObject();
+    return box is RenderBox ? box.globalToLocal(globalPosition) : globalPosition;
   }
 }

--- a/forui/lib/src/foundation/tappable/tappable_group.dart
+++ b/forui/lib/src/foundation/tappable/tappable_group.dart
@@ -115,6 +115,7 @@ class GroupEntry {
   GestureTapMoveCallback? onPressMove;
   GestureTapUpCallback? onPressUp;
   VoidCallback? onPress;
+
   /// [onLongPressDown] is always called together with [onPressDown] in [TappableGroupGestureRecognizer] but not the
   /// stock [GestureDetector]. We keep this redundant field to simplify callback mapping.
   GestureLongPressDownCallback? onLongPressDown;

--- a/forui/lib/src/foundation/tappable/tappable_group_recognizer.dart
+++ b/forui/lib/src/foundation/tappable/tappable_group_recognizer.dart
@@ -56,10 +56,13 @@ class TappableGroupGestureRecognizer extends OneSequenceGestureRecognizer {
   GroupEntry? _current;
   Timer? _longPressTimer;
   bool _accepted = false;
+  Offset _origin = .zero;
+  Offset _lastPosition = .zero;
 
-  /// Stored callback to fire after winning the arena. Only set for same-child taps (pressing → idle) where we defer to
-  /// the arena sweep — this lets scroll recognizers win the sweep when competing.
-  VoidCallback? _pendingOnPress;
+  /// The entry whose tap is awaiting arena resolution, paired with the [TapUpDetails] captured at PointerUp. Only set
+  /// for same-child taps (pressing → idle) where we defer to the arena sweep — this lets scroll recognizers win the
+  /// sweep when competing. [acceptGesture] fires `onPressUp` + `onPress`; [rejectGesture] fires `onPressCancel`.
+  (GroupEntry, TapUpDetails)? _pending;
 
   TappableGroupGestureRecognizer(this.entries, this.slidePressHapticFeedback) : _state = .idle;
 
@@ -72,62 +75,127 @@ class TappableGroupGestureRecognizer extends OneSequenceGestureRecognizer {
   @protected
   void handleEvent(PointerEvent event) {
     switch (event) {
-      case PointerDownEvent(:final buttons, :final position):
+      case PointerDownEvent(:final buttons, :final position, :final kind):
         assert(
           _state == .idle,
           '_state ($_state) must be idle. '
           'This is likely a bug in Forui. Please file a bug report: https://github.com/duobaseio/forui/issues/new?template=bug_report.md',
         );
 
+        // Pressed down on an entry.
         if (entries.firstWhereOrNull((e) => e.hitTest(position)) case final entry?) {
           _state = .pressing;
           _current = entry;
-          _current!.onPressStart(buttons);
-          _start();
+          _origin = position;
+          _lastPosition = position;
+          _start(entry, buttons, position, kind);
         }
 
-      case PointerMoveEvent(:final buttons, :final position):
-        if (_current?.hitTest(position) ?? false) {
-          // Internal movements.
+      case PointerMoveEvent(:final buttons, :final position, :final kind, :final delta):
+        _lastPosition = position;
+
+        // Internal movement over the current entry.
+        if (_current case final current? when current.hitTest(position)) {
+          if (_state == .longPressing) {
+            current.onLongPressMove?.call(
+              LongPressMoveUpdateDetails(
+                globalPosition: position,
+                localPosition: current.localPosition(position),
+                offsetFromOrigin: position - _origin,
+                localOffsetFromOrigin: current.localPosition(position) - current.localPosition(_origin),
+              ),
+            );
+          } else {
+            current.onPressMove?.call(
+              TapMoveDetails(
+                globalPosition: position,
+                localPosition: current.localPosition(position),
+                kind: kind,
+                delta: delta,
+              ),
+            );
+          }
+
           return;
         }
 
-        _state = .sliding;
-        _current?.onPressCancel();
+        // Moved out of the current.
+        if (_current case final current?) {
+          current.exit();
+          if (_state == .longPressing) {
+            current.onLongPressEnd?.call(
+              LongPressEndDetails(globalPosition: position, localPosition: current.localPosition(position)),
+            );
+          } else {
+            current.onPressCancel?.call();
+            current.onLongPressCancel?.call();
+          }
+        }
         _current = null;
+        _state = .sliding;
         _cancel();
 
+        // Moved into another entry.
         if (entries.firstWhereOrNull((e) => e.hitTest(position)) case final entry?) {
           _state = .slidePressing;
           unawaited(slidePressHapticFeedback());
           _current = entry;
-          _current!.onPressStart(buttons);
-          _start();
+          _origin = position;
+          _start(entry, buttons, position, kind);
         }
 
-      case PointerUpEvent(:final pointer):
+      case PointerUpEvent(:final pointer, :final position, :final kind):
+        _lastPosition = position;
+
         switch (_state) {
           // It is possible that the gesture is accepted before [PointerUpEvent] is called.
           case .slidePressing || .pressing when _accepted:
-            _current?.onPressEnd();
-            _current?.onPress?.call();
+            if (_current case final current?) {
+              current.release();
+              current.onPressUp?.call(
+                TapUpDetails(globalPosition: position, localPosition: current.localPosition(position), kind: kind),
+              );
+              current.onPress?.call();
+              current.onLongPressCancel?.call();
+            }
 
+          // Tap not yet accepted. Defer so scroll recognizers can still win the sweep.
           case .slidePressing || .pressing:
-            _current?.onPressEnd();
-            _pendingOnPress = _current?.onPress;
+            if (_current case final current?) {
+              current.release();
+              _pending = (
+                current,
+                TapUpDetails(globalPosition: position, localPosition: current.localPosition(position), kind: kind),
+              );
+              // onLongPressCancel doesn't depend on arena; fire immediately.
+              current.onLongPressCancel?.call();
+            }
 
-          // These two cases provide consistency with .slidePressing triggering onPress even if the tappable which was
-          // slided to has been held for a long time.
-          case .longPressing when _current?.onLongPress == null && _accepted:
-            _current?.onPressEnd();
-            _current?.onPress?.call();
-
+          // Long-press recognized but current has no onLongPress. Fire onPress as the documented
+          // slide-across-after-long-press fallback, alongside the long-press end callbacks.
+          //
+          // No deferral: long-press already won the arena via the timer's resolve(.accepted) so scroll can't take this
+          // anymore.
           case .longPressing when _current?.onLongPress == null:
-            _current?.onPressEnd();
-            _pendingOnPress = _current?.onPress;
+            if (_current case final current?) {
+              current.release();
+              current.onPressUp?.call(
+                TapUpDetails(globalPosition: position, localPosition: current.localPosition(position), kind: kind),
+              );
+              current.onPress?.call();
+              current.onLongPressEnd?.call(
+                LongPressEndDetails(globalPosition: position, localPosition: current.localPosition(position)),
+              );
+            }
 
+          // Long-press completed normally — fire end, no tap callbacks.
           case .longPressing:
-            _current?.onPressEnd();
+            if (_current case final current?) {
+              current.release();
+              current.onLongPressEnd?.call(
+                LongPressEndDetails(globalPosition: position, localPosition: current.localPosition(position)),
+              );
+            }
 
           default:
         }
@@ -139,28 +207,79 @@ class TappableGroupGestureRecognizer extends OneSequenceGestureRecognizer {
         stopTrackingPointer(pointer);
 
       case PointerCancelEvent():
-        _state = .idle;
-        _current?.onPressCancel();
+        if (_current case final current?) {
+          current.exit();
+          // Both press and long press started, so we need to cancel both. We do not need to cancel anything when long
+          // pressed as the timer already cancels presses.
+          if (_state != .longPressing) {
+            current.onPressCancel?.call();
+            current.onLongPressCancel?.call();
+          }
+        }
         _current = null;
+        _state = .idle;
         _cancel();
         resolve(.rejected);
     }
   }
 
+  /// Begins a press on [entry]: fires the internal `onPressStart` hook, the user-facing `onPressDown` and
+  /// `onLongPressDown` callbacks, and arms the long-press timer.
+  void _start(GroupEntry entry, int buttons, Offset position, PointerDeviceKind kind) {
+    entry.enter(buttons);
+
+    final localPosition = entry.localPosition(position);
+    entry.onPressDown?.call(TapDownDetails(globalPosition: position, localPosition: localPosition, kind: kind));
+    entry.onLongPressDown?.call(
+      LongPressDownDetails(globalPosition: position, localPosition: localPosition, kind: kind),
+    );
+
+    _longPressTimer = Timer(kLongPressTimeout, () {
+      if (_current == entry && (_state == .pressing || _state == .slidePressing)) {
+        _state = .longPressing;
+        // Match Flutter's LongPressGestureRecognizer ordering: onLongPressStart fires before onLongPress, and
+        // onTapCancel fires when the tap is rejected by long-press winning the arena.
+        entry.onLongPressStart?.call(
+          LongPressStartDetails(globalPosition: _lastPosition, localPosition: entry.localPosition(_lastPosition)),
+        );
+        entry.onLongPress?.call();
+        entry.onPressCancel?.call();
+        resolve(.accepted);
+      }
+    });
+  }
+
   @override
   void acceptGesture(int pointer) {
     _accepted = true;
-    _pendingOnPress?.call();
-    _pendingOnPress = null;
+    if (_pending case (final entry, final details)?) {
+      entry.onPressUp?.call(details);
+      entry.onPress?.call();
+    }
+    _pending = null;
   }
 
   @override
   void rejectGesture(int pointer) {
+    if (_current case final current?) {
+      current.exit();
+      // Both press and long press started, so we need to cancel both. We do not need to cancel anything when long
+      // pressed as the timer already cancels presses.
+      if (_state != .longPressing) {
+        current.onPressCancel?.call();
+        current.onLongPressCancel?.call();
+      }
+    }
+
+    // Pending tap (PointerUp already arrived, awaiting arena) is now rejected — fire its cancel.
+    if (_pending case (final entry, _)?) {
+      entry.onPressCancel?.call();
+    }
+
+    _current = null;
+    _pending = null;
     _state = .idle;
     _accepted = false;
-    _pendingOnPress = null;
-    _current?.onPressCancel();
-    _current = null;
     _cancel();
     stopTrackingPointer(pointer);
   }
@@ -173,17 +292,6 @@ class TappableGroupGestureRecognizer extends OneSequenceGestureRecognizer {
   void dispose() {
     _cancel();
     super.dispose();
-  }
-
-  void _start() {
-    final current = _current;
-    _longPressTimer = Timer(kLongPressTimeout, () {
-      if (_current == current && (_state == .pressing || _state == .slidePressing)) {
-        _state = .longPressing;
-        _current?.onLongPress?.call(); // We immediately call this to mirror [LongPressGestureRecognizer]'s behaviour.
-        resolve(.accepted);
-      }
-    });
   }
 
   void _cancel() {

--- a/forui/test/src/foundation/tappable/tappable_test.dart
+++ b/forui/test/src/foundation/tappable/tappable_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -25,6 +26,47 @@ class _StubTappableState extends AnimatedTappableState {
     Future.delayed(const Duration(seconds: 1)).then((_) => super.onPressEnd());
   }
 }
+
+FTappable _tappable(
+  List<String> calls, {
+  Key? key,
+  bool press = true,
+  bool longPress = true,
+  bool doubleTap = false,
+  bool secondary = false,
+  bool autofocus = false,
+  FocusNode? focusNode,
+  bool static = false,
+}) => (static ? FTappable.static : FTappable.new)(
+  key: key,
+  autofocus: autofocus,
+  focusNode: focusNode,
+  builder: (_, states, _) => Text('$states'),
+  onPressDown: press ? (_) => calls.add('onPressDown') : null,
+  onPressCancel: press ? () => calls.add('onPressCancel') : null,
+  onPressMove: press ? (_) => calls.add('onPressMove') : null,
+  onPressUp: press ? (_) => calls.add('onPressUp') : null,
+  onPress: press ? () => calls.add('onPress') : null,
+  onLongPressDown: longPress ? (_) => calls.add('onLongPressDown') : null,
+  onLongPressCancel: longPress ? () => calls.add('onLongPressCancel') : null,
+  onLongPressStart: longPress ? (_) => calls.add('onLongPressStart') : null,
+  onLongPressMove: longPress ? (_) => calls.add('onLongPressMove') : null,
+  onLongPressEnd: longPress ? (_) => calls.add('onLongPressEnd') : null,
+  onLongPress: longPress ? () => calls.add('onLongPress') : null,
+  onDoubleTapDown: doubleTap ? (_) => calls.add('onDoubleTapDown') : null,
+  onDoubleTapCancel: doubleTap ? () => calls.add('onDoubleTapCancel') : null,
+  onDoubleTap: doubleTap ? () => calls.add('onDoubleTap') : null,
+  onSecondaryPressDown: secondary ? (_) => calls.add('onSecondaryPressDown') : null,
+  onSecondaryPressCancel: secondary ? () => calls.add('onSecondaryPressCancel') : null,
+  onSecondaryPressUp: secondary ? (_) => calls.add('onSecondaryPressUp') : null,
+  onSecondaryPress: secondary ? () => calls.add('onSecondaryPress') : null,
+  onSecondaryLongPressDown: secondary ? (_) => calls.add('onSecondaryLongPressDown') : null,
+  onSecondaryLongPressCancel: secondary ? () => calls.add('onSecondaryLongPressCancel') : null,
+  onSecondaryLongPressStart: secondary ? (_) => calls.add('onSecondaryLongPressStart') : null,
+  onSecondaryLongPressMove: secondary ? (_) => calls.add('onSecondaryLongPressMove') : null,
+  onSecondaryLongPressEnd: secondary ? (_) => calls.add('onSecondaryLongPressEnd') : null,
+  onSecondaryLongPress: secondary ? () => calls.add('onSecondaryLongPress') : null,
+);
 
 void main() {
   late FocusNode focusNode;
@@ -86,119 +128,66 @@ void main() {
 
         expect(find.text(set(enabled).toString()), findsOneWidget);
       });
-
-      testWidgets('press', (tester) async {
-        var pressCount = 0;
-        var longPressCount = 0;
-
-        await tester.pumpWidget(
-          TestScaffold(
-            child: FTappable(
-              builder: (_, states, _) => Text('$states'),
-              onPress: enabled ? () => pressCount++ : null,
-              onLongPress: enabled ? () => longPressCount++ : null,
-            ),
-          ),
-        );
-
-        await tester.tap(find.byType(AnimatedTappable));
-        await tester.pumpAndSettle(const Duration(milliseconds: 200));
-
-        expect(pressCount, enabled ? 1 : 0);
-        expect(longPressCount, 0);
-      });
-
-      testWidgets('long press - $enabled', (tester) async {
-        var pressCount = 0;
-        var longPressCount = 0;
-        await tester.pumpWidget(
-          TestScaffold(
-            child: FTappable(
-              builder: (_, states, _) => Text('$states'),
-              onPress: enabled ? () => pressCount++ : null,
-              onLongPress: enabled ? () => longPressCount++ : null,
-            ),
-          ),
-        );
-        expect(find.text(set(enabled).toString()), findsOneWidget);
-
-        await tester.longPress(find.byType(AnimatedTappable));
-        expect(find.text({...set(enabled), FTappableVariant.pressed}.toString()), findsOneWidget);
-
-        await tester.pumpAndSettle();
-        expect(find.text(set(enabled).toString()), findsOneWidget);
-
-        expect(pressCount, 0);
-        expect(longPressCount, enabled ? 1 : 0);
-      });
-
-      testWidgets('press and hold - $enabled', (tester) async {
-        final key = GlobalKey<AnimatedTappableState>();
-
-        await tester.pumpWidget(
-          TestScaffold(
-            child: FTappable(key: key, builder: (_, states, _) => Text('$states'), onPress: enabled ? () {} : null),
-          ),
-        );
-        expect(find.text(set(enabled).toString()), findsOneWidget);
-        expect(key.currentState?.bounce.value, 1);
-
-        final gesture = await tester.press(find.byType(AnimatedTappable));
-        await tester.pumpAndSettle(const Duration(milliseconds: 200));
-        expect(find.text({...set(enabled), FTappableVariant.pressed}.toString()), findsOneWidget);
-        expect(key.currentState?.bounce.value, enabled ? 0.97 : 1.0);
-
-        await gesture.up();
-        await tester.pumpAndSettle();
-        expect(find.text(set(enabled).toString()), findsOneWidget);
-        expect(key.currentState?.bounce.value, 1);
-      });
-
-      testWidgets('press, hold & move outside - $enabled', (tester) async {
-        final key = GlobalKey<AnimatedTappableState>();
-
-        await tester.pumpWidget(
-          TestScaffold(
-            child: FTappable(key: key, builder: (_, states, _) => Text('$states'), onPress: enabled ? () {} : null),
-          ),
-        );
-        expect(find.text(set(enabled).toString()), findsOneWidget);
-        expect(key.currentState?.bounce.value, 1);
-
-        final gesture = await tester.press(find.byType(AnimatedTappable));
-        await tester.pumpAndSettle(const Duration(milliseconds: 200));
-        expect(find.text({...set(enabled), FTappableVariant.pressed}.toString()), findsOneWidget);
-        expect(key.currentState?.bounce.value, enabled ? 0.97 : 1.0);
-
-        await gesture.moveTo(.zero);
-        await tester.pumpAndSettle(const Duration(milliseconds: 200));
-
-        expect(find.text({...set(enabled)}.toString()), findsOneWidget);
-        expect(key.currentState?.bounce.value, 1.0);
-      });
-
-      testWidgets('shortcut', (tester) async {
-        var pressCount = 0;
-        var longPressCount = 0;
-
-        await tester.pumpWidget(
-          TestScaffold(
-            child: FTappable(
-              autofocus: true,
-              builder: (_, states, _) => Text('$states'),
-              onPress: enabled ? () => pressCount++ : null,
-              onLongPress: enabled ? () => longPressCount++ : null,
-            ),
-          ),
-        );
-
-        await tester.sendKeyEvent(.enter);
-        await tester.pumpAndSettle();
-
-        expect(pressCount, enabled ? 1 : 0);
-        expect(longPressCount, 0);
-      });
     }
+
+    testWidgets('tap fires full lifecycle', (tester) async {
+      final calls = <String>[];
+      await tester.pumpWidget(TestScaffold(child: _tappable(calls)));
+
+      await tester.tap(find.byType(AnimatedTappable));
+      await tester.pumpAndSettle();
+
+      expect(calls, contains('onPressDown'));
+      expect(calls, contains('onLongPressDown'));
+      expect(calls, contains('onLongPressCancel'));
+      expect(calls, containsAllInOrder(['onPressDown', 'onPressUp', 'onPress']));
+      expect(calls, isNot(contains('onLongPress')));
+      expect(calls, isNot(contains('onLongPressStart')));
+    });
+
+    testWidgets('long-press fires full lifecycle', (tester) async {
+      final calls = <String>[];
+      final key = GlobalKey<AnimatedTappableState>();
+      await tester.pumpWidget(TestScaffold(child: _tappable(calls, key: key)));
+
+      final gesture = await tester.press(find.byType(AnimatedTappable));
+      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+      expect(key.currentState?.bounce.value, 0.97);
+
+      await tester.pump(kLongPressTimeout);
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(key.currentState?.bounce.value, 1);
+
+      expect(calls, contains('onPressDown'));
+      expect(calls, contains('onLongPressDown'));
+      expect(calls, contains('onPressCancel'));
+      expect(calls, isNot(contains('onPress')));
+      expect(calls, isNot(contains('onPressUp')));
+      expect(calls, isNot(contains('onLongPressCancel')));
+    });
+
+    testWidgets('shortcut activates onPress without firing the gesture lifecycle', (tester) async {
+      final calls = <String>[];
+      await tester.pumpWidget(TestScaffold(child: _tappable(calls, autofocus: true)));
+
+      await tester.sendKeyEvent(.enter);
+      await tester.pumpAndSettle();
+
+      expect(calls, ['onPress']);
+    });
+
+    testWidgets('disabled tappable fires no lifecycle callbacks', (tester) async {
+      final calls = <String>[];
+      await tester.pumpWidget(
+        TestScaffold(child: _tappable(calls, press: false, longPress: false, focusNode: focusNode)),
+      );
+
+      await tester.tap(find.byType(AnimatedTappable));
+      await tester.pumpAndSettle();
+
+      expect(calls, isEmpty);
+    });
 
     testWidgets('disabled when no press callbacks given', (tester) async {
       await tester.pumpWidget(
@@ -418,108 +407,44 @@ void main() {
 
         expect(find.text(set(enabled).toString()), findsOneWidget);
       });
-
-      testWidgets('press', (tester) async {
-        var pressCount = 0;
-        var longPressCount = 0;
-
-        await tester.pumpWidget(
-          TestScaffold(
-            child: FTappable.static(
-              builder: (_, value, _) => Text('$value'),
-              onPress: enabled ? () => pressCount++ : null,
-              onLongPress: enabled ? () => longPressCount++ : null,
-            ),
-          ),
-        );
-
-        await tester.tap(find.byType(FTappable));
-        await tester.pumpAndSettle(const Duration(milliseconds: 200));
-
-        expect(pressCount, enabled ? 1 : 0);
-        expect(longPressCount, 0);
-      });
-
-      testWidgets('long press', (tester) async {
-        var pressCount = 0;
-        var longPressCount = 0;
-        await tester.pumpWidget(
-          TestScaffold(
-            child: FTappable.static(
-              builder: (_, states, _) => Text('$states'),
-              onPress: enabled ? () => pressCount++ : null,
-              onLongPress: enabled ? () => longPressCount++ : null,
-            ),
-          ),
-        );
-        expect(find.text(set(enabled).toString()), findsOneWidget);
-
-        await tester.longPress(find.byType(FTappable));
-        expect(find.text({...set(enabled), FTappableVariant.pressed}.toString()), findsOneWidget);
-
-        await tester.pumpAndSettle();
-        expect(find.text(set(enabled).toString()), findsOneWidget);
-
-        expect(pressCount, 0);
-        expect(longPressCount, enabled ? 1 : 0);
-      });
-
-      testWidgets('press and hold - $enabled', (tester) async {
-        await tester.pumpWidget(
-          TestScaffold(
-            child: FTappable.static(builder: (_, states, _) => Text('$states'), onPress: enabled ? () {} : null),
-          ),
-        );
-        expect(find.text(set(enabled).toString()), findsOneWidget);
-
-        final gesture = await tester.press(find.byType(FTappable));
-        await tester.pumpAndSettle(const Duration(milliseconds: 200));
-        expect(find.text({...set(enabled), FTappableVariant.pressed}.toString()), findsOneWidget);
-
-        await gesture.up();
-        await tester.pumpAndSettle();
-        expect(find.text(set(enabled).toString()), findsOneWidget);
-      });
-
-      testWidgets('press, hold & move outside - $enabled', (tester) async {
-        await tester.pumpWidget(
-          TestScaffold(
-            child: FTappable.static(builder: (_, states, _) => Text('$states'), onPress: enabled ? () {} : null),
-          ),
-        );
-        expect(find.text(set(enabled).toString()), findsOneWidget);
-
-        final gesture = await tester.press(find.byType(FTappable));
-        await tester.pumpAndSettle(const Duration(milliseconds: 200));
-        expect(find.text({...set(enabled), FTappableVariant.pressed}.toString()), findsOneWidget);
-
-        await gesture.moveTo(.zero);
-        await tester.pumpAndSettle();
-        expect(find.text(set(enabled).toString()), findsOneWidget);
-      });
-
-      testWidgets('shortcut', (tester) async {
-        var pressCount = 0;
-        var longPressCount = 0;
-
-        await tester.pumpWidget(
-          TestScaffold(
-            child: FTappable.static(
-              autofocus: true,
-              builder: (_, value, _) => Text('$value'),
-              onPress: enabled ? () => pressCount++ : null,
-              onLongPress: enabled ? () => longPressCount++ : null,
-            ),
-          ),
-        );
-
-        await tester.sendKeyEvent(.enter);
-        await tester.pumpAndSettle();
-
-        expect(pressCount, enabled ? 1 : 0);
-        expect(longPressCount, 0);
-      });
     }
+
+    testWidgets('tap fires full lifecycle', (tester) async {
+      final calls = <String>[];
+      await tester.pumpWidget(TestScaffold(child: _tappable(calls, static: true)));
+
+      await tester.tap(find.byType(FTappable));
+      await tester.pumpAndSettle();
+
+      expect(calls, contains('onPressDown'));
+      expect(calls, contains('onLongPressDown'));
+      expect(calls, contains('onLongPressCancel'));
+      expect(calls, containsAllInOrder(['onPressDown', 'onPressUp', 'onPress']));
+      expect(calls, isNot(contains('onLongPress')));
+    });
+
+    testWidgets('long-press fires full lifecycle', (tester) async {
+      final calls = <String>[];
+      await tester.pumpWidget(TestScaffold(child: _tappable(calls, static: true)));
+
+      await tester.longPress(find.byType(FTappable));
+      await tester.pumpAndSettle();
+
+      expect(calls, contains('onPressDown'));
+      expect(calls, contains('onLongPressDown'));
+      expect(calls, contains('onPressCancel'));
+      expect(calls, isNot(contains('onPress')));
+    });
+
+    testWidgets('shortcut activates onPress without firing the gesture lifecycle', (tester) async {
+      final calls = <String>[];
+      await tester.pumpWidget(TestScaffold(child: _tappable(calls, static: true, autofocus: true)));
+
+      await tester.sendKeyEvent(.enter);
+      await tester.pumpAndSettle();
+
+      expect(calls, ['onPress']);
+    });
 
     testWidgets('disabled when no press callbacks given', (tester) async {
       await tester.pumpWidget(
@@ -665,6 +590,196 @@ void main() {
       expect(previous, contains(FTappableVariant.hovered));
       expect(current, isNot(contains(FTappableVariant.hovered)));
       expect(hovered, false);
+    });
+  });
+
+  group('in FTappableGroup', () {
+    Widget tappables(List<String> calls) => TestScaffold(
+      child: FTappableGroup(
+        child: Row(
+          children: [
+            FTappable(
+              builder: (_, _, _) => const SizedBox(width: 50, height: 50, child: Text('A')),
+              onPress: () => calls.add('A.onPress'),
+              onPressDown: (_) => calls.add('A.onPressDown'),
+              onPressMove: (_) => calls.add('A.onPressMove'),
+              onPressUp: (_) => calls.add('A.onPressUp'),
+              onPressCancel: () => calls.add('A.onPressCancel'),
+              onLongPress: () => calls.add('A.onLongPress'),
+              onLongPressDown: (_) => calls.add('A.onLongPressDown'),
+              onLongPressCancel: () => calls.add('A.onLongPressCancel'),
+              onLongPressStart: (_) => calls.add('A.onLongPressStart'),
+              onLongPressMove: (_) => calls.add('A.onLongPressMove'),
+              onLongPressEnd: (_) => calls.add('A.onLongPressEnd'),
+            ),
+            FTappable(
+              builder: (_, _, _) => const SizedBox(width: 50, height: 50, child: Text('B')),
+              onPress: () => calls.add('B.onPress'),
+              onPressDown: (_) => calls.add('B.onPressDown'),
+              onPressMove: (_) => calls.add('B.onPressMove'),
+              onPressUp: (_) => calls.add('B.onPressUp'),
+              onPressCancel: () => calls.add('B.onPressCancel'),
+              onLongPress: () => calls.add('B.onLongPress'),
+              onLongPressDown: (_) => calls.add('B.onLongPressDown'),
+              onLongPressCancel: () => calls.add('B.onLongPressCancel'),
+              onLongPressStart: (_) => calls.add('B.onLongPressStart'),
+              onLongPressMove: (_) => calls.add('B.onLongPressMove'),
+              onLongPressEnd: (_) => calls.add('B.onLongPressEnd'),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    testWidgets('tap fires full lifecycle in exact order', (tester) async {
+      final calls = <String>[];
+      await tester.pumpWidget(tappables(calls));
+
+      await tester.tap(find.text('A'));
+      await tester.pumpAndSettle();
+
+      expect(calls, ['A.onPressDown', 'A.onLongPressDown', 'A.onPressUp', 'A.onPress', 'A.onLongPressCancel']);
+    });
+
+    testWidgets('long-press fires full lifecycle in exact order', (tester) async {
+      final calls = <String>[];
+      await tester.pumpWidget(tappables(calls));
+
+      await tester.longPress(find.text('A'));
+      await tester.pumpAndSettle();
+
+      expect(calls, [
+        'A.onPressDown',
+        'A.onLongPressDown',
+        'A.onLongPressStart',
+        'A.onLongPress',
+        'A.onPressCancel',
+        'A.onLongPressEnd',
+      ]);
+    });
+
+    testWidgets('wiggle within A fires onPressMove without re-firing onPressDown', (tester) async {
+      final calls = <String>[];
+      await tester.pumpWidget(tappables(calls));
+
+      final aCenter = tester.getCenter(find.text('A'));
+      final gesture = await tester.startGesture(aCenter);
+      await tester.pump();
+      // Wiggle inside A's bounds (entries are 50x50 — these offsets stay within).
+      await gesture.moveTo(aCenter + const Offset(5, 0));
+      await tester.pump();
+      await gesture.moveTo(aCenter + const Offset(-5, 5));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      // Down fires exactly once (no cancel/re-down cycle on every move).
+      expect(calls.where((c) => c == 'A.onPressDown').length, 1);
+      expect(calls.where((c) => c == 'A.onLongPressDown').length, 1);
+      // Move callbacks fire for each move within the entry.
+      expect(calls.where((c) => c == 'A.onPressMove').length, greaterThanOrEqualTo(2));
+      // onPressCancel does NOT fire — tap completed normally.
+      expect(calls, isNot(contains('A.onPressCancel')));
+      // Completes with onPressUp + onPress + onLongPressCancel (long-press lost the arena).
+      expect(calls, containsAllInOrder(['A.onPressUp', 'A.onPress', 'A.onLongPressCancel']));
+    });
+
+    testWidgets('slide A to B and release fires both lifecycles', (tester) async {
+      final calls = <String>[];
+      await tester.pumpWidget(tappables(calls));
+
+      final gesture = await tester.startGesture(tester.getCenter(find.text('A')));
+      await tester.pump();
+      await gesture.moveTo(tester.getCenter(find.text('B')));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(calls.first, 'A.onPressDown');
+      expect(
+        calls,
+        containsAllInOrder(['A.onPressDown', 'A.onLongPressDown', 'A.onPressCancel', 'A.onLongPressCancel']),
+      );
+      expect(
+        calls,
+        containsAllInOrder(['B.onPressDown', 'B.onLongPressDown', 'B.onPressUp', 'B.onPress', 'B.onLongPressCancel']),
+      );
+      expect(calls, isNot(contains('A.onPress')));
+      expect(calls, isNot(contains('A.onPressUp')));
+    });
+
+    testWidgets('long-press A then slide to B and release fires both lifecycles', (tester) async {
+      final calls = <String>[];
+      await tester.pumpWidget(tappables(calls));
+
+      final gesture = await tester.startGesture(tester.getCenter(find.text('A')));
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+      await gesture.moveTo(tester.getCenter(find.text('B')));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(
+        calls,
+        containsAllInOrder([
+          'A.onPressDown',
+          'A.onLongPressDown',
+          'A.onLongPressStart',
+          'A.onLongPress',
+          'A.onPressCancel',
+          'A.onLongPressEnd',
+        ]),
+      );
+      expect(
+        calls,
+        containsAllInOrder(['B.onPressDown', 'B.onLongPressDown', 'B.onPressUp', 'B.onPress', 'B.onLongPressCancel']),
+      );
+      // The documented both-fire: A.onLongPress AND B.onPress.
+      expect(calls, contains('A.onLongPress'));
+      expect(calls, contains('B.onPress'));
+    });
+
+    testWidgets('slide off into empty space fires cancels only', (tester) async {
+      final calls = <String>[];
+      await tester.pumpWidget(tappables(calls));
+
+      final gesture = await tester.startGesture(tester.getCenter(find.text('A')));
+      await tester.pump();
+      await gesture.moveTo(.zero);
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(calls, ['A.onPressDown', 'A.onLongPressDown', 'A.onPressCancel', 'A.onLongPressCancel']);
+    });
+
+    testWidgets('slide A → B → A and release fires fresh A lifecycle', (tester) async {
+      final calls = <String>[];
+      await tester.pumpWidget(tappables(calls));
+
+      final gesture = await tester.startGesture(tester.getCenter(find.text('A')));
+      await tester.pump();
+      await gesture.moveTo(tester.getCenter(find.text('B')));
+      await tester.pump();
+      await gesture.moveTo(tester.getCenter(find.text('A')));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      // A appears twice — once cancelled, once completed.
+      final aDowns = calls.where((c) => c == 'A.onPressDown').length;
+      expect(aDowns, 2);
+      expect(
+        calls,
+        containsAllInOrder([
+          'A.onPressDown',
+          'A.onPressCancel',
+          'B.onPressDown',
+          'B.onPressCancel',
+          'A.onPressDown',
+          'A.onPress',
+        ]),
+      );
     });
   });
 


### PR DESCRIPTION
**Describe the changes**
Expose granular gesture callbacks on `FTappable`/`FTappable.static` and `FTappableGroup`, in addition to the existing `onPress`/`onLongPress`/`onDoubleTap`/`onSecondaryPress`/`onSecondaryLongPress`:

- Primary tap: `onPressDown`, `onPressCancel`, `onPressMove`, `onPressUp`.
- Long press: `onLongPressDown`, `onLongPressCancel`, `onLongPressStart`, `onLongPressMove`, `onLongPressEnd`.
- Double tap: `onDoubleTapDown`, `onDoubleTapCancel`.
- Secondary tap: `onSecondaryPressDown`, `onSecondaryPressCancel`, `onSecondaryPressUp`.
- Secondary long press: `onSecondaryLongPressDown`, `onSecondaryLongPressCancel`, `onSecondaryLongPressStart`, `onSecondaryLongPressMove`, `onSecondaryLongPressEnd`.

Also updates `FTappableGroupRecognizer` to forward the new events, refreshes the tappable tests, and adds the new parameters to the `docs_snippets` usage files.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [x] I have included the relevant samples.
- [x] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)