### PR TITLE
Fix `FAutocomplete` focus traversal and `onChange` propagation

### DIFF
--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -21,6 +21,9 @@
 
 * Fix `FAutocomplete` not showing context menu by default.
 * Fix `FAutocomplete` not notifying control's `onChange` callback when a suggestion is selected via tap or tab completion.
+* Fix `FAutocomplete` committing the first suggestion when `TextInputAction.next` or Tab is pressed while the popover
+  is open and no inline typeahead completion is available.
+* Fix `FAutocomplete` popover staying open after Tab moves focus to another form field.
 
 ### `FAvatar`
 * **Breaking** Add `FAvatarStyle.fallbackIcon`. Defaults to `FIcons.userRound`.

--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Change `FAutocomplete.contentErrorBuilder`; pass `null` to hide the popover when there is an error.
 
 * Fix `FAutocomplete` not showing context menu by default.
+* Fix `FAutocomplete` not notifying control's `onChange` callback when a suggestion is selected via tap or tab completion.
 
 ### `FAvatar`
 * **Breaking** Add `FAvatarStyle.fallbackIcon`. Defaults to `FIcons.userRound`.

--- a/forui/lib/src/widgets/autocomplete/autocomplete.dart
+++ b/forui/lib/src/widgets/autocomplete/autocomplete.dart
@@ -776,6 +776,7 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
   late FocusScopeNode _popoverFocus;
   bool _tapFocus = false;
   bool _mutating = false;
+  bool _itemTap = false;
   String? _previous;
   int _monotonic = 0;
 
@@ -843,7 +844,7 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
       });
 
       // Skip if text changed programmatically while the field isn't focused.
-      if ( _fieldFocus.hasFocus) {
+      if (_fieldFocus.hasFocus) {
         _toggle();
       }
     }
@@ -858,12 +859,14 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
       }
       _tapFocus = false;
       _toggle();
-      // Hide the popover when the textfield loses focus and there are no completions to prevent focus from being trapped
-      // in the empty popover.
-    } else if (!_fieldFocus.hasFocus && _popoverFocus.descendants.isEmpty) {
+      // Hide the popover when focus leaves the autocomplete entirely (field and popover both unfocused). Keeps the
+      // popover open while the user is keyboard-navigating items (popover has focus), or while an item tap is
+      // unfocusing the field (handled by onPress's autoHide flag instead).
+    } else if (!_fieldFocus.hasFocus && !_popoverFocus.hasFocus && !_itemTap) {
       _popoverController.hide();
     }
 
+    _itemTap = false;
     _restore = null;
   }
 
@@ -1000,7 +1003,10 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
         forceErrorText: widget.forceErrorText,
         errorBuilder: widget.errorBuilder,
         builder: (context, _, variants, field) => FocusTraversalGroup(
-          policy: SkipDelegateTraversalPolicy(FocusTraversalGroup.maybeOf(context) ?? ReadingOrderTraversalPolicy()),
+          policy: SkipDelegateTraversalPolicy(
+            FocusTraversalGroup.maybeOf(context) ?? ReadingOrderTraversalPolicy(),
+            _popoverFocus,
+          ),
           child: FPopover(
             control: .managed(controller: _popoverController),
             style: style.contentStyle,
@@ -1035,7 +1041,9 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
                         .macOS || .windows || .linux => true,
                         _ => false,
                       };
+
                   if (!retainFocus) {
+                    _itemTap = true;
                     _fieldFocus.unfocus(); // Hides on-screen keyboard.
                   }
 

--- a/forui/lib/src/widgets/autocomplete/autocomplete.dart
+++ b/forui/lib/src/widgets/autocomplete/autocomplete.dart
@@ -1088,13 +1088,9 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
                 bindings: {
                   const SingleActivator(.escape): _popoverController.hide,
                   const SingleActivator(.arrowDown): () => _popoverFocus.descendants.firstOrNull?.requestFocus(),
-                  if (_controller.current case (:final replacement, completion: final _))
-                    const SingleActivator(.tab): () => _complete(replacement),
-                  if (_controller.current case (
-                    :final replacement,
-                    completion: final _,
-                  ) when widget.rightArrowToComplete)
-                    const SingleActivator(.arrowRight): () => _complete(replacement),
+                  if (_controller.current != null) const SingleActivator(.tab): _complete,
+                  if (_controller.current != null && widget.rightArrowToComplete)
+                    const SingleActivator(.arrowRight): _complete,
                 },
                 child: widget.builder(context, style, variants, field),
               ),
