### PR TITLE
Add FAvatar demo with stacked slide-in animation

### DIFF
--- a/demo/lib/main.dart
+++ b/demo/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart' hide Autocomplete, Tooltip;
 import 'package:forui/forui.dart';
 
-import 'widgets/autocomplete.dart';
+import 'widgets/avatar.dart';
 
 void main() {
   runApp(const Application());
@@ -29,7 +29,7 @@ class Application extends StatelessWidget {
         ),
       ),
       home: const FScaffold(
-        child: Autocomplete(),
+        child: Avatar(),
       ),
     );
   }

--- a/demo/lib/widgets/avatar.dart
+++ b/demo/lib/widgets/avatar.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/widgets.dart';
+import 'package:forui/forui.dart';
+
+class Avatar extends StatefulWidget {
+  const Avatar({super.key});
+
+  @override
+  State<Avatar> createState() => _AvatarState();
+}
+
+class _AvatarState extends State<Avatar> with SingleTickerProviderStateMixin {
+  static const List<ImageProvider> _images = [
+    NetworkImage('https://i.pravatar.cc/300?img=12'),
+    AssetImage(''),
+    NetworkImage('https://i.pravatar.cc/300?img=33'),
+    NetworkImage('https://i.pravatar.cc/300?img=58'),
+    AssetImage(''),
+  ];
+  static const _fallbackTextStyle = TextStyle(fontSize: _avatarSize * 0.4, fontWeight: FontWeight.w500);
+
+  static const List<Widget?> _fallbacks = [
+    Text('AB', style: _fallbackTextStyle),
+    Text('MK', style: _fallbackTextStyle),
+    Text('EF', style: _fallbackTextStyle),
+    Text('TS', style: _fallbackTextStyle),
+    Text('JL', style: _fallbackTextStyle),
+  ];
+
+  static const _avatarSize = 120.0;
+  static const _ringPadding = 6.0;
+  static const _step = 72.0;
+  static const _slideDistance = 360.0;
+
+  static const _slideStartDelayMs = 480;
+  static const _slideDurationMs = 600;
+  static const _holdDurationMs = 5000;
+  static const _fadeOutDurationMs = 600;
+  static const _resetGapMs = 200;
+
+  static const _count = 5;
+  static const _fadeOutStartMs =
+      (_count - 1) * _slideStartDelayMs + _slideDurationMs + _holdDurationMs;
+  static const _totalMs = _fadeOutStartMs + _fadeOutDurationMs + _resetGapMs;
+
+  late AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: _totalMs),
+    )..repeat();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ringDiameter = _avatarSize + _ringPadding * 2;
+    final stackWidth = ringDiameter + _step * (_images.length - 1);
+    final ringColor = context.theme.colors.background;
+
+    return Center(
+      child: SizedBox(
+        width: stackWidth,
+        height: ringDiameter,
+        child: AnimatedBuilder(
+          animation: _controller,
+          builder: (_, _) {
+            final elapsedMs = _controller.value * _totalMs;
+            final fadeOut = ((elapsedMs - _fadeOutStartMs) / _fadeOutDurationMs).clamp(0.0, 1.0);
+
+            return Stack(
+              clipBehavior: .none,
+              children: [
+                for (var i = 0; i < _images.length; i++)
+                  Positioned(
+                    left: i * _step,
+                    top: 0,
+                    child: _buildAvatar(i, elapsedMs, fadeOut, ringDiameter, ringColor),
+                  ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAvatar(int i, double elapsedMs, double fadeOut, double ringDiameter, Color ringColor) {
+    final raw = ((elapsedMs - i * _slideStartDelayMs) / _slideDurationMs).clamp(0.0, 1.0);
+    final eased = Curves.easeOutCubic.transform(raw);
+    final dx = (1 - eased) * _slideDistance;
+    final opacity = eased * (1 - fadeOut);
+
+    return Opacity(
+      opacity: opacity,
+      child: Transform.translate(
+        offset: Offset(dx, 0),
+        child: Container(
+          width: ringDiameter,
+          height: ringDiameter,
+          padding: const EdgeInsets.all(_ringPadding),
+          decoration: BoxDecoration(shape: .circle, color: ringColor),
+          child: FAvatar(
+            image: _images[i],
+            fallback: _fallbacks[i],
+            size: _avatarSize,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/demo/macos/Runner/DebugProfile.entitlements
+++ b/demo/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/demo/macos/Runner/Release.entitlements
+++ b/demo/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
**Describe the changes**

Adds a new `FAvatar` demo at `demo/lib/widgets/avatar.dart` that auto-loops a five-avatar row sliding in one-by-one from the right, holding the settled stack for ~5s, then fading out together. Three positions load portraits from `i.pravatar.cc` while two use `Text` initials as fallback to showcase the image-error path. Wires the demo into `demo/lib/main.dart` as the active screen, and adds the `com.apple.security.network.client` macOS entitlement (debug + release) so `NetworkImage` requests aren't blocked by the app sandbox.

**Checklist**
- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.