### PR TITLE
Default FToaster alignment + CLI clickable file:// paths

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ Forui
 
 MIT License
 
-Copyright (c) 2024 Forus Labs Pte Ltd
+Copyright (c) 2026 Duobase IO
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -192,8 +192,11 @@ customized globally. Defaults to Lucide-backed set, `FIcons.lucide()`.
 * Change `FTimeField.defaultIconBuilder` to resolve the clock icon from `FIcons.clock4`.
 
 
-### `FToast`
+### `FToast` & `FToaster`
 * Add `FToast.clipBehavior` to clip the toast's content to the inner path of its decoration. Defaults to `Clip.none`.
+
+* Change `FToasterStyle.toastAlignment` default to `FToastAlignment.topCenter` on touch devices.
+* Change `showFToast`/`showRawFToast` default `swipeToDismiss` to derive from the resolved alignment.
 
 
 ### `FTileGroup`

--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -210,6 +210,8 @@ customized globally. Defaults to Lucide-backed set, `FIcons.lucide()`.
 
 
 ### Others
+* Change CLI to print generated file paths as `file://` URIs so they are clickable in JetBrains IDEs.
+
 * Fix spurious `LicenseRegistry` entries, including a hyphen-only "package" name, caused by separator rows in `LICENSE`.
 
 

--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -206,6 +206,10 @@ customized globally. Defaults to Lucide-backed set, `FIcons.lucide()`.
   `FTypography.extensions`.
 
 
+### Others
+* Fix spurious `LicenseRegistry` entries, including a hyphen-only "package" name, caused by separator rows in `LICENSE`.
+
+
 ## 0.21.3
 
 ### `FDeterminateProgress`

--- a/forui/LICENSE
+++ b/forui/LICENSE
@@ -1,9 +1,8 @@
---------------------------------------------------------------------------------
 Forui
 
 MIT License
 
-Copyright (c) 2025 Duobase IO
+Copyright (c) 2026 Duobase IO
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/forui/bin/args/command.dart
+++ b/forui/bin/args/command.dart
@@ -13,12 +13,11 @@ import 'utils.dart';
 /// If we are on Windows, Unicode emojis are supported in Windows Terminal,
 /// which sets the WT_SESSION environment variable. See: https://github.com/microsoft/terminal/issues/1040
 ///
-/// JetBrains' JediTerm (the IDE's embedded Terminal tab) miscounts the width of wide characters at column 0, clipping
-/// the emoji and eating the space that follows it. Detect it via TERMINAL_EMULATOR=JetBrains-JediTerm and fall back to
-/// no emoji. The Run window is unaffected since it uses a different renderer and TERMINAL_EMULATOR is not
-/// inherited.
-///
-/// See https://youtrack-production.pub.aws.intellij.net/projects/IJPL/issues/IJPL-103740/Full-support-for-OSC8-terminal-hyperlinks.
+/// JediTerm does not handle emojis properly (rendered as 2 cells but reported as 1-cell wide), shifting the hyperlink
+/// hotspot off the rendered path text. OSC 8 hyperlinks would work around JediTerm's regex-based path detector, but
+/// JediTerm does not support them either, see https://youtrack.jetbrains.com/issue/IJPL-103740. As a workaround, we
+/// disable emojis when TERMINAL_EMULATOR=JetBrains-JediTerm. The Run window is unaffected since it uses a different
+/// renderer that sizes emojis correctly.
 bool get emoji =>
     _debugEmoji ??
     (!Platform.isWindows || Platform.environment.containsKey('WT_SESSION')) &&

--- a/forui/bin/args/command.dart
+++ b/forui/bin/args/command.dart
@@ -11,9 +11,18 @@ import 'utils.dart';
 ///
 /// Assume Unicode emojis are supported when not on Windows.
 /// If we are on Windows, Unicode emojis are supported in Windows Terminal,