@@ -1105,7 +1101,7 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
     );
   }
 
-  void _complete(String replacement) {
+  void _complete() {
     if (widget.autoHide) {
       _popoverController.hide();
     }

--- a/forui/lib/src/widgets/autocomplete/autocomplete.dart
+++ b/forui/lib/src/widgets/autocomplete/autocomplete.dart
@@ -775,6 +775,7 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
   late FocusNode _fieldFocus;
   late FocusScopeNode _popoverFocus;
   bool _tapFocus = false;
+  bool _mutating = false;
   String? _previous;
   int _monotonic = 0;
 
@@ -831,18 +832,20 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
       return;
     }
 
-    setState(() {
-      _previous = _controller.text;
-      _controller.loadSuggestions(_data = widget.filter(_controller.text)).ignore();
-    });
-
+    _previous = _controller.text;
     if (widget.control case FAutocompleteManagedControl(:final onChange?)) {
       onChange(_controller.value);
     }
 
-    // Skip if text changed programmatically while the field isn't focused.
-    if (_fieldFocus.hasFocus) {
-      _toggle();
+    if (!_mutating) {
+      setState(() {
+        _controller.loadSuggestions(_data = widget.filter(_controller.text)).ignore();
+      });
+
+      // Skip if text changed programmatically while the field isn't focused.
+      if ( _fieldFocus.hasFocus) {
+        _toggle();
+      }
     }
   }
 
@@ -1015,8 +1018,9 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
             cutoutBuilder: widget.contentCutoutBuilder,
             onTapHide: () {
               if (_restore case final restore?) {
-                _previous = restore;
+                _mutating = true;
                 _controller.text = restore;
+                _mutating = false;
               }
               widget.contentOnTapHide?.call();
             },
@@ -1039,13 +1043,15 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
                     _popoverController.hide();
                   }
 
-                  _previous = value;
+                  _mutating = true;
                   _controller.text = value;
+                  _mutating = false;
                 },
                 onFocus: (value) {
                   _restore ??= _controller.text;
-                  _previous = value;
+                  _mutating = true;
                   _controller.text = value;
+                  _mutating = false;
                 },
                 child: widget.popoverBuilder(
                   context,
@@ -1095,8 +1101,9 @@ class _State extends State<FAutocomplete> with TickerProviderStateMixin {
     if (widget.autoHide) {
       _popoverController.hide();
     }
-    _previous = replacement;
+    _mutating = true;
     _controller.complete();
+    _mutating = false;
   }
 }
 

--- a/forui/lib/src/widgets/autocomplete/skip_delegate_traversal_policy.dart
+++ b/forui/lib/src/widgets/autocomplete/skip_delegate_traversal_policy.dart
@@ -1,13 +1,21 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
-/// A [FocusTraversalPolicy] that delegates to another policy but skips [FocusScopeNode] descendants that have no
-/// traversal descendants themselves.
+/// A [FocusTraversalPolicy] that skips:
+/// * the popover's [FocusScopeNode] when the current focus is outside of it.
+/// * any [FocusScopeNode] with no traversal descendants.
+///
+/// This shifts the focus from the autocomplete to the next focusable widget when the user presses tab, instead of
+/// stepping into the popover.
+///
+/// It also allows the focus to move between suggestions when the focus is already inside of the popover and the user
+/// presses tab.
 @internal
 class SkipDelegateTraversalPolicy with Diagnosticable implements FocusTraversalPolicy {
   final FocusTraversalPolicy _delegate;
+  final FocusScopeNode _popover;
 
-  SkipDelegateTraversalPolicy(this._delegate);
+  SkipDelegateTraversalPolicy(this._delegate, this._popover);
 
   @override
   TraversalRequestFocusCallback get requestFocusCallback => _delegate.requestFocusCallback;
@@ -42,11 +50,17 @@ class SkipDelegateTraversalPolicy with Diagnosticable implements FocusTraversalP
       _delegate.inDirection(currentNode, direction);
 
   @override
-  Iterable<FocusNode> sortDescendants(Iterable<FocusNode> descendants, FocusNode currentNode) =>
-      _delegate.sortDescendants(
-        descendants.where((descendant) => descendant is! FocusScopeNode || descendant.traversalDescendants.isNotEmpty),
-        currentNode,
-      );
+  Iterable<FocusNode> sortDescendants(Iterable<FocusNode> descendants, FocusNode currentNode) {
+    final inside = currentNode == _popover || currentNode.ancestors.contains(_popover);
+    return _delegate.sortDescendants(
+      descendants.where(
+        (d) =>
+            (inside || (d != _popover && !d.ancestors.contains(_popover))) &&
+            (d is! FocusScopeNode || d.traversalDescendants.isNotEmpty),
+      ),
+      currentNode,
+    );
+  }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/forui/test/src/widgets/autocomplete/autocomplete_test.dart
+++ b/forui/test/src/widgets/autocomplete/autocomplete_test.dart
@@ -418,6 +418,110 @@ void main() {
     });
   }
 
