### PR TITLE
Add FLineCalendarScrollController

### DIFF
--- a/docs_snippets/lib/usages/widgets/line_calendar.dart
+++ b/docs_snippets/lib/usages/widgets/line_calendar.dart
@@ -1,6 +1,5 @@
 // ignore_for_file: avoid_redundant_argument_values
 
-
 import 'package:forui/forui.dart';
 
 final lineCalendar = FLineCalendar(

--- a/docs_snippets/lib/usages/widgets/line_calendar.dart
+++ b/docs_snippets/lib/usages/widgets/line_calendar.dart
@@ -1,6 +1,5 @@
 // ignore_for_file: avoid_redundant_argument_values
 
-import 'package:flutter/widgets.dart';
 
 import 'package:forui/forui.dart';
 

--- a/docs_snippets/lib/usages/widgets/line_calendar.dart
+++ b/docs_snippets/lib/usages/widgets/line_calendar.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: avoid_redundant_argument_values
 
+import 'package:flutter/widgets.dart';
+
 import 'package:forui/forui.dart';
 
 final lineCalendar = FLineCalendar(
@@ -7,17 +9,13 @@ final lineCalendar = FLineCalendar(
   control: const .managed(),
   // {@endcategory}
   // {@category "Scroll"}
-  initialScroll: .now(),
-  initialScrollAlignment: .center,
-  scrollCacheExtent: null,
-  keyboardDismissBehavior: .manual,
-  physics: null,
+  scrollControl: const .managed(),
   // {@endcategory}
   // {@category "Core"}
   style: const .delta(itemSpacing: 10),
-  start: .utc(1900),
-  end: .utc(2100),
-  today: .now(),
+  scrollCacheExtent: null,
+  keyboardDismissBehavior: .manual,
+  physics: null,
   builder: (context, data, child) => child!,
   // {@endcategory}
 );
@@ -41,4 +39,30 @@ final FLineCalendarControl managedExternal = .managed(
   // Don't create a controller inline. Store it in a State instead.
   controller: .date(initial: .now(), selectable: (date) => true, toggleable: false, truncateAndStripTimezone: true),
   onChange: (date) {},
+);
+
+// {@category "Scroll" "`.managed()` with internal controller"}
+/// Manages the line calendar scroll internally.
+final FLineCalendarScrollControl scrollManagedInternal = .managed(
+  // Don't create a controller inline. Store it in a State instead.
+  start: .utc(1900),
+  end: .utc(2100),
+  today: .now(),
+  initialDate: .now(),
+  initialAlignment: .center,
+  onChange: (offset) {},
+);
+
+// {@category "Scroll" "`.managed()` with external controller"}
+/// Uses an external [FLineCalendarScrollController] to drive programmatic scrolling.
+final FLineCalendarScrollControl scrollManagedExternal = .managed(
+  // Don't create a controller inline. Store it in a State instead.
+  controller: FLineCalendarScrollController(
+    start: .utc(1900),
+    end: .utc(2100),
+    today: .now(),
+    initialDate: .now(),
+    initialAlignment: .center,
+  ),
+  onChange: (offset) {},
 );

--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -107,6 +107,12 @@ customized globally. Defaults to Lucide-backed set, `FIcons.lucide()`.
 
 
 ### `FLineCalendar`
+* Add `FLineCalendarScrollControl`.
+* Add `FLineCalendarScrollController`.
+* Add `FLineCalendar.scrollControl`.
+
+* **Breaking** Move `FLineCalendar.start`, `end`, `today`, `initialScroll`, and `initialScrollAlignment` to
+  `FLineCalendarScrollControl.managed(...)`.
 * **Breaking** Rename `FLineCalendar.cacheExtent` to `FLineCalendar.scrollCacheExtent`.
 
 

--- a/forui/example/lib/sandbox.dart
+++ b/forui/example/lib/sandbox.dart
@@ -50,10 +50,7 @@ class _SandboxState extends State<Sandbox> {
           SizedBox(
             width: _viewportWidth,
             child: FLineCalendar(
-              scrollControl: .managed(
-                controller: _scroll,
-                onChange: (offset) => setState(() => _offset = offset),
-              ),
+              scrollControl: .managed(controller: _scroll, onChange: (offset) => setState(() => _offset = offset)),
             ),
           ),
           Text('offset: ${_offset.toStringAsFixed(1)}    viewport: ${_viewportWidth.toStringAsFixed(0)}'),
@@ -101,10 +98,8 @@ class _SandboxState extends State<Sandbox> {
               ),
               FButton(
                 mainAxisSize: .min,
-                onPress: () => _scroll.jumpToDate(
-                  DateTime.utc(_target.year, _target.month, _target.day),
-                  alignment: _alignment,
-                ),
+                onPress: () =>
+                    _scroll.jumpToDate(DateTime.utc(_target.year, _target.month, _target.day), alignment: _alignment),
                 child: const Text('Jump to today'),
               ),
               FButton(

--- a/forui/example/lib/sandbox.dart
+++ b/forui/example/lib/sandbox.dart
@@ -23,6 +23,22 @@ class Sandbox extends StatefulWidget {
 }
 
 class _SandboxState extends State<Sandbox> {
+  final _scroll = FLineCalendarScrollController(
+    start: DateTime.utc(2024),
+    end: DateTime.utc(2026),
+    today: DateTime.utc(2025, 6, 15),
+  );
+  static const _target = (year: 2025, month: 6, day: 15);
+  double _offset = 0;
+  double _viewportWidth = 400;
+  AlignmentDirectional _alignment = AlignmentDirectional.center;
+
+  @override
+  void dispose() {
+    _scroll.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) => SingleChildScrollView(
     padding: const EdgeInsets.all(20),
@@ -31,6 +47,78 @@ class _SandboxState extends State<Sandbox> {
         mainAxisSize: MainAxisSize.min,
         spacing: 20,
         children: [
+          SizedBox(
+            width: _viewportWidth,
+            child: FLineCalendar(
+              scrollControl: .managed(
+                controller: _scroll,
+                onChange: (offset) => setState(() => _offset = offset),
+              ),
+            ),
+          ),
+          Text('offset: ${_offset.toStringAsFixed(1)}    viewport: ${_viewportWidth.toStringAsFixed(0)}'),
+          SizedBox(
+            width: 320,
+            child: Material(
+              child: Slider(
+                value: _viewportWidth,
+                min: 120,
+                max: 600,
+                onChanged: (v) => setState(() => _viewportWidth = v),
+              ),
+            ),
+          ),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            alignment: WrapAlignment.center,
+            children: [
+              for (final (label, value) in const [
+                ('start', AlignmentDirectional.centerStart),
+                ('center', AlignmentDirectional.center),
+                ('end', AlignmentDirectional.centerEnd),
+              ])
+                FButton(
+                  mainAxisSize: .min,
+                  variant: _alignment == value ? .primary : .outline,
+                  onPress: () => setState(() => _alignment = value),
+                  child: Text(label),
+                ),
+            ],
+          ),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            alignment: WrapAlignment.center,
+            children: [
+              FButton(
+                mainAxisSize: .min,
+                onPress: () => _scroll.animateToDate(
+                  DateTime.utc(_target.year, _target.month, _target.day),
+                  alignment: _alignment,
+                ),
+                child: const Text('Animate to today'),
+              ),
+              FButton(
+                mainAxisSize: .min,
+                onPress: () => _scroll.jumpToDate(
+                  DateTime.utc(_target.year, _target.month, _target.day),
+                  alignment: _alignment,
+                ),
+                child: const Text('Jump to today'),
+              ),
+              FButton(
+                mainAxisSize: .min,
+                onPress: () => _scroll.animateToDate(DateTime.utc(2024), alignment: _alignment),
+                child: const Text('Jump to start'),
+              ),
+              FButton(
+                mainAxisSize: .min,
+                onPress: () => _scroll.animateToDate(DateTime.utc(2025, 12, 31), alignment: _alignment),
+                child: const Text('NYE'),
+              ),
+            ],
+          ),
           Wrap(
             spacing: 8,
             runSpacing: 8,

--- a/forui/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/forui/example/macos/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */

--- a/forui/lib/fix_data/line_calendar.yaml
+++ b/forui/lib/fix_data/line_calendar.yaml
@@ -11,3 +11,444 @@ transforms:
       - kind: renameParameter
         oldName: 'cacheExtent'
         newName: 'scrollCacheExtent'
+
+  - title: 'Migrate FLineCalendar date and alignment params into scrollControl.'
+    date: 2026-05-20
+    element:
+      uris: [ 'package:forui/forui.dart' ]
+      constructor: ''
+      inClass: FLineCalendar
+    variables:
+      start:
+        kind: fragment
+        value: arguments[start]
+      end:
+        kind: fragment
+        value: arguments[end]
+      today:
+        kind: fragment
+        value: arguments[today]
+      initialScroll:
+        kind: fragment
+        value: arguments[initialScroll]
+      initialScrollAlignment:
+        kind: fragment
+        value: arguments[initialScrollAlignment]
+    oneOf:
+      # 5 params
+      - if: "start != '' && end != '' && today != '' && initialScroll != '' && initialScrollAlignment != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(start: {% start %}, end: {% end %}, today: {% today %}, initialDate: {% initialScroll %}, initialAlignment: {% initialScrollAlignment %})'
+          - kind: removeParameter
+            name: 'start'
+          - kind: removeParameter
+            name: 'end'
+          - kind: removeParameter
+            name: 'today'
+          - kind: removeParameter
+            name: 'initialScroll'
+          - kind: removeParameter
+            name: 'initialScrollAlignment'
+
+      # 4 params
+      - if: "start != '' && end != '' && today != '' && initialScroll != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(start: {% start %}, end: {% end %}, today: {% today %}, initialDate: {% initialScroll %})'
+          - kind: removeParameter
+            name: 'start'
+          - kind: removeParameter
+            name: 'end'
+          - kind: removeParameter
+            name: 'today'
+          - kind: removeParameter
+            name: 'initialScroll'
+      - if: "start != '' && end != '' && today != '' && initialScrollAlignment != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(start: {% start %}, end: {% end %}, today: {% today %}, initialAlignment: {% initialScrollAlignment %})'
+          - kind: removeParameter
+            name: 'start'
+          - kind: removeParameter
+            name: 'end'
+          - kind: removeParameter
+            name: 'today'
+          - kind: removeParameter
+            name: 'initialScrollAlignment'
+      - if: "start != '' && end != '' && initialScroll != '' && initialScrollAlignment != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(start: {% start %}, end: {% end %}, initialDate: {% initialScroll %}, initialAlignment: {% initialScrollAlignment %})'
+          - kind: removeParameter
+            name: 'start'
+          - kind: removeParameter
+            name: 'end'
+          - kind: removeParameter
+            name: 'initialScroll'
+          - kind: removeParameter
+            name: 'initialScrollAlignment'
+      - if: "start != '' && today != '' && initialScroll != '' && initialScrollAlignment != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(start: {% start %}, today: {% today %}, initialDate: {% initialScroll %}, initialAlignment: {% initialScrollAlignment %})'
+          - kind: removeParameter
+            name: 'start'
+          - kind: removeParameter
+            name: 'today'
+          - kind: removeParameter
+            name: 'initialScroll'
+          - kind: removeParameter
+            name: 'initialScrollAlignment'
+      - if: "end != '' && today != '' && initialScroll != '' && initialScrollAlignment != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(end: {% end %}, today: {% today %}, initialDate: {% initialScroll %}, initialAlignment: {% initialScrollAlignment %})'
+          - kind: removeParameter
+            name: 'end'
+          - kind: removeParameter
+            name: 'today'
+          - kind: removeParameter
+            name: 'initialScroll'
+          - kind: removeParameter
+            name: 'initialScrollAlignment'
+
+      # 3 params
+      - if: "start != '' && end != '' && today != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(start: {% start %}, end: {% end %}, today: {% today %})'
+          - kind: removeParameter
+            name: 'start'
+          - kind: removeParameter
+            name: 'end'
+          - kind: removeParameter
+            name: 'today'
+      - if: "start != '' && end != '' && initialScroll != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(start: {% start %}, end: {% end %}, initialDate: {% initialScroll %})'
+          - kind: removeParameter
+            name: 'start'
+          - kind: removeParameter
+            name: 'end'
+          - kind: removeParameter
+            name: 'initialScroll'
+      - if: "start != '' && end != '' && initialScrollAlignment != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(start: {% start %}, end: {% end %}, initialAlignment: {% initialScrollAlignment %})'
+          - kind: removeParameter
+            name: 'start'
+          - kind: removeParameter
+            name: 'end'
+          - kind: removeParameter
+            name: 'initialScrollAlignment'
+      - if: "start != '' && today != '' && initialScroll != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(start: {% start %}, today: {% today %}, initialDate: {% initialScroll %})'
+          - kind: removeParameter
+            name: 'start'
+          - kind: removeParameter
+            name: 'today'
+          - kind: removeParameter
+            name: 'initialScroll'
+      - if: "start != '' && today != '' && initialScrollAlignment != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(start: {% start %}, today: {% today %}, initialAlignment: {% initialScrollAlignment %})'
+          - kind: removeParameter
+            name: 'start'
+          - kind: removeParameter
+            name: 'today'
+          - kind: removeParameter
+            name: 'initialScrollAlignment'
+      - if: "start != '' && initialScroll != '' && initialScrollAlignment != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(start: {% start %}, initialDate: {% initialScroll %}, initialAlignment: {% initialScrollAlignment %})'
+          - kind: removeParameter
+            name: 'start'
+          - kind: removeParameter
+            name: 'initialScroll'
+          - kind: removeParameter
+            name: 'initialScrollAlignment'
+      - if: "end != '' && today != '' && initialScroll != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(end: {% end %}, today: {% today %}, initialDate: {% initialScroll %})'
+          - kind: removeParameter
+            name: 'end'
+          - kind: removeParameter
+            name: 'today'
+          - kind: removeParameter
+            name: 'initialScroll'
+      - if: "end != '' && today != '' && initialScrollAlignment != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(end: {% end %}, today: {% today %}, initialAlignment: {% initialScrollAlignment %})'
+          - kind: removeParameter
+            name: 'end'
+          - kind: removeParameter
+            name: 'today'
+          - kind: removeParameter
+            name: 'initialScrollAlignment'
+      - if: "end != '' && initialScroll != '' && initialScrollAlignment != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(end: {% end %}, initialDate: {% initialScroll %}, initialAlignment: {% initialScrollAlignment %})'
+          - kind: removeParameter
+            name: 'end'
+          - kind: removeParameter
+            name: 'initialScroll'
+          - kind: removeParameter
+            name: 'initialScrollAlignment'
+      - if: "today != '' && initialScroll != '' && initialScrollAlignment != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(today: {% today %}, initialDate: {% initialScroll %}, initialAlignment: {% initialScrollAlignment %})'
+          - kind: removeParameter
+            name: 'today'
+          - kind: removeParameter
+            name: 'initialScroll'
+          - kind: removeParameter
+            name: 'initialScrollAlignment'
+
+      # 2 params
+      - if: "start != '' && end != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(start: {% start %}, end: {% end %})'
+          - kind: removeParameter
+            name: 'start'
+          - kind: removeParameter
+            name: 'end'
+      - if: "start != '' && today != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(start: {% start %}, today: {% today %})'
+          - kind: removeParameter
+            name: 'start'
+          - kind: removeParameter
+            name: 'today'
+      - if: "start != '' && initialScroll != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(start: {% start %}, initialDate: {% initialScroll %})'
+          - kind: removeParameter
+            name: 'start'
+          - kind: removeParameter
+            name: 'initialScroll'
+      - if: "start != '' && initialScrollAlignment != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(start: {% start %}, initialAlignment: {% initialScrollAlignment %})'
+          - kind: removeParameter
+            name: 'start'
+          - kind: removeParameter
+            name: 'initialScrollAlignment'
+      - if: "end != '' && today != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(end: {% end %}, today: {% today %})'
+          - kind: removeParameter
+            name: 'end'
+          - kind: removeParameter
+            name: 'today'
+      - if: "end != '' && initialScroll != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(end: {% end %}, initialDate: {% initialScroll %})'
+          - kind: removeParameter
+            name: 'end'
+          - kind: removeParameter
+            name: 'initialScroll'
+      - if: "end != '' && initialScrollAlignment != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(end: {% end %}, initialAlignment: {% initialScrollAlignment %})'
+          - kind: removeParameter
+            name: 'end'
+          - kind: removeParameter
+            name: 'initialScrollAlignment'
+      - if: "today != '' && initialScroll != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(today: {% today %}, initialDate: {% initialScroll %})'
+          - kind: removeParameter
+            name: 'today'
+          - kind: removeParameter
+            name: 'initialScroll'
+      - if: "today != '' && initialScrollAlignment != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(today: {% today %}, initialAlignment: {% initialScrollAlignment %})'
+          - kind: removeParameter
+            name: 'today'
+          - kind: removeParameter
+            name: 'initialScrollAlignment'
+      - if: "initialScroll != '' && initialScrollAlignment != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(initialDate: {% initialScroll %}, initialAlignment: {% initialScrollAlignment %})'
+          - kind: removeParameter
+            name: 'initialScroll'
+          - kind: removeParameter
+            name: 'initialScrollAlignment'
+
+      # 1 param
+      - if: "start != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(start: {% start %})'
+          - kind: removeParameter
+            name: 'start'
+      - if: "end != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(end: {% end %})'
+          - kind: removeParameter
+            name: 'end'
+      - if: "today != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(today: {% today %})'
+          - kind: removeParameter
+            name: 'today'
+      - if: "initialScroll != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(initialDate: {% initialScroll %})'
+          - kind: removeParameter
+            name: 'initialScroll'
+      - if: "initialScrollAlignment != ''"
+        changes:
+          - kind: addParameter
+            name: 'scrollControl'
+            index: 0
+            style: 'required_named'
+            argumentValue:
+              expression: '.managed(initialAlignment: {% initialScrollAlignment %})'
+          - kind: removeParameter
+            name: 'initialScrollAlignment'

--- a/forui/lib/src/widgets/line_calendar/calendar_layout.dart
+++ b/forui/lib/src/widgets/line_calendar/calendar_layout.dart
@@ -8,38 +8,31 @@ import 'package:forui/forui.dart';
 import 'package:forui/src/foundation/rendering.dart';
 import 'package:forui/src/widgets/line_calendar/line_calendar_controller.dart';
 import 'package:forui/src/widgets/line_calendar/line_calendar_item.dart';
+import 'package:forui/src/widgets/line_calendar/line_calendar_scroll_controller.dart';
 
 @internal
 class CalendarLayout extends StatefulWidget {
   final FLineCalendarControl control;
+  final FLineCalendarScrollControl scrollControl;
   final FLineCalendarStyle style;
-  final AlignmentDirectional alignment;
   final ScrollPhysics? physics;
   final ScrollCacheExtent? scrollCacheExtent;
   final ScrollViewKeyboardDismissBehavior keyboardDismissBehavior;
   final TextScaler scale;
   final TextStyle textStyle;
   final ValueWidgetBuilder<FLineCalendarItemData> builder;
-  final LocalDate start;
-  final LocalDate? end;
-  final LocalDate? initialScroll;
-  final LocalDate today;
   final BoxConstraints constraints;
 
   const CalendarLayout({
     required this.control,
+    required this.scrollControl,
     required this.style,
-    required this.alignment,
     required this.physics,
     required this.scrollCacheExtent,
     required this.keyboardDismissBehavior,
     required this.scale,
     required this.textStyle,
     required this.builder,
-    required this.start,
-    required this.end,
-    required this.initialScroll,
-    required this.today,
     required this.constraints,
     super.key,
   });
@@ -52,62 +45,44 @@ class CalendarLayout extends StatefulWidget {
     super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('control', control))
+      ..add(DiagnosticsProperty('scrollControl', scrollControl))
       ..add(DiagnosticsProperty('style', style))
-      ..add(DiagnosticsProperty('alignment', alignment))
       ..add(DiagnosticsProperty('physics', physics))
       ..add(DiagnosticsProperty('scrollCacheExtent', scrollCacheExtent))
       ..add(DiagnosticsProperty('keyboardDismissBehavior', keyboardDismissBehavior))
       ..add(DiagnosticsProperty('scaler', scale))
       ..add(DiagnosticsProperty('textStyle', textStyle))
       ..add(ObjectFlagProperty.has('builder', builder))
-      ..add(DiagnosticsProperty('start', start))
-      ..add(DiagnosticsProperty('end', end))
-      ..add(DiagnosticsProperty('initialScroll', initialScroll))
-      ..add(DiagnosticsProperty('today', today))
       ..add(DiagnosticsProperty('constraints', constraints));
   }
 }
 
 class _CalendarLayoutState extends State<CalendarLayout> {
   late FCalendarController<DateTime?> _controller;
-  late ScrollController _scrollController;
-  late double _width;
+  late FLineCalendarScrollController _scrollController;
+  late double _itemExtent;
 
   @override
   void initState() {
     super.initState();
-    _width = _estimateWidth();
-
     _controller = widget.control.create(_handleOnChange);
-
-    final start = ((widget.initialScroll ?? widget.today).difference(widget.start).inDays) * _width;
-    _scrollController = ScrollController(
-      initialScrollOffset: switch (widget.alignment.start) {
-        -1 => start,
-        1 => start - widget.constraints.maxWidth + _width,
-        _ => start - (widget.constraints.maxWidth - _width) / 2,
-      },
-    );
+    _scrollController = widget.scrollControl.create(_handleOnScroll)
+      ..initialize(_itemExtent = _estimateExtent(), widget.constraints.maxWidth);
   }
 
   @override
   void didUpdateWidget(covariant CalendarLayout old) {
     super.didUpdateWidget(old);
     if (widget.style != old.style || widget.scale != old.scale || widget.textStyle != old.textStyle) {
-      _width = _estimateWidth();
+      _itemExtent = _estimateExtent();
     }
 
     _controller = widget.control.update(old.control, _controller, _handleOnChange).$1;
+    _scrollController = widget.scrollControl.update(old.scrollControl, _scrollController, _handleOnScroll).$1
+      ..initialize(_itemExtent, widget.constraints.maxWidth);
   }
 
-  @override
-  void dispose() {
-    _scrollController.dispose();
-    widget.control.dispose(_controller, _handleOnChange);
-    super.dispose();
-  }
-
-  double _estimateWidth() {
+  double _estimateExtent() {
     final scale = widget.scale;
     final textStyle = widget.textStyle;
 
@@ -119,7 +94,7 @@ class _CalendarLayoutState extends State<CalendarLayout> {
       return dateHeight + weekdayHeight + otherHeight;
     }
 
-    // We use the height to estimate the width.
+    // We use the height to estimate the item's extent.
     return [
       height(widget.style, {.selected}),
       height(widget.style, {.selected, .hovered}),
@@ -128,47 +103,59 @@ class _CalendarLayoutState extends State<CalendarLayout> {
     ].max!;
   }
 
+  @override
+  void dispose() {
+    widget.scrollControl.dispose(_scrollController, _handleOnScroll);
+    widget.control.dispose(_controller, _handleOnChange);
+    super.dispose();
+  }
+
   void _handleOnChange() {
     if (widget.control case FLineCalendarManagedControl(:final onChange?)) {
       onChange(_controller.value);
     }
   }
 
-  @override
-  Widget build(BuildContext _) {
-    final placeholder = widget.today.toNative();
-    return SpeculativeLayout(
-      children: [
-        ItemContent(style: widget.style, variants: {.selected}, date: placeholder),
-        ItemContent(style: widget.style, variants: {.selected, .hovered}, date: placeholder),
-        ItemContent(style: widget.style, variants: const {}, date: placeholder),
-        ItemContent(style: widget.style, variants: {.hovered}, date: placeholder),
-        ListView.builder(
-          scrollCacheExtent: widget.scrollCacheExtent,
-          controller: _scrollController,
-          scrollDirection: .horizontal,
-          padding: .zero,
-          physics: widget.physics,
-          keyboardDismissBehavior: widget.keyboardDismissBehavior,
-          itemExtent: _width,
-          itemCount: widget.end == null ? null : widget.end!.difference(widget.start).inDays + 1,
-          itemBuilder: (_, index) {
-            final date = widget.start.plus(days: index);
-            return Padding(
-              padding: .symmetric(horizontal: widget.style.itemSpacing / 2),
-              child: Item(
-                controller: _controller,
-                style: widget.style,
-                date: date.toNative(),
-                today: widget.today == date,
-                builder: widget.builder,
-              ),
-            );
-          },
-        ),
-      ],
-    );
+  void _handleOnScroll() {
+    if (widget.scrollControl case FLineCalendarScrollManagedControl(:final onChange?)) {
+      onChange(_scrollController.offset);
+    }
   }
+
+  @override
+  Widget build(BuildContext _) => SpeculativeLayout(
+    children: [
+      ItemContent(style: widget.style, variants: {.selected}, date: _scrollController.today),
+      ItemContent(style: widget.style, variants: {.selected, .hovered}, date: _scrollController.today),
+      ItemContent(style: widget.style, variants: const {}, date: _scrollController.today),
+      ItemContent(style: widget.style, variants: {.hovered}, date: _scrollController.today),
+      ListView.builder(
+        scrollCacheExtent: widget.scrollCacheExtent,
+        controller: _scrollController,
+        scrollDirection: .horizontal,
+        padding: .zero,
+        physics: widget.physics,
+        keyboardDismissBehavior: widget.keyboardDismissBehavior,
+        itemExtent: _itemExtent,
+        itemCount: _scrollController.end == null
+            ? null
+            : _scrollController.end!.difference(_scrollController.start).inDays + 1,
+        itemBuilder: (_, index) {
+          final date = _scrollController.start.plus(days: index);
+          return Padding(
+            padding: .symmetric(horizontal: widget.style.itemSpacing / 2),
+            child: Item(
+              controller: _controller,
+              style: widget.style,
+              date: date,
+              today: _scrollController.today == date,
+              builder: widget.builder,
+            ),
+          );
+        },
+      ),
+    ],
+  );
 }
 
 @internal

--- a/forui/lib/src/widgets/line_calendar/line_calendar.dart
+++ b/forui/lib/src/widgets/line_calendar/line_calendar.dart
@@ -5,7 +5,6 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 import 'package:meta/meta.dart';
-import 'package:sugar/sugar.dart';
 
 import 'package:forui/forui.dart';
 import 'package:forui/src/foundation/annotations.dart';
@@ -41,6 +40,9 @@ class FLineCalendar extends StatelessWidget {
   /// Defines how this line calendar's value is controlled.
   final FLineCalendarControl control;
 
+  /// Defines how this line calendar is scrolled.
+  final FLineCalendarScrollControl scrollControl;
+
   /// The style.
   ///
   /// To modify the current style:
@@ -61,9 +63,6 @@ class FLineCalendar extends StatelessWidget {
   /// ```
   final FLineCalendarStyleDelta style;
 
-  /// The alignment to which the initially scrolled date will be aligned. Defaults to [Alignment.center].
-  final AlignmentDirectional initialScrollAlignment;
-
   /// How the scroll view should respond to user input.
   ///
   /// Defaults to matching platform conventions.
@@ -83,66 +82,23 @@ class FLineCalendar extends StatelessWidget {
   /// in a [Stack] to avoid re-creating the custom content from scratch.
   final ValueWidgetBuilder<FLineCalendarItemData> builder;
 
-  final LocalDate _start;
-  final LocalDate? _end;
-  final LocalDate? _initialScroll;
-  final LocalDate _today;
-
   /// Creates a [FLineCalendar].
-  ///
-  /// [start] represents the start date, inclusive. It is truncated to the nearest date. Defaults to the
-  /// [DateTime.utc(1900)].
-  ///
-  /// [end] represents the end date, exclusive. It is truncated to the nearest date.
-  ///
-  /// [initialScroll] represents the initial date to which the line calendar is scrolled. It is aligned based on
-  /// [initialScrollAlignment]. It is truncated to the nearest date. Defaults to [today] if not provided.
-  ///
-  /// [today] represents the current date. It is truncated to the nearest date. Defaults to the [DateTime.now].
-  ///
-  /// ## Contract
-  /// Throws [AssertionError] if:
-  /// * [end] <= [start].
-  /// * [initialScroll] < [start] or [end] <= [initialScroll].
-  /// * [today] < [start] or [end] <= [today].
-  FLineCalendar({
+  const FLineCalendar({
     this.control = const .managed(),
+    this.scrollControl = const .managed(),
     this.style = const .context(),
-    this.initialScrollAlignment = .center,
     this.physics,
     this.scrollCacheExtent,
     this.keyboardDismissBehavior = .manual,
     this.builder = defaultBuilder,
-    DateTime? start,
-    DateTime? end,
-    DateTime? initialScroll,
-    DateTime? today,
     super.key,
-  }) : _start = (start ?? .utc(1900)).toLocalDate(),
-       _end = end?.toLocalDate(),
-       _initialScroll = initialScroll?.toLocalDate(),
-       _today = (today ?? .now()).toLocalDate(),
-       assert(
-         start == null || end == null || start.toLocalDate() < end.toLocalDate(),
-         'start ($start) must be < end ($end)',
-       ),
-       assert(
-         initialScroll == null ||
-             start == null ||
-             (initialScroll.toLocalDate() >= start.toLocalDate() && initialScroll.toLocalDate() < end!.toLocalDate()),
-         'initialScroll ($initialScroll) must be >= start ($start)',
-       ),
-       assert(
-         today == null ||
-             start == null ||
-             (today.toLocalDate() >= start.toLocalDate() && today.toLocalDate() < end!.toLocalDate()),
-         'today ($today) must be >= start ($start) and < end ($end)',
-       );
+  });
 
   @override
   Widget build(BuildContext context) => LayoutBuilder(
     builder: (context, constraints) => CalendarLayout(
       control: control,
+      scrollControl: scrollControl,
       style: style(context.theme.lineCalendarStyle),
       physics: physics,
       scrollCacheExtent: scrollCacheExtent,
@@ -150,12 +106,7 @@ class FLineCalendar extends StatelessWidget {
       scale: MediaQuery.textScalerOf(context),
       textStyle: DefaultTextStyle.of(context).style,
       builder: builder,
-      start: _start,
-      end: _end,
-      initialScroll: _initialScroll,
-      today: _today,
       constraints: constraints,
-      alignment: initialScrollAlignment,
     ),
   );
 
@@ -164,8 +115,8 @@ class FLineCalendar extends StatelessWidget {
     super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('control', control))
+      ..add(DiagnosticsProperty('scrollControl', scrollControl))
       ..add(DiagnosticsProperty('style', style))
-      ..add(DiagnosticsProperty('initialScrollAlignment', initialScrollAlignment))
       ..add(DiagnosticsProperty('physics', physics))
       ..add(DiagnosticsProperty('scrollCacheExtent', scrollCacheExtent))
       ..add(DiagnosticsProperty('keyboardDismissBehavior', keyboardDismissBehavior))

--- a/forui/lib/src/widgets/line_calendar/line_calendar_scroll_controller.dart
+++ b/forui/lib/src/widgets/line_calendar/line_calendar_scroll_controller.dart
@@ -1,0 +1,216 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+import 'package:sugar/sugar.dart';
+
+import 'package:forui/forui.dart';
+
+part 'line_calendar_scroll_controller.control.dart';
+
+/// A [ScrollController] that scrolls an [FLineCalendar] to a [DateTime].
+///
+/// Use [jumpToDate] and [animateToDate] to programmatically scroll the calendar.
+/// The controller must be attached to an [FLineCalendar] via
+/// [FLineCalendarScrollControl.managed] before either method is called.
+class FLineCalendarScrollController extends ScrollController {
+  /// The start date, inclusive. It is always in UTC and truncated to the nearest date. Defaults to `DateTime.utc(1900)`.
+  final DateTime start;
+
+  /// The end date, exclusive. It is always in UTC and truncated to the nearest date. Defaults to null.
+  final DateTime? end;
+
+  /// The current date. It is always in UTC and truncated to the nearest date. Defaults to [DateTime.now].
+  final DateTime today;
+
+  /// The initial date to which the calendar will be scrolled. It is always in UTC. Defaults to [today].
+  late final DateTime initialDate;
+
+  /// The alignment to which the initially scrolled date will be aligned. Defaults to [Alignment.center].
+  final AlignmentDirectional initialAlignment;
+
+  double _itemExtent;
+  double _viewport;
+
+  /// Creates a [FLineCalendarScrollController].
+  ///
+  /// ## Contract
+  /// Throws [AssertionError] if:
+  /// * [end] <= [start].
+  /// * [initialDate] < [start] or [end] <= [initialDate].
+  /// * [today] < [start] or [end] <= [today].
+  FLineCalendarScrollController({
+    this.initialAlignment = .center,
+    DateTime? start,
+    DateTime? end,
+    DateTime? today,
+    DateTime? initialDate,
+    super.keepScrollOffset = true,
+    super.debugLabel,
+  }) : start = (start ?? .utc(1900)).toLocalDate().toNative(),
+       end = end?.toLocalDate().toNative(),
+       today = (today?.toLocalDate() ?? .now()).toNative(),
+       _itemExtent = 0,
+       _viewport = 0,
+       assert(
+         start == null || end == null || start.toLocalDate() < end.toLocalDate(),
+         'start ($start) must be < end ($end)',
+       ),
+       assert(
+         initialDate == null ||
+             start == null ||
+             (initialDate.toLocalDate() >= start.toLocalDate() && initialDate.toLocalDate() < end!.toLocalDate()),
+         'initialDate ($initialDate) must be >= start ($start)',
+       ),
+       assert(
+         today == null ||
+             start == null ||
+             (today.toLocalDate() >= start.toLocalDate() && today.toLocalDate() < end!.toLocalDate()),
+         'today ($today) must be >= start ($start) and < end ($end)',
+       ) {
+    this.initialDate = initialDate?.toLocalDate().toNative() ?? this.today;
+  }
+
+  /// Animates to [date].
+  Future<void> animateToDate(
+    DateTime date, {
+    Duration duration = const Duration(milliseconds: 300),
+    Curve curve = Curves.easeOutCubic,
+    AlignmentDirectional alignment = .center,
+  }) => animateTo(_offset(date, alignment), duration: duration, curve: curve);
+
+  /// Jumps to [date] without animation.
+  void jumpToDate(DateTime date, {AlignmentDirectional alignment = .center}) => jumpTo(_offset(date, alignment));
+
+  double _offset(DateTime date, AlignmentDirectional alignment) {
+    final raw = date.toLocalDate().difference(start.toLocalDate()).inDays * _itemExtent;
+    return switch (alignment.start) {
+      -1 => raw,
+      1 => raw - position.viewportDimension + _itemExtent,
+      _ => raw - (position.viewportDimension - _itemExtent) / 2,
+    }.clamp(position.minScrollExtent, position.maxScrollExtent);
+  }
+
+  @override
+  double get initialScrollOffset {
+    if (_itemExtent == 0 || _viewport == 0) {
+      return 0;
+    }
+
+    final raw = initialDate.difference(start).inDays * _itemExtent;
+    return switch (initialAlignment.start) {
+      -1 => raw,
+      1 => raw - _viewport + _itemExtent,
+      _ => raw - (_viewport - _itemExtent) / 2,
+    };
+  }
+}
+
+@internal
+extension InternalFLineCalendarScrollController on FLineCalendarScrollController {
+  void initialize(double itemExtent, double viewport) {
+    _itemExtent = itemExtent;
+    _viewport = viewport;
+  }
+
+  double get itemExtent => _itemExtent;
+}
+
+/// A [FLineCalendarScrollControl] defines how an [FLineCalendar] is scrolled.
+///
+/// {@macro forui.foundation.doc_templates.control}
+sealed class FLineCalendarScrollControl with Diagnosticable, _$FLineCalendarScrollControlMixin {
+  /// Creates a managed [FLineCalendarScrollControl].
+  const factory FLineCalendarScrollControl.managed({
+    FLineCalendarScrollController? controller,
+    DateTime? start,
+    DateTime? end,
+    DateTime? today,
+    DateTime? initialDate,
+    AlignmentDirectional? initialAlignment,
+    ValueChanged<double>? onChange,
+  }) = FLineCalendarScrollManagedControl;
+
+  const FLineCalendarScrollControl._();
+
+  (FLineCalendarScrollController, bool) _update(
+    FLineCalendarScrollControl old,
+    FLineCalendarScrollController controller,
+    VoidCallback callback,
+  );
+}
+
+/// A [FLineCalendarScrollManagedControl] enables widgets to manage their own controller internally while exposing parameters
+/// for common configurations.
+///
+/// {@macro forui.foundation.doc_templates.managed}
+class FLineCalendarScrollManagedControl extends FLineCalendarScrollControl
+    with _$FLineCalendarScrollManagedControlMixin {
+  /// The controller.
+  @override
+  final FLineCalendarScrollController? controller;
+
+  /// The start date, inclusive. It is truncated to the nearest date. Defaults to the `DateTime.utc(1900)`.
+  @override
+  final DateTime? start;
+
+  /// The end date, exclusive. It is truncated to the nearest date. Defaults to null.
+  @override
+  final DateTime? end;
+
+  /// The current date. It is truncated to the nearest date. Defaults to the [DateTime.now].
+  @override
+  final DateTime? today;
+
+  /// The initial date to which the calendar will be scrolled. Defaults to `today`.
+  @override
+  final DateTime? initialDate;
+
+  /// The alignment to which the initially scrolled date will be aligned. Defaults to [Alignment.center].
+  @override
+  final AlignmentDirectional? initialAlignment;
+
+  /// Called when the scroll offset changes.
+  @override
+  final ValueChanged<double>? onChange;
+
+  /// Creates a [FLineCalendarScrollManagedControl].
+  ///
+  /// ## Contract
+  /// Throws [AssertionError] if [controller] is provided alongside any other parameter (except [onChange]). Pass the
+  /// other parameters to the [controller] instead.
+  const FLineCalendarScrollManagedControl({
+    this.controller,
+    this.start,
+    this.end,
+    this.today,
+    this.initialDate,
+    this.initialAlignment,
+    this.onChange,
+  }) : assert(
+         controller == null ||
+             (start == null && end == null && today == null && initialDate == null && initialAlignment == null),
+         'Cannot provide both controller and other parameters. Pass these parameters to the controller instead.',
+       ),
+       super._();
+
+  @override
+  FLineCalendarScrollController createController() =>
+      controller ??
+      FLineCalendarScrollController(
+        start: start,
+        end: end,
+        today: today,
+        initialDate: initialDate,
+        initialAlignment: initialAlignment ?? .center,
+      );
+}
+
+class _Lifted extends FLineCalendarScrollControl with _$_LiftedMixin {
+  _Lifted.lifted() : super._();
+
+  @override
+  FLineCalendarScrollController createController() => throw UnimplementedError();
+
+  @override
+  void _updateController(FLineCalendarScrollController controller) => throw UnimplementedError();
+}

--- a/forui/lib/widgets/line_calendar.dart
+++ b/forui/lib/widgets/line_calendar.dart
@@ -8,3 +8,5 @@ library forui.widgets.line_calendar;
 export '../src/widgets/line_calendar/line_calendar.dart';
 export '../src/widgets/line_calendar/line_calendar_controller.dart' hide InternalFLineCalendarControl;
 export '../src/widgets/line_calendar/line_calendar_item.dart' hide Item, ItemContent;
+export '../src/widgets/line_calendar/line_calendar_scroll_controller.dart'
+    hide InternalFLineCalendarScrollControl, InternalFLineCalendarScrollController;

--- a/forui/test/src/widgets/line_calendar/line_calendar_golden_test.dart
+++ b/forui/test/src/widgets/line_calendar/line_calendar_golden_test.dart
@@ -45,7 +45,7 @@ void main() {
           builder: (context, setState) => TestScaffold.app(
             child: FLineCalendar(
               control: .lifted(date: value, onChange: (date) => setState(() => value = date)),
-              today: DateTime(2024, 11, 28),
+              scrollControl: .managed(today: DateTime(2024, 11, 28)),
             ),
           ),
         ),
@@ -65,7 +65,7 @@ void main() {
           builder: (context, setState) => TestScaffold.app(
             child: FLineCalendar(
               control: .lifted(date: value, onChange: (_) {}),
-              today: DateTime(2024, 11, 28),
+              scrollControl: .managed(today: DateTime(2024, 11, 28)),
             ),
           ),
         ),
@@ -86,7 +86,7 @@ void main() {
             theme: theme.data,
             child: Focus(
               focusNode: focus,
-              child: FLineCalendar(today: DateTime(2024, 11, 28)),
+              child: FLineCalendar(scrollControl: .managed(today: DateTime(2024, 11, 28))),
             ),
           ),
         );
@@ -104,7 +104,7 @@ void main() {
             theme: theme.data,
             child: FLineCalendar(
               control: .managed(selectable: (d) => d.day != 19),
-              today: DateTime(2025, 12, 19),
+              scrollControl: .managed(today: DateTime(2025, 12, 19)),
             ),
           ),
         );
@@ -120,7 +120,7 @@ void main() {
               focusNode: focus,
               child: FLineCalendar(
                 control: .managed(selectable: (d) => d.day != 19),
-                today: DateTime(2025, 12, 19),
+                scrollControl: .managed(today: DateTime(2025, 12, 19)),
               ),
             ),
           ),
@@ -142,7 +142,7 @@ void main() {
             theme: theme.data,
             child: FLineCalendar(
               control: .managed(initial: DateTime(2025, 12, 19), selectable: (d) => d.day != 19),
-              today: DateTime(2025, 12, 19),
+              scrollControl: .managed(today: DateTime(2025, 12, 19)),
             ),
           ),
         );
@@ -161,7 +161,7 @@ void main() {
               focusNode: focus,
               child: FLineCalendar(
                 control: .managed(initial: DateTime(2025, 12, 19), selectable: (d) => d.day != 19),
-                today: DateTime(2025, 12, 19),
+                scrollControl: .managed(today: DateTime(2025, 12, 19)),
               ),
             ),
           ),
@@ -181,7 +181,7 @@ void main() {
         await tester.pumpWidget(
           TestScaffold(
             theme: theme.data,
-            child: FLineCalendar(today: DateTime(2024, 11, 28)),
+            child: FLineCalendar(scrollControl: .managed(today: DateTime(2024, 11, 28))),
           ),
         );
 
@@ -198,7 +198,7 @@ void main() {
         await tester.pumpWidget(
           TestScaffold(
             theme: theme.data,
-            child: FLineCalendar(today: DateTime(2024, 11, 28)),
+            child: FLineCalendar(scrollControl: .managed(today: DateTime(2024, 11, 28))),
           ),
         );
 
@@ -218,7 +218,7 @@ void main() {
             theme: theme.data,
             child: Focus(
               focusNode: focus,
-              child: FLineCalendar(today: DateTime(2024, 11, 28)),
+              child: FLineCalendar(scrollControl: .managed(today: DateTime(2024, 11, 28))),
             ),
           ),
         );
@@ -240,7 +240,7 @@ void main() {
         await tester.pumpWidget(
           TestScaffold(
             theme: theme.data,
-            child: FLineCalendar(today: DateTime(2024, 11, 28)),
+            child: FLineCalendar(scrollControl: .managed(today: DateTime(2024, 11, 28))),
           ),
         );
 
@@ -263,7 +263,7 @@ void main() {
         await tester.pumpWidget(
           TestScaffold(
             theme: theme.data,
-            child: FLineCalendar(today: DateTime(2024, 11, 28)),
+            child: FLineCalendar(scrollControl: .managed(today: DateTime(2024, 11, 28))),
           ),
         );
 
@@ -285,7 +285,7 @@ void main() {
             theme: theme.data,
             child: FLineCalendar(
               control: .managed(initial: DateTime(2024, 11, 29)),
-              today: DateTime(2024, 11, 28),
+              scrollControl: .managed(today: DateTime(2024, 11, 28)),
             ),
           ),
         );
@@ -302,7 +302,7 @@ void main() {
             theme: theme.data,
             child: FLineCalendar(
               control: .managed(initial: DateTime(2024, 11, 29), toggleable: true),
-              today: DateTime(2024, 11, 28),
+              scrollControl: .managed(today: DateTime(2024, 11, 28)),
             ),
           ),
         );
@@ -319,7 +319,7 @@ void main() {
     await tester.pumpWidget(
       TestScaffold.app(
         textDirection: .rtl,
-        child: FLineCalendar(today: DateTime(2024, 11, 28)),
+        child: FLineCalendar(scrollControl: .managed(today: DateTime(2024, 11, 28))),
       ),
     );
 
@@ -329,7 +329,9 @@ void main() {
   testWidgets('align to start', (tester) async {
     await tester.pumpWidget(
       TestScaffold.app(
-        child: FLineCalendar(initialScrollAlignment: .bottomStart, today: DateTime(2024, 11, 28)),
+        child: FLineCalendar(
+          scrollControl: .managed(initialAlignment: .bottomStart, today: DateTime(2024, 11, 28)),
+        ),
       ),
     );
 
@@ -339,7 +341,9 @@ void main() {
   testWidgets('align to end', (tester) async {
     await tester.pumpWidget(
       TestScaffold.app(
-        child: FLineCalendar(initialScrollAlignment: .bottomEnd, today: DateTime(2024, 11, 28)),
+        child: FLineCalendar(
+          scrollControl: .managed(initialAlignment: .bottomEnd, today: DateTime(2024, 11, 28)),
+        ),
       ),
     );
 
@@ -356,7 +360,7 @@ void main() {
               Positioned(top: 5, left: 5, child: Container(width: 3, height: 3, color: const Color(0xFF00FF00))),
             ],
           ),
-          today: DateTime(2024, 11, 28),
+          scrollControl: .managed(today: DateTime(2024, 11, 28)),
         ),
       ),
     );

--- a/forui/test/src/widgets/line_calendar/line_calendar_scroll_controller_test.dart
+++ b/forui/test/src/widgets/line_calendar/line_calendar_scroll_controller_test.dart
@@ -1,0 +1,192 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:forui/forui.dart';
+import '../../test_scaffold.dart';
+
+void main() {
+  // Use a fixed date range so offset math is deterministic.
+  final start = DateTime.utc(2024);
+  final end = DateTime.utc(2025);
+  final today = DateTime.utc(2024, 11, 28);
+  // The widget's full constraint width in the TestScaffold; the calendar fills the available width.
+  // We pump with a SizedBox so we know the viewport.
+  const viewport = 400.0;
+
+  Future<({double itemExtent, double viewport})> pumpCalendar(
+    WidgetTester tester, {
+    FLineCalendarScrollController? controller,
+    AlignmentDirectional initialAlignment = .center,
+    DateTime? initialDate,
+  }) async {
+    await tester.pumpWidget(
+      TestScaffold(
+        padded: false,
+        child: SizedBox(
+          width: viewport,
+          child: FLineCalendar(
+            scrollControl: controller == null
+                ? .managed(
+                    start: start,
+                    end: end,
+                    today: today,
+                    initialAlignment: initialAlignment,
+                    initialDate: initialDate,
+                  )
+                : .managed(controller: controller),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final list = tester.widget<ListView>(find.byType(ListView));
+    return (itemExtent: list.itemExtent!, viewport: viewport);
+  }
+
+  double expectedOffset({
+    required DateTime start,
+    required DateTime target,
+    required double itemExtent,
+    required double viewport,
+    required AlignmentDirectional alignment,
+    required double maxScrollExtent,
+  }) {
+    final raw = target.difference(start).inDays * itemExtent;
+    final unclamped = switch (alignment.start) {
+      -1 => raw,
+      1 => raw - viewport + itemExtent,
+      _ => raw - (viewport - itemExtent) / 2,
+    };
+    return unclamped.clamp(0.0, maxScrollExtent);
+  }
+
+  group('FLineCalendarScrollController', () {
+    testWidgets('throws assertion when used before being attached', (tester) async {
+      final controller = autoDispose(FLineCalendarScrollController());
+      expect(() => controller.jumpToDate(today), throwsA(isA<AssertionError>()));
+    });
+
+    for (final (alignment, name) in [
+      (AlignmentDirectional.centerStart, 'start'),
+      (AlignmentDirectional.center, 'center'),
+      (AlignmentDirectional.centerEnd, 'end'),
+    ]) {
+      testWidgets('jumpToDate aligns $name', (tester) async {
+        final controller = autoDispose(FLineCalendarScrollController(start: start, end: end, today: today));
+        final dims = await pumpCalendar(tester, controller: controller);
+
+        final target = DateTime.utc(2024, 6, 15);
+        controller.jumpToDate(target, alignment: alignment);
+        await tester.pump();
+
+        final expected = expectedOffset(
+          start: start,
+          target: target,
+          itemExtent: dims.itemExtent,
+          viewport: dims.viewport,
+          alignment: alignment,
+          maxScrollExtent: controller.position.maxScrollExtent,
+        );
+        expect(controller.position.pixels, expected);
+      });
+
+      testWidgets('animateToDate aligns $name', (tester) async {
+        final controller = autoDispose(FLineCalendarScrollController(start: start, end: end, today: today));
+        final dims = await pumpCalendar(tester, controller: controller);
+
+        final target = DateTime.utc(2024, 8);
+        unawaited(
+          controller.animateToDate(
+            target,
+            duration: const Duration(milliseconds: 200),
+            curve: Curves.linear,
+            alignment: alignment,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final expected = expectedOffset(
+          start: start,
+          target: target,
+          itemExtent: dims.itemExtent,
+          viewport: dims.viewport,
+          alignment: alignment,
+          maxScrollExtent: controller.position.maxScrollExtent,
+        );
+        expect(controller.position.pixels, expected);
+      });
+    }
+
+    testWidgets('jumpToDate clamps below minScrollExtent', (tester) async {
+      final controller = autoDispose(FLineCalendarScrollController(start: start, end: end, today: today));
+      await pumpCalendar(tester, controller: controller);
+
+      controller.jumpToDate(start);
+      await tester.pump();
+      expect(controller.position.pixels, controller.position.minScrollExtent);
+    });
+
+    testWidgets('initialDate honored when no user controller', (tester) async {
+      final dims = await pumpCalendar(tester, initialDate: DateTime.utc(2024, 7, 4));
+
+      final list = tester.widget<ListView>(find.byType(ListView));
+      final controller = list.controller!;
+
+      final expected = expectedOffset(
+        start: start,
+        target: DateTime.utc(2024, 7, 4),
+        itemExtent: dims.itemExtent,
+        viewport: dims.viewport,
+        alignment: AlignmentDirectional.center,
+        maxScrollExtent: controller.position.maxScrollExtent,
+      );
+      expect(controller.position.pixels, expected);
+    });
+
+    testWidgets('swapping controller updates start', (tester) async {
+      final first = autoDispose(FLineCalendarScrollController(start: start, end: end, today: today));
+
+      await tester.pumpWidget(
+        TestScaffold(
+          padded: false,
+          child: SizedBox(
+            width: viewport,
+            child: FLineCalendar(scrollControl: .managed(controller: first)),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final newStart = DateTime.utc(2024, 6);
+      final second = autoDispose(FLineCalendarScrollController(start: newStart, end: end, today: today));
+      await tester.pumpWidget(
+        TestScaffold(
+          padded: false,
+          child: SizedBox(
+            width: viewport,
+            child: FLineCalendar(scrollControl: .managed(controller: second)),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final list = tester.widget<ListView>(find.byType(ListView));
+      final itemExtent = list.itemExtent!;
+
+      final target = DateTime.utc(2024, 7);
+      second.jumpToDate(target, alignment: .centerStart);
+      await tester.pump();
+
+      // Offset should be measured from the NEW start.
+      final expected = (target.difference(newStart).inDays * itemExtent).clamp(
+        second.position.minScrollExtent,
+        second.position.maxScrollExtent,
+      );
+      expect(second.position.pixels, expected);
+    });
+  });
+}

--- a/forui_hooks/CHANGELOG.md
+++ b/forui_hooks/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.22.0 (Next)
+
+### `FLineCalendar`
+* Add `useFLineCalendarScrollController(...)`.
+
+
 ## 0.21.0
 * **Breaking** Remove `useFPopoverController(motion: ...)`. Configure motion via `FPopoverStyle` instead.
 * **Breaking** Remove `useFTooltipController(motion: ...)`. Configure motion via `FTooltipStyle` instead.

--- a/forui_hooks/lib/forui_hooks.dart
+++ b/forui_hooks/lib/forui_hooks.dart
@@ -2,6 +2,7 @@ export '/src/accordion_controller_hook.dart';
 export '/src/autocomplete_controller_hook.dart';
 export '/src/calendar_controller_hook.dart';
 export '/src/date_field_controller_hook.dart';
+export '/src/line_calendar_scroll_controller_hook.dart';
 export '/src/multi_value_notifier_hook.dart';
 export '/src/pagination_controller_hook.dart';
 export '/src/picker_controller_hook.dart';

--- a/forui_hooks/lib/src/line_calendar_scroll_controller_hook.dart
+++ b/forui_hooks/lib/src/line_calendar_scroll_controller_hook.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:forui/forui.dart';
+
+/// Creates a [FLineCalendarScrollController] that is automatically disposed.
+FLineCalendarScrollController useFLineCalendarScrollController({
+  DateTime? start,
+  DateTime? end,
+  DateTime? today,
+  DateTime? initialDate,
+  AlignmentDirectional initialAlignment = .center,
+  bool keepScrollOffset = true,
+  String? debugLabel,
+  List<Object?>? keys,
+}) => use(
+  _LineCalendarScrollControllerHook(
+    start: start,
+    end: end,
+    today: today,
+    initialDate: initialDate,
+    initialAlignment: initialAlignment,
+    keepScrollOffset: keepScrollOffset,
+    debugLabel: debugLabel,
+    keys: keys,
+  ),
+);
+
+class _LineCalendarScrollControllerHook extends Hook<FLineCalendarScrollController> {
+  final DateTime? start;
+  final DateTime? end;
+  final DateTime? today;
+  final DateTime? initialDate;
+  final AlignmentDirectional initialAlignment;
+  final bool keepScrollOffset;
+  final String? debugLabel;
+
+  const _LineCalendarScrollControllerHook({
+    required this.start,
+    required this.end,
+    required this.today,
+    required this.initialDate,
+    required this.initialAlignment,
+    required this.keepScrollOffset,
+    required this.debugLabel,
+    super.keys,
+  });
+
+  @override
+  _LineCalendarScrollControllerHookState createState() => .new();
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('start', start))
+      ..add(DiagnosticsProperty('end', end))
+      ..add(DiagnosticsProperty('today', today))
+      ..add(DiagnosticsProperty('initialDate', initialDate))
+      ..add(DiagnosticsProperty('initialAlignment', initialAlignment))
+      ..add(FlagProperty('keepScrollOffset', value: keepScrollOffset, ifTrue: 'keepScrollOffset'))
+      ..add(StringProperty('debugLabel', debugLabel));
+  }
+}
+
+class _LineCalendarScrollControllerHookState
+    extends HookState<FLineCalendarScrollController, _LineCalendarScrollControllerHook> {
+  late final _controller = FLineCalendarScrollController(
+    start: hook.start,
+    end: hook.end,
+    today: hook.today,
+    initialDate: hook.initialDate,
+    initialAlignment: hook.initialAlignment,
+    keepScrollOffset: hook.keepScrollOffset,
+    debugLabel: hook.debugLabel,
+  );
+
+  @override
+  FLineCalendarScrollController build(BuildContext context) => _controller;
+
+  @override
+  void dispose() => _controller.dispose();
+
+  @override
+  bool get debugHasShortDescription => false;
+
+  @override
+  String get debugLabel => 'useFLineCalendarScrollController';
+}

--- a/forui_hooks/test/src/line_calendar_scroll_controller_hook_test.dart
+++ b/forui_hooks/test/src/line_calendar_scroll_controller_hook_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:forui/forui.dart';
+
+import 'package:forui_hooks/forui_hooks.dart';
+
+void main() {
+  testWidgets('useFLineCalendarScrollController', (tester) async {
+    late FLineCalendarScrollController controller;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: HookBuilder(
+          builder: (context) {
+            controller = useFLineCalendarScrollController(
+              start: DateTime.utc(2024),
+              end: DateTime.utc(2026),
+              today: DateTime.utc(2025, 6, 15),
+            );
+            return SizedBox(
+              width: 400,
+              child: FLineCalendar(scrollControl: .managed(controller: controller)),
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    controller.jumpToDate(DateTime.utc(2025, 6, 15));
+    await tester.pumpAndSettle();
+  });
+}


### PR DESCRIPTION
**Describe the changes**

Introduces `FLineCalendarScrollController` for programmatic date scrolling via `jumpToDate(...)` and `animateToDate(...)`. The controller now owns the calendar's date config (`start`, `end`, `today`, `initialDate`, `initialAlignment`); `FLineCalendarScrollControl.managed(...)` forwards these into a new internal controller when none is supplied and adds an `onChange` callback fired on every scroll offset change.

* The date/alignment params (`start`, `end`, `today`, `initialScroll`, `initialScrollAlignment`) move off `FLineCalendar` and onto `FLineCalendarScrollControl.managed(...)`; `initialScroll` is renamed to `initialDate` and `initialScrollAlignment` to `initialAlignment`.
* Initial scroll offset is now derived inside the controller (overriding `initialScrollOffset`) using internal `itemExtent` / `viewport` cached via the `@internal InternalFLineCalendarScrollController.initialize(...)` extension.
* Date inputs are truncated via `toLocalDate().toNative()` so all stored values are UTC midnight; the contract assertions live on the controller.
* `animateToDate` defaults to `Duration(milliseconds: 300)` / `Curves.easeOutCubic`, matching `FPickerController`.
* Data-driven fixes added for the migration (`dart fix --apply` lifts old params into `scrollControl: .managed(...)` across all 31 combinations).
* Sandbox extended with an interactive viewport-width slider, alignment toggle, and live offset readout to exercise alignment + clamping.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [x] I have included the relevant samples.
- [x] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)