-/// which sets the WT_SESSION environment variable. See:
-/// https://github.com/microsoft/terminal/issues/1040
-bool get emoji => _debugEmoji ?? !Platform.isWindows || Platform.environment.containsKey('WT_SESSION');
+/// which sets the WT_SESSION environment variable. See: https://github.com/microsoft/terminal/issues/1040
+///
+/// JetBrains' JediTerm (the IDE's embedded Terminal tab) miscounts the width of wide characters at column 0, clipping
+/// the emoji and eating the space that follows it. Detect it via TERMINAL_EMULATOR=JetBrains-JediTerm and fall back to
+/// no emoji. The Run window is unaffected since it uses a different renderer and TERMINAL_EMULATOR is not
+/// inherited.
+///
+/// See https://youtrack-production.pub.aws.intellij.net/projects/IJPL/issues/IJPL-103740/Full-support-for-OSC8-terminal-hyperlinks.
+bool get emoji =>
+    _debugEmoji ??
+    (!Platform.isWindows || Platform.environment.containsKey('WT_SESSION')) &&
+        Platform.environment['TERMINAL_EMULATOR'] != 'JetBrains-JediTerm';
 
 // ignore: avoid_positional_boolean_parameters
 set emoji(bool? value) => _debugEmoji = value;

--- a/forui/bin/commands/init/command.dart
+++ b/forui/bin/commands/init/command.dart
@@ -35,11 +35,11 @@ class InitCommand extends ForuiCommand {
   void run() {
     final template = argResults!['template'] as String;
 
-    _configuration().writeAsStringSync(defaults);
-    stdout.writeln('${emoji ? '✅' : '[Done]'} Created forui.yaml.');
+    final config = _configuration()..writeAsStringSync(defaults);
+    stdout.writeln('${emoji ? '✅' : '[Done]'} Created ${Uri.file(config.absolute.path)}.');
 
-    _main().writeAsStringSync(formatter.format(snippets['main-$template']!.$2));
-    stdout.writeln('${emoji ? '✅' : '[Done]'} Created lib/main.dart.');
+    final main = _main()..writeAsStringSync(formatter.format(snippets['main-$template']!.$2));
+    stdout.writeln('${emoji ? '✅' : '[Done]'} Created ${Uri.file(main.absolute.path)}.');
   }
 
   File _configuration() {
@@ -54,10 +54,9 @@ class InitCommand extends ForuiCommand {
     }
 
     if (yaml.existsSync() || yml.existsSync()) {
-      final extension = yaml.existsSync() ? 'yaml' : 'yml';
       file = yaml.existsSync() ? yaml : yml;
 
-      _prompt('forui.$extension');
+      _prompt(file);
     }
 
     return file;
@@ -73,7 +72,7 @@ class InitCommand extends ForuiCommand {
 
     if (file.existsSync()) {
       _prompt(
-        'lib/main.dart',
+        file,
         'You can generate a main.dart later by running "dart forui snippet create main-basic/main-router". ',
       );
     }
@@ -81,16 +80,17 @@ class InitCommand extends ForuiCommand {
     return file;
   }
 
-  void _prompt(String file, [String message = '']) {
+  void _prompt(File file, [String message = '']) {
     final input = !globalResults!.flag('no-input');
+    final uri = Uri.file(file.absolute.path);
 
     if (!input) {
-      stdout.writeln('$file already exists. Skipping... ');
+      stdout.writeln('$uri already exists. Skipping... ');
       exit(0);
     }
 
     while (true) {
-      stdout.write('${emoji ? '⚠️' : '[Warning]'} $file already exists. ${message}Overwrite it? [Y/n] ');
+      stdout.write('${emoji ? '⚠️' : '[Warning]'} $uri already exists. ${message}Overwrite it? [Y/n] ');
 
       switch (stdin.readLineSync()) {
         case 'y' || 'Y' || '':

--- a/forui/bin/commands/snippet/create_command.dart
+++ b/forui/bin/commands/snippet/create_command.dart
@@ -124,7 +124,7 @@ class SnippetCreateCommand extends ForuiCommand {
         ..createSync(recursive: true)
         ..writeAsStringSync(formatter.format(source));
 
-      stdout.writeln('${emoji ? '✅' : '[Done]'} $path');
+      stdout.writeln('${emoji ? '✅' : '[Done]'} ${Uri.file(path)}');
     }
   }
 
@@ -142,7 +142,7 @@ class SnippetCreateCommand extends ForuiCommand {
       ..writeln()
       ..writeln('Existing files:');
     for (final path in existing) {
-      stdout.writeln('  $path');
+      stdout.writeln('  ${Uri.file(path)}');
     }
 
     while (true) {

--- a/forui/bin/commands/style/create/generate.dart
+++ b/forui/bin/commands/style/create/generate.dart
@@ -164,7 +164,7 @@ extension Generation on StyleCreateCommand {
       ..writeln()
       ..writeln('Existing files:');
     for (final path in existing) {
-      stdout.writeln('  $path');
+      stdout.writeln('  ${Uri.file(path)}');
     }
 
     while (true) {
@@ -205,7 +205,7 @@ extension Generation on StyleCreateCommand {
         ..createSync(recursive: true)
         ..writeAsStringSync(formatter.format(buffer.toString()));
 
-      stdout.writeln('${emoji ? '✅' : '[Done]'} $path');
+      stdout.writeln('${emoji ? '✅' : '[Done]'} ${Uri.file(path)}');
     }
   }
 

--- a/forui/bin/commands/style/style.dart
+++ b/forui/bin/commands/style/style.dart
@@ -621,7 +621,7 @@ enum Style {
     null,
     <String>['toaster'],
     <String>['FToasterStyle'],
-    'FToasterStyle toasterStyle({\n  required FColors colors,\n  required FTypography typography,\n  required FStyle style,\n  required bool touch,\n}) => FToasterStyle(\n  toastStyles: .inherit(\n    colors: colors,\n    typography: typography,\n    style: style,\n    touch: touch,\n  ),\n  max: 3,\n  padding: const .symmetric(horizontal: 20, vertical: 15),\n  expandBehavior: .hoverOrPress,\n  expandHoverEnterDuration: const Duration(milliseconds: 200),\n  expandHoverExitDuration: const Duration(milliseconds: 200),\n  expandStartSpacing: 0,\n  expandSpacing: 10,\n  collapsedProtrusion: 12,\n  collapsedScale: 0.9,\n  motion: const FToasterMotion(),\n  toastAlignment: .bottomEnd,\n);\n',
+    'FToasterStyle toasterStyle({\n  required FColors colors,\n  required FTypography typography,\n  required FStyle style,\n  required bool touch,\n}) => FToasterStyle(\n  toastStyles: .inherit(\n    colors: colors,\n    typography: typography,\n    style: style,\n    touch: touch,\n  ),\n  toastAlignment: touch ? .topCenter : .bottomEnd,\n  max: 3,\n  padding: const .symmetric(horizontal: 20, vertical: 15),\n  expandBehavior: .hoverOrPress,\n  expandHoverEnterDuration: const Duration(milliseconds: 200),\n  expandHoverExitDuration: const Duration(milliseconds: 200),\n  expandStartSpacing: 0,\n  expandSpacing: 10,\n  collapsedProtrusion: 12,\n  collapsedScale: 0.9,\n  motion: const FToasterMotion(),\n);\n',
   ),
   ftooltipstyle(
     'FTooltipStyle',

--- a/forui/bin/commands/theme/create_command.dart
+++ b/forui/bin/commands/theme/create_command.dart
@@ -126,7 +126,7 @@ class ThemeCreateCommand extends ForuiCommand {
       ..writeAsStringSync(formatter.format(buffer.toString()));
 
     stdout
-      ..writeln('${emoji ? '✅' : '[Done]'} $path')
+      ..writeln('${emoji ? '✅' : '[Done]'} ${Uri.file(path)}')
       ..writeln()
       ..writeln('See https://forui.dev/docs/guides/customizing-themes for how to use the generated theme.');
   }
@@ -138,7 +138,7 @@ class ThemeCreateCommand extends ForuiCommand {
     }
 
     while (true) {
-      stdout.write('${emoji ? '⚠️' : '[Warning]'} $existing already exists. Overwrite it? [Y/n] ');
+      stdout.write('${emoji ? '⚠️' : '[Warning]'} ${Uri.file(existing)} already exists. Overwrite it? [Y/n] ');
 
       switch (stdin.readLineSync()) {
         case 'y' || 'Y' || '':

--- a/forui/example/LICENSE
+++ b/forui/example/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Duobase IO
+Copyright (c) 2026 Duobase IO
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/forui/example/lib/sandbox.dart
+++ b/forui/example/lib/sandbox.dart
@@ -1,6 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
 
+const _alignments = <String, FToastAlignment?>{
+  'default': null,
+  'topStart': FToastAlignment.topStart,
+  'topCenter': FToastAlignment.topCenter,
+  'topEnd': FToastAlignment.topEnd,
+  'topLeft': FToastAlignment.topLeft,
+  'topRight': FToastAlignment.topRight,
+  'bottomStart': FToastAlignment.bottomStart,
+  'bottomCenter': FToastAlignment.bottomCenter,
+  'bottomEnd': FToastAlignment.bottomEnd,
+  'bottomLeft': FToastAlignment.bottomLeft,
+  'bottomRight': FToastAlignment.bottomRight,
+};
+
 class Sandbox extends StatefulWidget {
   const Sandbox({super.key});
 
@@ -17,6 +31,24 @@ class _SandboxState extends State<Sandbox> {
         mainAxisSize: MainAxisSize.min,
         spacing: 20,
         children: [
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            alignment: WrapAlignment.center,
+            children: [
+              for (final MapEntry(:key, :value) in _alignments.entries)
+                FButton(
+                  mainAxisSize: .min,
+                  onPress: () => showFToast(
+                    context: context,
+                    alignment: value,
+                    title: Text(key),
+                    description: const Text('Swipe or wait to dismiss.'),
+                  ),
+                  child: Text(key),
+                ),
+            ],
+          ),
           FDateField(
             control: .managed(initial: DateTime(2025, 12, 31)),
             label: const Text('Start Date'),

--- a/forui/lib/src/widgets/toast/toaster.dart
+++ b/forui/lib/src/widgets/toast/toaster.dart
@@ -8,9 +8,12 @@ import 'package:forui/src/widgets/toast/toaster_stack.dart';
 ///
 /// [alignment] defaults to [FToasterStyle.toastAlignment].
 ///
-/// [swipeToDismiss] represents axes in which to swipe to dismiss a toast. Defaults to horizontally towards the closest
-/// edge of the screen with a left bias. For example, if [alignment] is [FToastAlignment.bottomRight], the default swipe
-/// direction is [AxisDirection.right].
+/// [swipeToDismiss] represents axes in which to swipe to dismiss a toast.
+///
+/// Defaults to the directions of the toast's alignment:
+/// * Corner positions allow both vertical and horizontal swipe (e.g. [FToastAlignment.bottomRight] defaults to
+///  `[AxisDirection.down, AxisDirection.right]`).
+/// * Centered positions allow only the vertical axis (e.g. [FToastAlignment.topCenter] defaults to `[AxisDirection.up]`).
 ///
 /// Set [swipeToDismiss] to an empty list to disable swiping to dismiss.
 ///
@@ -84,9 +87,14 @@ FToasterEntry showFToast({
 ///
 /// [alignment] defaults to [FToasterStyle.toastAlignment].
 ///
-/// [swipeToDismiss] represents axes in which to swipe to dismiss a toast. Defaults to horizontally towards the closest
-/// edge of the screen with a left bias. For example, if [alignment] is [FToastAlignment.bottomRight], the default swipe
-/// direction is [AxisDirection.right].
+/// [swipeToDismiss] represents axes in which to swipe to dismiss a toast.
+///
+/// Defaults to the directions of the toast's alignment:
+/// * Corner positions allow both vertical and horizontal swipe (e.g. [FToastAlignment.bottomRight] defaults to
+///  `[AxisDirection.down, AxisDirection.right]`).
+/// * Centered positions allow only the vertical axis (e.g. [FToastAlignment.topCenter] defaults to `[AxisDirection.up]`).
+///
+/// Set [swipeToDismiss] to an empty list to disable swiping to dismiss.
 ///
 /// Set [swipeToDismiss] to an empty list to disable swiping to dismiss.
 ///
@@ -325,7 +333,12 @@ class FToasterState extends State<FToaster> {
     final direction = Directionality.maybeOf(context) ?? .ltr;
     final toasterStyle = widget.style(context.theme.toasterStyle);
     final resolved = (alignment ?? toasterStyle.toastAlignment)._alignment.resolve(direction);
-    final directions = swipeToDismiss ?? [if (resolved.x < 1) .left else .right];
+    final directions =
+        swipeToDismiss ??
+        [
+          if (resolved.y < 0) .up else if (resolved.y > 0) .down,
+          if (resolved.x < 0) .left else if (resolved.x > 0) .right,
+        ];
 
     final entry = ToasterEntry(
       style(toasterStyle.toastStyles.resolve({variant, context.platformVariant})),

--- a/forui/lib/src/widgets/toast/toaster.dart
+++ b/forui/lib/src/widgets/toast/toaster.dart
@@ -96,8 +96,6 @@ FToasterEntry showFToast({
 ///
 /// Set [swipeToDismiss] to an empty list to disable swiping to dismiss.
 ///
-/// Set [swipeToDismiss] to an empty list to disable swiping to dismiss.
-///
 /// [dismissThreshold] is the fraction of the toast's width/height that must be swiped before the toast is dismissed.
 /// The higher the threshold, the more the user has to swipe to dismiss the toast. Defaults to 0.5.
 ///

--- a/forui/lib/src/widgets/toast/toaster_style.dart
+++ b/forui/lib/src/widgets/toast/toaster_style.dart
@@ -73,7 +73,8 @@ class FToasterStyle with Diagnosticable, _$FToasterStyleFunctions {
   @override
   final FToasterMotion motion;
 
-  /// The toast's alignment relative to a [FToaster]. Defaults to [FToastAlignment.bottomEnd].
+  /// The toast's alignment relative to a [FToaster]. Defaults to [FToastAlignment.topCenter] on touch devices, and
+  /// [FToastAlignment.bottomEnd] otherwise.
   @override
   final FToastAlignment toastAlignment;
 
@@ -105,6 +106,7 @@ class FToasterStyle with Diagnosticable, _$FToasterStyleFunctions {
     required bool touch,
   }) : this(
          toastStyles: .inherit(colors: colors, typography: typography, style: style, touch: touch),
+         toastAlignment: touch ? .topCenter : .bottomEnd,
        );
 }
 

--- a/forui/test/src/widgets/toast/toaster_test.dart
+++ b/forui/test/src/widgets/toast/toaster_test.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:forui/forui.dart';
+import 'package:forui/src/widgets/toast/toaster.dart';
 import '../../test_scaffold.dart';
 
 Widget small(
@@ -61,6 +62,60 @@ Widget button([
 );
 
 void main() {
+  group('FToasterStyle.inherit', () {
+    test('defaults toastAlignment to topCenter on touch', () {
+      expect(FThemes.neutral.light.touch.toasterStyle.toastAlignment, FToastAlignment.topCenter);
+    });
+
+    test('defaults toastAlignment to bottomEnd on desktop', () {
+      expect(FThemes.neutral.light.desktop.toasterStyle.toastAlignment, FToastAlignment.bottomEnd);
+    });
+  });
+
+  group('default swipeToDismiss', () {
+    for (final (FToastAlignment alignment, TextDirection textDirection, List<AxisDirection> expected) in [
+      (.topCenter, .ltr, [.up]),
+      (.bottomCenter, .ltr, [.down]),
+      (.topLeft, .ltr, [.up, .left]),
+      (.topRight, .ltr, [.up, .right]),
+      (.bottomLeft, .ltr, [.down, .left]),
+      (.bottomRight, .ltr, [.down, .right]),
+      (.topStart, .ltr, [.up, .left]),
+      (.topEnd, .ltr, [.up, .right]),
+      (.topStart, .rtl, [.up, .right]),
+      (.bottomEnd, .rtl, [.down, .left]),
+    ]) {
+      testWidgets('$alignment ($textDirection) has $expected swipe to dismiss', (tester) async {
+        late BuildContext capturedContext;
+        await tester.pumpWidget(
+          TestScaffold(
+            child: Directionality(
+              textDirection: textDirection,
+              child: FToaster(
+                child: Builder(
+                  builder: (context) {
+                    capturedContext = context;
+                    return const SizedBox.shrink();
+                  },
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final entry =
+            showRawFToast(
+                  context: capturedContext,
+                  alignment: alignment,
+                  builder: (_, _) => const SizedBox(width: 100, height: 50),
+                )
+                as ToasterEntry;
+
+        expect(entry.swipeToDismiss, expected);
+      });
+    }
+  });
+
   for (final behavior in FToasterExpandBehavior.values) {
     group('$behavior', () {
       testWidgets('auto-close', (tester) async {

--- a/forui_assets/CHANGELOG.md
+++ b/forui_assets/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.22.0
 * **Breaking** Rename `FIcons` to `FLucideIcons`.
 
+* Fix spurious `LicenseRegistry` entries, including a hyphen-only "package" name, caused by separator rows in `LICENSE`.
+
 
 ## 0.21.0
 * No changes. Lucide icon mappings are still incorrect.

--- a/forui_assets/LICENSE
+++ b/forui_assets/LICENSE
@@ -1,9 +1,8 @@
---------------------------------------------------------------------------------
 Forui
 
 MIT License
 
-Copyright (c) 2024 Forus Labs Pte Ltd
+Copyright (c) 2026 Duobase IO
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -37,4 +36,3 @@ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR 
 INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
---------------------------------------------------------------------------------

--- a/forui_hooks/LICENSE
+++ b/forui_hooks/LICENSE
@@ -2,7 +2,7 @@ Forui Hooks
 
 MIT License
 
-Copyright (c) 2024 Forus Labs Pte Ltd
+Copyright (c) 2026 Duobase IO
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/forui_internal_gen/LICENSE
+++ b/forui_internal_gen/LICENSE
@@ -2,7 +2,7 @@ Forui Internal Gen
 
 MIT License
 
-Copyright (c) 2025 Duobase IO
+Copyright (c) 2026 Duobase IO
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
**Describe the changes**

- `FToasterStyle.inherit()` defaults `toastAlignment` to `FToastAlignment.topCenter` on touch and `FToastAlignment.bottomEnd` on desktop, matching shadcn/sonner.
- `showFToast` / `showRawFToast` derive their default `swipeToDismiss` from the resolved anchor using sonner's two-axis rule (corners get both axes, centers get the vertical axis only).
- CLI prints generated file paths as `file:///` URIs so they are clickable in JetBrains IDEs (Terminal tab + Run window) and modern terminals (iTerm2, Windows Terminal, VS Code, kitty, alacritty, wezterm). Suppresses emoji in the JediTerm Terminal tab (detected via `TERMINAL_EMULATOR=JetBrains-JediTerm`) where the wide-character column miscount clips the glyph and consumes the trailing space; the Run window keeps emoji since `TERMINAL_EMULATOR` is not inherited by child processes.
- Fixes #1022 — spurious `LicenseRegistry` entries caused by separator rows in `LICENSE`.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [x] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)