+  group('onChange', () {
+    testWidgets('onChange callback called when suggestion is tapped', (tester) async {
+      TextEditingValue? changedValue;
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FAutocomplete(
+            key: key,
+            control: .managed(controller: controller, onChange: (value) => changedValue = value),
+            items: fruits,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byKey(key), 'app');
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Apple'));
+      await tester.pumpAndSettle();
+
+      expect(changedValue?.text, 'Apple');
+    });
+
+    testWidgets('onChange callback called when tab completes inline suggestion', (tester) async {
+      TextEditingValue? changedValue;
+      final focus = autoDispose(FocusNode());
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FAutocomplete(
+            key: key,
+            control: .managed(controller: controller, onChange: (value) => changedValue = value),
+            focusNode: focus,
+            items: fruits,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byKey(key), 'app');
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyEvent(.tab);
+      await tester.pumpAndSettle();
+
+      expect(controller.text, 'Apple');
+      expect(changedValue?.text, 'Apple');
+    });
+
+    testWidgets('onChange callback called when arrow-key navigation previews a suggestion', (tester) async {
+      TextEditingValue? changedValue;
+      final focus = autoDispose(FocusNode());
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FAutocomplete(
+            key: key,
+            control: .managed(controller: controller, onChange: (value) => changedValue = value),
+            focusNode: focus,
+            items: fruits,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byKey(key), 'app');
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyEvent(.arrowDown);
+      await tester.pumpAndSettle();
+
+      expect(controller.text, 'Apple');
+      expect(changedValue?.text, 'Apple');
+    });
+
+    testWidgets('onChange callback called when popover dismiss restores prior text', (tester) async {
+      final changes = <String>[];
+      final focus = autoDispose(FocusNode());
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FAutocomplete(
+            key: key,
+            control: .managed(controller: controller, onChange: (value) => changes.add(value.text)),
+            focusNode: focus,
+            items: fruits,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byKey(key), 'app');
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyEvent(.arrowDown);
+      await tester.pumpAndSettle();
+      expect(controller.text, 'Apple');
+
+      await tester.sendKeyEvent(.escape);
+      await tester.pumpAndSettle();
+
+      expect(controller.text, 'app');
+      expect(changes.last, 'app');
+      expect(changes.where((c) => c == 'app').length, 2);
+    });
+  });
+
   testWidgets('enter closes popover', (tester) async {
     final focus = autoDispose(FocusNode());
     await tester.pumpWidget(

--- a/forui/test/src/widgets/autocomplete/autocomplete_test.dart
+++ b/forui/test/src/widgets/autocomplete/autocomplete_test.dart
@@ -256,6 +256,145 @@ void main() {
       expect(autocompleteFocus.hasFocus, false);
       expect(buttonFocus.hasFocus, true);
     });
+
+    testWidgets('TextInputAction.next does not select suggestion when popover is open', (tester) async {
+      final autocompleteFocus = autoDispose(FocusNode());
+      final buttonFocus = autoDispose(FocusNode());
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: Column(
+            children: [
+              FAutocomplete(
+                key: key,
+                control: .managed(controller: controller),
+                popoverControl: .managed(controller: popoverController),
+                focusNode: autocompleteFocus,
+                textInputAction: TextInputAction.next,
+                items: fruits,
+              ),
+              FButton(onPress: () {}, focusNode: buttonFocus, child: const Text('button')),
+            ],
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(key));
+      await tester.pumpAndSettle();
+      expect(popoverController.status.isForwardOrCompleted, true);
+
+      await tester.testTextInput.receiveAction(TextInputAction.next);
+      await tester.pumpAndSettle();
+
+      expect(controller.text, '');
+      expect(popoverController.status.isForwardOrCompleted, false);
+      expect(autocompleteFocus.hasFocus, false);
+      expect(buttonFocus.hasFocus, true);
+    });
+
+    testWidgets('tab between popover items navigates within popover', (tester) async {
+      final autocompleteFocus = autoDispose(FocusNode());
+      final buttonFocus = autoDispose(FocusNode());
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: Column(
+            children: [
+              FAutocomplete(
+                key: key,
+                control: .managed(controller: controller),
+                popoverControl: .managed(controller: popoverController),
+                focusNode: autocompleteFocus,
+                items: fruits,
+              ),
+              FButton(onPress: () {}, focusNode: buttonFocus, child: const Text('button')),
+            ],
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(key));
+      await tester.pumpAndSettle();
+      expect(popoverController.status.isForwardOrCompleted, true);
+
+      await tester.sendKeyEvent(.arrowDown);
+      await tester.pumpAndSettle();
+      expect(controller.text, 'Apple');
+
+      await tester.sendKeyEvent(.tab);
+      await tester.pumpAndSettle();
+
+      expect(controller.text, 'Banana');
+      expect(popoverController.status.isForwardOrCompleted, true);
+      expect(buttonFocus.hasFocus, false);
+    });
+
+    testWidgets('TextInputAction.next does not commit completion with typed prefix', (tester) async {
+      final autocompleteFocus = autoDispose(FocusNode());
+      final buttonFocus = autoDispose(FocusNode());
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: Column(
+            children: [
+              FAutocomplete(
+                key: key,
+                control: .managed(controller: controller),
+                popoverControl: .managed(controller: popoverController),
+                focusNode: autocompleteFocus,
+                textInputAction: TextInputAction.next,
+                items: fruits,
+              ),
+              FButton(onPress: () {}, focusNode: buttonFocus, child: const Text('button')),
+            ],
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byKey(key), 'b');
+      await tester.pumpAndSettle();
+
+      await tester.testTextInput.receiveAction(TextInputAction.next);
+      await tester.pumpAndSettle();
+
+      expect(controller.text, 'b');
+      expect(popoverController.status.isForwardOrCompleted, false);
+      expect(buttonFocus.hasFocus, true);
+    });
+
+    testWidgets('tab from empty field with popover open closes popover and moves focus', (tester) async {
+      final autocompleteFocus = autoDispose(FocusNode());
+      final buttonFocus = autoDispose(FocusNode());
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: Column(
+            children: [
+              FAutocomplete(
+                key: key,
+                control: .managed(controller: controller),
+                popoverControl: .managed(controller: popoverController),
+                focusNode: autocompleteFocus,
+                items: fruits,
+              ),
+              FButton(onPress: () {}, focusNode: buttonFocus, child: const Text('button')),
+            ],
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(key));
+      await tester.pumpAndSettle();
+      expect(popoverController.status.isForwardOrCompleted, true);
+
+      await tester.sendKeyEvent(.tab);
+      await tester.pumpAndSettle();
+
+      expect(controller.text, '');
+      expect(popoverController.status.isForwardOrCompleted, false);
+      expect(autocompleteFocus.hasFocus, false);
+      expect(buttonFocus.hasFocus, true);
+    });
   });
 
   group('right arrow completion', () {


### PR DESCRIPTION
## Summary

* Fix `FAutocomplete` committing the first suggestion when `TextInputAction.next` or Tab is pressed while the popover is open and no inline typeahead completion is available (#1020).
* Fix `FAutocomplete` popover staying open after Tab moves focus to another form field (#1020).
* Fix `FAutocomplete` not notifying control's `onChange` when a suggestion is selected via tap or tab completion (#1019).
* Fix `FAutocomplete` not showing context menu by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)