### PR TITLE
Fix broken widget previews after docs reorganization

### DIFF
--- a/docs/content/docs/widgets/data/accordion.mdx
+++ b/docs/content/docs/widgets/data/accordion.mdx
@@ -15,7 +15,7 @@ import accordionItemUsage from '@/snippets/usages/data/accordion/accordionItem.j
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='accordion' height={700}/>
+        <Widget name='data/accordion' height={700}/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={defaultSnippet} />
@@ -49,7 +49,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='accordion' variant='max' height={600}/>
+        <Widget name='data/accordion' variant='max' height={600}/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={maxSnippet} />

--- a/docs/content/docs/widgets/data/avatar.mdx
+++ b/docs/content/docs/widgets/data/avatar.mdx
@@ -16,7 +16,7 @@ import avatarRawUsage from '@/snippets/usages/data/avatar/raw.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-      <Widget name='avatar'/>
+      <Widget name='data/avatar'/>
   </Tab>
   <Tab value="Code">
       <CodeSnippet snippet={defaultSnippet} />
@@ -49,7 +49,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='avatar' variant='raw'/>
+        <Widget name='data/avatar' variant='raw'/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={rawSnippet} />
@@ -60,7 +60,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='avatar' variant='invalid'/>
+        <Widget name='data/avatar' variant='invalid'/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={invalidSnippet} />

--- a/docs/content/docs/widgets/data/badge.mdx
+++ b/docs/content/docs/widgets/data/badge.mdx
@@ -17,7 +17,7 @@ import badgeRawUsage from '@/snippets/usages/data/badge/raw.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-      <Widget name='badge' variant='primary'/>
+      <Widget name='data/badge' variant='primary'/>
   </Tab>
   <Tab value="Code">
       <CodeSnippet snippet={primarySnippet} />
@@ -50,7 +50,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-      <Widget name='badge' variant='primary'/>
+      <Widget name='data/badge' variant='primary'/>
   </Tab>
   <Tab value="Code">
       <CodeSnippet snippet={primarySnippet} />
@@ -61,7 +61,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-      <Widget name='badge' variant='secondary'/>
+      <Widget name='data/badge' variant='secondary'/>
   </Tab>
   <Tab value="Code">
       <CodeSnippet snippet={secondarySnippet} />
@@ -72,7 +72,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-      <Widget name='badge' variant='outline'/>
+      <Widget name='data/badge' variant='outline'/>
   </Tab>
   <Tab value="Code">
       <CodeSnippet snippet={outlineSnippet} />
@@ -83,7 +83,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-      <Widget name='badge' variant='destructive'/>
+      <Widget name='data/badge' variant='destructive'/>
   </Tab>
   <Tab value="Code">
       <CodeSnippet snippet={destructiveSnippet} />

--- a/docs/content/docs/widgets/data/calendar.mdx
+++ b/docs/content/docs/widgets/data/calendar.mdx
@@ -30,7 +30,7 @@ controls the date selection behavior, including single date, multiple dates, and
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='calendar' height={500}/>
+        <Widget name='data/calendar' height={500}/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={defaultSnippet} />
@@ -70,7 +70,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='calendar' height={500}/>
+        <Widget name='data/calendar' height={500}/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={defaultSnippet} />
@@ -81,7 +81,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='calendar' variant='dates' height={500}/>
+        <Widget name='data/calendar' variant='dates' height={500}/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={datesSnippet} />
@@ -92,7 +92,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='calendar' variant='unselectable' height={500}/>
+        <Widget name='data/calendar' variant='unselectable' height={500}/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={unselectableSnippet} />
@@ -103,7 +103,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='calendar' variant='range' height={500}/>
+        <Widget name='data/calendar' variant='range' height={500}/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={rangeSnippet} />

--- a/docs/content/docs/widgets/data/card.mdx
+++ b/docs/content/docs/widgets/data/card.mdx
@@ -14,7 +14,7 @@ import cardRawUsage from '@/snippets/usages/data/card/raw.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-      <Widget name='card' height={400}/>
+      <Widget name='data/card' height={400}/>
   </Tab>
   <Tab value="Code">
       <CodeSnippet snippet={defaultSnippet} />

--- a/docs/content/docs/widgets/data/item-group.mdx
+++ b/docs/content/docs/widgets/data/item-group.mdx
@@ -25,7 +25,7 @@ import itemGroupMergeUsage from '@/snippets/usages/data/item_group/merge.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='item-group'/>
+    <Widget name='data/item-group'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -78,7 +78,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='item-group' variant='scrollable' height={200}/>
+    <Widget name='data/item-group' variant='scrollable' height={200}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={scrollableSnippet} />
@@ -89,7 +89,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='item-group' variant='lazy' height={300}/>
+    <Widget name='data/item-group' variant='lazy' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={lazySnippet} />
@@ -103,7 +103,7 @@ several sections.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='item-group' variant='merge' height={300}/>
+    <Widget name='data/item-group' variant='merge' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={mergeSnippet} />
@@ -116,7 +116,7 @@ several sections.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='item-group' variant='full'/>
+    <Widget name='data/item-group' variant='full'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={fullSnippet} />
@@ -127,7 +127,7 @@ several sections.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='item-group' variant='indented'/>
+    <Widget name='data/item-group' variant='indented'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={indentedSnippet} />

--- a/docs/content/docs/widgets/data/item.mdx
+++ b/docs/content/docs/widgets/data/item.mdx
@@ -24,7 +24,7 @@ import itemRawUsage from '@/snippets/usages/data/item/raw.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='item'/>
+    <Widget name='data/item'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -67,7 +67,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='item' variant='destructive'/>
+    <Widget name='data/item' variant='destructive'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={destructiveSnippet} />
@@ -78,7 +78,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='item' variant='untappable'/>
+    <Widget name='data/item' variant='untappable'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={untappableSnippet} />
@@ -89,7 +89,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='item' variant='disabled'/>
+    <Widget name='data/item' variant='disabled'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={disabledSnippet} />
@@ -100,7 +100,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='item' variant='subtitle'/>
+    <Widget name='data/item' variant='subtitle'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={subtitleSnippet} />
@@ -111,7 +111,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='item' variant='details'/>
+    <Widget name='data/item' variant='details'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={detailsSnippet} />

--- a/docs/content/docs/widgets/data/line-calendar.mdx
+++ b/docs/content/docs/widgets/data/line-calendar.mdx
@@ -18,7 +18,7 @@ import lineCalendarUsage from '@/snippets/usages/data/line_calendar/lineCalendar
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='line-calendar' height={200}/>
+        <Widget name='data/line-calendar' height={200}/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={defaultSnippet} />

--- a/docs/content/docs/widgets/feedback/alert.mdx
+++ b/docs/content/docs/widgets/feedback/alert.mdx
@@ -14,7 +14,7 @@ import alertUsage from '@/snippets/usages/feedback/alert/alert.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='alert' variant='primary'/>
+    <Widget name='feedback/alert' variant='primary'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={primarySnippet} />
@@ -44,7 +44,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='alert' variant='primary'/>
+    <Widget name='feedback/alert' variant='primary'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={primarySnippet} />
@@ -55,7 +55,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='alert' variant='destructive'/>
+    <Widget name='feedback/alert' variant='destructive'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={destructiveSnippet} />

--- a/docs/content/docs/widgets/feedback/circular-progress.mdx
+++ b/docs/content/docs/widgets/feedback/circular-progress.mdx
@@ -15,7 +15,7 @@ import circularProgressPinwheelUsage from '@/snippets/usages/feedback/progress/c
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='progress' variant='circular'/>
+    <Widget name='feedback/progress' variant='circular'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={circularSnippet} />

--- a/docs/content/docs/widgets/feedback/determinate-progress.mdx
+++ b/docs/content/docs/widgets/feedback/determinate-progress.mdx
@@ -13,7 +13,7 @@ import determinateProgressUsage from '@/snippets/usages/feedback/progress/determ
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='progress' variant='determinate'/>
+    <Widget name='feedback/progress' variant='determinate'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={determinateSnippet} />

--- a/docs/content/docs/widgets/feedback/progress.mdx
+++ b/docs/content/docs/widgets/feedback/progress.mdx
@@ -13,7 +13,7 @@ import progressUsage from '@/snippets/usages/feedback/progress/progress.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='progress'/>
+    <Widget name='feedback/progress'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />

--- a/docs/content/docs/widgets/form/autocomplete.mdx
+++ b/docs/content/docs/widgets/form/autocomplete.mdx
@@ -33,7 +33,7 @@ import formSnippet from '@/snippets/examples/form/autocomplete/form.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='autocomplete' height={400}/>
+    <Widget name='form/autocomplete' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -92,7 +92,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='autocomplete' variant='detailed' height={400}/>
+    <Widget name='form/autocomplete' variant='detailed' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={detailedSnippet} />
@@ -103,7 +103,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='autocomplete' variant='section' height={400}/>
+    <Widget name='form/autocomplete' variant='section' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={sectionSnippet} />
@@ -114,7 +114,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='autocomplete' variant='divider' height={400}/>
+    <Widget name='form/autocomplete' variant='divider' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={dividerSnippet} />
@@ -127,7 +127,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='autocomplete' variant='async' height={400}/>
+    <Widget name='form/autocomplete' variant='async' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={asyncSnippet} />
@@ -138,7 +138,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='autocomplete' variant='async-loading' height={400}/>
+    <Widget name='form/autocomplete' variant='async-loading' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={asyncLoadingSnippet} />
@@ -149,7 +149,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='autocomplete' variant='async-error' height={400}/>
+    <Widget name='form/autocomplete' variant='async-error' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={asyncErrorSnippet} />
@@ -160,7 +160,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='autocomplete' variant='clearable' height={400}/>
+    <Widget name='form/autocomplete' variant='clearable' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={clearableSnippet} />
@@ -171,7 +171,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='autocomplete' variant='popover-builder' height={400}/>
+    <Widget name='form/autocomplete' variant='popover-builder' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={popoverBuilderSnippet} />
@@ -182,7 +182,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='autocomplete' variant='form' height={400}/>
+    <Widget name='form/autocomplete' variant='form' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={formSnippet} />

--- a/docs/content/docs/widgets/form/button.mdx
+++ b/docs/content/docs/widgets/form/button.mdx
@@ -24,7 +24,7 @@ import buttonRawUsage from '@/snippets/usages/form/button/raw.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='button' variant='primary'/>
+    <Widget name='form/button' variant='primary'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={primarySnippet} />
@@ -72,7 +72,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='button' variant='primary'/>
+    <Widget name='form/button' variant='primary'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={primarySnippet} />
@@ -83,7 +83,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='button' variant='secondary'/>
+    <Widget name='form/button' variant='secondary'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={secondarySnippet} />
@@ -94,7 +94,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='button' variant='destructive'/>
+    <Widget name='form/button' variant='destructive'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={destructiveSnippet} />
@@ -105,7 +105,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='button' variant='outline'/>
+    <Widget name='form/button' variant='outline'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={outlineSnippet} />
@@ -116,7 +116,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='button' variant='ghost'/>
+    <Widget name='form/button' variant='ghost'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={ghostSnippet} />
@@ -127,7 +127,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='button' variant='sizes'/>
+    <Widget name='form/button' variant='sizes'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={sizesSnippet} />
@@ -138,7 +138,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='button' variant='toggle'/>
+        <Widget name='form/button' variant='toggle'/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={toggleSnippet} />
@@ -151,7 +151,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='button' variant='icon'/>
+    <Widget name='form/button' variant='icon'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={iconSnippet} />
@@ -162,7 +162,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='button' variant='only-icon'/>
+    <Widget name='form/button' variant='only-icon'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={onlyIconSnippet} />
@@ -173,7 +173,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='button' variant='circular-progress'/>
+    <Widget name='form/button' variant='circular-progress'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={circularProgressSnippet} />

--- a/docs/content/docs/widgets/form/checkbox.mdx
+++ b/docs/content/docs/widgets/form/checkbox.mdx
@@ -27,7 +27,7 @@ import checkboxUsage from '@/snippets/usages/form/checkbox/checkbox.json';
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='checkbox'/>
+        <Widget name='form/checkbox'/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={defaultSnippet} />
@@ -58,7 +58,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='checkbox' variant='leading-label'/>
+    <Widget name='form/checkbox' variant='leading-label'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={leadingLabelSnippet} />
@@ -69,7 +69,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='checkbox' variant='disabled'/>
+    <Widget name='form/checkbox' variant='disabled'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={disabledSnippet} />
@@ -80,7 +80,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='checkbox' variant='error'/>
+    <Widget name='form/checkbox' variant='error'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={errorSnippet} />
@@ -91,7 +91,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='checkbox' variant='raw'/>
+        <Widget name='form/checkbox' variant='raw'/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={rawSnippet} />
@@ -103,7 +103,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='checkbox' variant='form' height={550}/>
+    <Widget name='form/checkbox' variant='form' height={550}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={formSnippet} />

--- a/docs/content/docs/widgets/form/date-field.mdx
+++ b/docs/content/docs/widgets/form/date-field.mdx
@@ -44,7 +44,7 @@ The input field does not support the following locales that use non-western nume
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='date-field' height={500}/>
+        <Widget name='form/date-field' height={500}/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={defaultSnippet} />
@@ -80,7 +80,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='date-field' variant='calendar' height={500}/>
+        <Widget name='form/date-field' variant='calendar' height={500}/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={calendarSnippet} />
@@ -91,7 +91,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='date-field' variant='input'/>
+        <Widget name='form/date-field' variant='input'/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={inputSnippet} />
@@ -102,7 +102,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='date-field' variant='clearable' height={500}/>
+        <Widget name='form/date-field' variant='clearable' height={500}/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={clearableSnippet} />
@@ -114,7 +114,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='date-field' variant='popover-builder' height={500}/>
+        <Widget name='form/date-field' variant='popover-builder' height={500}/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={popoverBuilderSnippet} />
@@ -125,7 +125,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='date-field' variant='validator' height={500}/>
+        <Widget name='form/date-field' variant='validator' height={500}/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={validatorSnippet} />
@@ -137,7 +137,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='date-field' variant='form' height={600}/>
+        <Widget name='form/date-field' variant='form' height={600}/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={formSnippet} />

--- a/docs/content/docs/widgets/form/date-time-picker.mdx
+++ b/docs/content/docs/widgets/form/date-time-picker.mdx
@@ -22,7 +22,7 @@ Recommended for touch devices.
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='date-time-picker'/>
+        <Widget name='form/date-time-picker'/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={defaultSnippet} />
@@ -52,7 +52,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='date-time-picker' variant='hour24'/>
+        <Widget name='form/date-time-picker' variant='hour24'/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={hour24Snippet} />
@@ -64,7 +64,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='date-time-picker' variant='interval'/>
+        <Widget name='form/date-time-picker' variant='interval'/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={intervalSnippet} />

--- a/docs/content/docs/widgets/form/label.mdx
+++ b/docs/content/docs/widgets/form/label.mdx
@@ -16,7 +16,7 @@ import labelUsage from '@/snippets/usages/form/label/label.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='label' variant='horizontal'/>
+    <Widget name='form/label' variant='horizontal'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={horizontalSnippet} />
@@ -51,7 +51,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='label' variant='vertical'/>
+        <Widget name='form/label' variant='vertical'/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={verticalSnippet} />
@@ -62,7 +62,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='label' variant='disabled'/>
+    <Widget name='form/label' variant='disabled'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={disabledSnippet} />
@@ -73,7 +73,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='label' variant='error'/>
+    <Widget name='form/label' variant='error'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={errorSnippet} />

--- a/docs/content/docs/widgets/form/multi-select.mdx
+++ b/docs/content/docs/widgets/form/multi-select.mdx
@@ -38,7 +38,7 @@ import formSnippet from '@/snippets/examples/form/multi-select/form.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='multi-select' height={400}/>
+    <Widget name='form/multi-select' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -92,7 +92,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='multi-select' variant='detailed' height={400}/>
+    <Widget name='form/multi-select' variant='detailed' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={detailedSnippet} />
@@ -103,7 +103,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='multi-select' variant='section' height={400}/>
+    <Widget name='form/multi-select' variant='section' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={sectionSnippet} />
@@ -114,7 +114,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='multi-select' variant='divider' height={400}/>
+    <Widget name='form/multi-select' variant='divider' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={dividerSnippet} />
@@ -127,7 +127,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='multi-select' variant='sync' height={400}/>
+    <Widget name='form/multi-select' variant='sync' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={syncSnippet} />
@@ -138,7 +138,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='multi-select' variant='async' height={400}/>
+    <Widget name='form/multi-select' variant='async' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={asyncSnippet} />
@@ -149,7 +149,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='multi-select' variant='async-loading' height={400}/>
+    <Widget name='form/multi-select' variant='async-loading' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={asyncLoadingSnippet} />
@@ -160,7 +160,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='multi-select' variant='async-error' height={400}/>
+    <Widget name='form/multi-select' variant='async-error' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={asyncErrorSnippet} />
@@ -173,7 +173,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='multi-select' variant='clearable' height={400}/>
+    <Widget name='form/multi-select' variant='clearable' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={clearableSnippet} />
@@ -184,7 +184,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='multi-select' variant='format' height={400}/>
+    <Widget name='form/multi-select' variant='format' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={formatSnippet} />
@@ -195,7 +195,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='multi-select' variant='min-max' height={400}/>
+    <Widget name='form/multi-select' variant='min-max' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={minMaxSnippet} />
@@ -206,7 +206,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='multi-select' variant='sorted' height={400}/>
+    <Widget name='form/multi-select' variant='sorted' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={sortedSnippet} />
@@ -217,7 +217,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='multi-select' variant='popover-builder' height={400}/>
+    <Widget name='form/multi-select' variant='popover-builder' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={popoverBuilderSnippet} />
@@ -228,7 +228,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='multi-select' variant='form' height={400}/>
+    <Widget name='form/multi-select' variant='form' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={formSnippet} />

--- a/docs/content/docs/widgets/form/otp-field.mdx
+++ b/docs/content/docs/widgets/form/otp-field.mdx
@@ -15,7 +15,7 @@ import otpFieldUsage from '@/snippets/usages/form/otp_field/otpField.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='otp-field'/>
+    <Widget name='form/otp-field'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -45,7 +45,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='otp-field' variant='divider'/>
+    <Widget name='form/otp-field' variant='divider'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={dividerSnippet} />
@@ -56,7 +56,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='otp-field' variant='no-formatter'/>
+    <Widget name='form/otp-field' variant='no-formatter'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={noFormatterSnippet} />

--- a/docs/content/docs/widgets/form/picker.mdx
+++ b/docs/content/docs/widgets/form/picker.mdx
@@ -26,7 +26,7 @@ Recommended for touch devices.
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='picker'/>
+        <Widget name='form/picker'/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={defaultSnippet} />
@@ -62,7 +62,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='picker' variant='loop'/>
+        <Widget name='form/picker' variant='loop'/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={loopSnippet} />
@@ -73,7 +73,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='picker' variant='builder'/>
+        <Widget name='form/picker' variant='builder'/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={builderSnippet} />
@@ -84,7 +84,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='picker' variant='multiple'/>
+        <Widget name='form/picker' variant='multiple'/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={multipleSnippet} />
@@ -95,7 +95,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='picker' variant='separator'/>
+        <Widget name='form/picker' variant='separator'/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={separatorSnippet} />

--- a/docs/content/docs/widgets/form/radio.mdx
+++ b/docs/content/docs/widgets/form/radio.mdx
@@ -19,7 +19,7 @@ import radioUsage from '@/snippets/usages/form/radio/radio.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='radio'/>
+    <Widget name='form/radio'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -49,7 +49,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='radio' variant='leading-label'/>
+    <Widget name='form/radio' variant='leading-label'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={leadingLabelSnippet} />

--- a/docs/content/docs/widgets/form/select-group.mdx
+++ b/docs/content/docs/widgets/form/select-group.mdx
@@ -23,7 +23,7 @@ import radioFormSnippet from '@/snippets/examples/form/select-group/radio-form.j
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select-group' height={300}/>
+    <Widget name='form/select-group' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -59,7 +59,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='select-group' variant='checkbox-form' height={400}/>
+        <Widget name='form/select-group' variant='checkbox-form' height={400}/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={checkboxFormSnippet} />
@@ -71,7 +71,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select-group' variant='radio-form' height={400}/>
+    <Widget name='form/select-group' variant='radio-form' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={radioFormSnippet} />

--- a/docs/content/docs/widgets/form/select.mdx
+++ b/docs/content/docs/widgets/form/select.mdx
@@ -36,7 +36,7 @@ import formSnippet from '@/snippets/examples/form/select/form.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select' height={400}/>
+    <Widget name='form/select' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -95,7 +95,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select' variant='detailed' height={400}/>
+    <Widget name='form/select' variant='detailed' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={detailedSnippet} />
@@ -106,7 +106,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select' variant='section' height={400}/>
+    <Widget name='form/select' variant='section' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={sectionSnippet} />
@@ -117,7 +117,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select' variant='divider' height={400}/>
+    <Widget name='form/select' variant='divider' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={dividerSnippet} />
@@ -130,7 +130,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select' variant='sync' height={400}/>
+    <Widget name='form/select' variant='sync' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={syncSnippet} />
@@ -141,7 +141,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select' variant='async' height={400}/>
+    <Widget name='form/select' variant='async' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={asyncSnippet} />
@@ -152,7 +152,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select' variant='async-loading' height={400}/>
+    <Widget name='form/select' variant='async-loading' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={asyncLoadingSnippet} />
@@ -163,7 +163,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select' variant='async-error' height={400}/>
+    <Widget name='form/select' variant='async-error' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={asyncErrorSnippet} />
@@ -176,7 +176,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select' variant='toggleable' height={400}/>
+    <Widget name='form/select' variant='toggleable' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={toggleableSnippet} />
@@ -187,7 +187,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select' variant='clearable' height={400}/>
+    <Widget name='form/select' variant='clearable' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={clearableSnippet} />
@@ -198,7 +198,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select' variant='popover-builder' height={400}/>
+    <Widget name='form/select' variant='popover-builder' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={popoverBuilderSnippet} />
@@ -209,7 +209,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select' variant='format' height={400}/>
+    <Widget name='form/select' variant='format' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={formatSnippet} />
@@ -220,7 +220,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select' variant='form' height={400}/>
+    <Widget name='form/select' variant='form' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={formSnippet} />

--- a/docs/content/docs/widgets/form/slider.mdx
+++ b/docs/content/docs/widgets/form/slider.mdx
@@ -28,7 +28,7 @@ import sliderMarkUsage from '@/snippets/usages/form/slider/sliderMark.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='slider'/>
+    <Widget name='form/slider'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -68,7 +68,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='slider' variant='labelled'/>
+    <Widget name='form/slider' variant='labelled'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={labelledSnippet} />
@@ -79,7 +79,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='slider' variant='disabled'/>
+    <Widget name='form/slider' variant='disabled'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={disabledSnippet} />
@@ -90,7 +90,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='slider' variant='error'/>
+    <Widget name='form/slider' variant='error'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={errorSnippet} />
@@ -101,7 +101,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='slider' variant='tooltip'/>
+    <Widget name='form/slider' variant='tooltip'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={tooltipSnippet} />
@@ -117,7 +117,7 @@ Marks provide visual reference points on the slider track. Each mark consists of
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='slider' variant='marks'/>
+    <Widget name='form/slider' variant='marks'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={marksSnippet} />
@@ -130,7 +130,7 @@ Marks provide visual reference points on the slider track. Each mark consists of
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='slider' variant='discrete'/>
+    <Widget name='form/slider' variant='discrete'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={discreteSnippet} />
@@ -141,7 +141,7 @@ Marks provide visual reference points on the slider track. Each mark consists of
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='slider' variant='range'/>
+    <Widget name='form/slider' variant='range'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={rangeSnippet} />
@@ -152,7 +152,7 @@ Marks provide visual reference points on the slider track. Each mark consists of
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='slider' variant='boundaries'/>
+    <Widget name='form/slider' variant='boundaries'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={boundariesSnippet} />
@@ -163,7 +163,7 @@ Marks provide visual reference points on the slider track. Each mark consists of
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='slider' variant='vertical' height={500}/>
+    <Widget name='form/slider' variant='vertical' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={verticalSnippet} />
@@ -178,7 +178,7 @@ Slide anywhere on the track or thumb to select a value.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='slider' variant='slide'/>
+    <Widget name='form/slider' variant='slide'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={slideSnippet} />
@@ -191,7 +191,7 @@ Slide the thumb to select a value.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='slider' variant='slide-thumb'/>
+    <Widget name='form/slider' variant='slide-thumb'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={slideThumbSnippet} />
@@ -204,7 +204,7 @@ Tap anywhere on the track to select a value.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='slider' variant='tap'/>
+    <Widget name='form/slider' variant='tap'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={tapSnippet} />
@@ -217,7 +217,7 @@ Tap anywhere or slide the thumb to select a value.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='slider' variant='tap-and-slide-thumb'/>
+    <Widget name='form/slider' variant='tap-and-slide-thumb'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={tapAndSlideThumbSnippet} />
@@ -228,7 +228,7 @@ Tap anywhere or slide the thumb to select a value.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='slider' variant='form' height='500'/>
+    <Widget name='form/slider' variant='form' height='500'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={formSnippet} />

--- a/docs/content/docs/widgets/form/switch.mdx
+++ b/docs/content/docs/widgets/form/switch.mdx
@@ -16,7 +16,7 @@ import switchUsage from '@/snippets/usages/form/switch/switchWidget.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='switch'/>
+    <Widget name='form/switch'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -46,7 +46,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='switch' variant='leading-label'/>
+    <Widget name='form/switch' variant='leading-label'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={leadingLabelSnippet} />
@@ -57,7 +57,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='switch' variant='disabled'/>
+    <Widget name='form/switch' variant='disabled'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={disabledSnippet} />
@@ -68,7 +68,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='switch' variant='form' height={500}/>
+    <Widget name='form/switch' variant='form' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={formSnippet} />

--- a/docs/content/docs/widgets/form/text-field.mdx
+++ b/docs/content/docs/widgets/form/text-field.mdx
@@ -26,7 +26,7 @@ import textFieldPasswordUsage from '@/snippets/usages/form/text_field/textFieldP
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='text-field'/>
+    <Widget name='form/text-field'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -72,7 +72,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='text-field'/>
+    <Widget name='form/text-field'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -83,7 +83,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='text-field' variant='disabled'/>
+    <Widget name='form/text-field' variant='disabled'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={disabledSnippet} />
@@ -94,7 +94,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='text-field' variant='clearable'/>
+    <Widget name='form/text-field' variant='clearable'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={clearableSnippet} />
@@ -107,7 +107,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='text-field' variant='email'/>
+    <Widget name='form/text-field' variant='email'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={emailSnippet} />
@@ -118,7 +118,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='text-field' variant='password'/>
+    <Widget name='form/text-field' variant='password'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={passwordSnippet} />
@@ -129,7 +129,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='text-field' variant='multiline'/>
+    <Widget name='form/text-field' variant='multiline'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={multilineSnippet} />

--- a/docs/content/docs/widgets/form/text-form-field.mdx
+++ b/docs/content/docs/widgets/form/text-form-field.mdx
@@ -22,7 +22,7 @@ import textFormFieldPasswordUsage from '@/snippets/usages/form/text_form_field/t
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='text-form-field' height={550}/>
+    <Widget name='form/text-form-field' height={550}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />

--- a/docs/content/docs/widgets/form/time-field.mdx
+++ b/docs/content/docs/widgets/form/time-field.mdx
@@ -53,7 +53,7 @@ The following locales will default to Chinese (zh):
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='time-field'/>
+        <Widget name='form/time-field'/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={defaultSnippet} />
@@ -86,7 +86,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='time-field' variant='hour24'/>
+        <Widget name='form/time-field' variant='hour24'/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={hour24Snippet} />
@@ -97,7 +97,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='time-field' variant='picker' height={500}/>
+        <Widget name='form/time-field' variant='picker' height={500}/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={pickerSnippet} />
@@ -108,7 +108,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='time-field' variant='popover-builder' height={500}/>
+        <Widget name='form/time-field' variant='popover-builder' height={500}/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={popoverBuilderSnippet} />
@@ -119,7 +119,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='time-field' variant='validator' height={500}/>
+        <Widget name='form/time-field' variant='validator' height={500}/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={validatorSnippet} />
@@ -131,7 +131,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='time-field' variant='form' height={600}/>
+        <Widget name='form/time-field' variant='form' height={600}/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={formSnippet} />

--- a/docs/content/docs/widgets/form/time-picker.mdx
+++ b/docs/content/docs/widgets/form/time-picker.mdx
@@ -23,7 +23,7 @@ Recommended for touch devices.
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='time-picker'/>
+        <Widget name='form/time-picker'/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={defaultSnippet} />
@@ -53,7 +53,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='time-picker' variant='hour24'/>
+        <Widget name='form/time-picker' variant='hour24'/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={hour24Snippet} />
@@ -65,7 +65,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='time-picker' variant='interval'/>
+        <Widget name='form/time-picker' variant='interval'/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={intervalSnippet} />
@@ -77,7 +77,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
-        <Widget name='time-picker' variant='animated' height={500}/>
+        <Widget name='form/time-picker' variant='animated' height={500}/>
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={animatedSnippet} />

--- a/docs/content/docs/widgets/foundation/collapsible.mdx
+++ b/docs/content/docs/widgets/foundation/collapsible.mdx
@@ -13,7 +13,7 @@ import collapsibleUsage from '@/snippets/usages/foundation/collapsible/collapsib
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='collapsible' height={400}/>
+    <Widget name='foundation/collapsible' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={collapsibleDefault} />

--- a/docs/content/docs/widgets/foundation/focused-outline.mdx
+++ b/docs/content/docs/widgets/foundation/focused-outline.mdx
@@ -13,7 +13,7 @@ import focusedOutlineUsage from '@/snippets/usages/foundation/focused_outline/fo
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='focused-outline' height={300}/>
+    <Widget name='foundation/focused-outline' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={focusedOutlineDefault} />

--- a/docs/content/docs/widgets/foundation/overlay.mdx
+++ b/docs/content/docs/widgets/foundation/overlay.mdx
@@ -19,7 +19,7 @@ import overlayUsage from '@/snippets/usages/foundation/overlay/overlay.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='overlay' height={300}/>
+    <Widget name='foundation/overlay' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={overlayDefault} />

--- a/docs/content/docs/widgets/foundation/portal.mdx
+++ b/docs/content/docs/widgets/foundation/portal.mdx
@@ -19,7 +19,7 @@ import portalUsage from '@/snippets/usages/foundation/portal/portal.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='portal' height={500}/>
+    <Widget name='foundation/portal' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={portalDefault} />
@@ -33,4 +33,4 @@ import portalUsage from '@/snippets/usages/foundation/portal/portal.json';
 
 ## Visualization
 
-<Widget name='portal-visualization' height={600}/>
+<Widget name='foundation/portal-visualization' height={600}/>

--- a/docs/content/docs/widgets/foundation/tappable.mdx
+++ b/docs/content/docs/widgets/foundation/tappable.mdx
@@ -22,7 +22,7 @@ import tappableStaticUsage from '@/snippets/usages/foundation/tappable/tappableS
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='tappable' height={300}/>
+    <Widget name='foundation/tappable' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={tappableDefault} />
@@ -46,7 +46,7 @@ You can customize a tappable's bounce animation by passing a `FTappableMotion`.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='tappable' variant='bounce' height={300}/>
+    <Widget name='foundation/tappable' variant='bounce' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={tappableBounce} />
@@ -60,7 +60,7 @@ and slide across to another, the pressed state transfers to the new tappable.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='tappable-group' height={300}/>
+    <Widget name='foundation/tappable-group' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={tappableGroupDefault} />

--- a/docs/content/docs/widgets/layout/divider.mdx
+++ b/docs/content/docs/widgets/layout/divider.mdx
@@ -13,7 +13,7 @@ import dividerUsage from '@/snippets/usages/layout/divider/divider.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='divider' height={300}/>
+    <Widget name='layout/divider' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />

--- a/docs/content/docs/widgets/layout/resizable.mdx
+++ b/docs/content/docs/widgets/layout/resizable.mdx
@@ -18,7 +18,7 @@ import resizableRegionUsage from '@/snippets/usages/layout/resizable/resizableRe
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='resizable' height={700}/>
+    <Widget name='layout/resizable' height={700}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -51,7 +51,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='resizable' variant='no-cascading' height={700}/>
+    <Widget name='layout/resizable' variant='no-cascading' height={700}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={noCascadingSnippet} />
@@ -62,7 +62,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='resizable' variant='horizontal' height={400}/>
+    <Widget name='layout/resizable' variant='horizontal' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={horizontalSnippet} />
@@ -73,7 +73,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='resizable' variant='divider' height={400}/>
+    <Widget name='layout/resizable' variant='divider' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={dividerSnippet} />
@@ -84,7 +84,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='resizable' variant='no-divider' height={400}/>
+    <Widget name='layout/resizable' variant='no-divider' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={noDividerSnippet} />

--- a/docs/content/docs/widgets/layout/scaffold.mdx
+++ b/docs/content/docs/widgets/layout/scaffold.mdx
@@ -14,7 +14,7 @@ import scaffoldUsage from '@/snippets/usages/layout/scaffold/scaffold.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='scaffold' height={600}/>
+    <Widget name='layout/scaffold' height={600}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />

--- a/docs/content/docs/widgets/navigation/bottom-navigation-bar.mdx
+++ b/docs/content/docs/widgets/navigation/bottom-navigation-bar.mdx
@@ -15,7 +15,7 @@ import bottomNavigationBarItemUsage from '@/snippets/usages/navigation/bottom_na
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='bottom-navigation-bar'/>
+    <Widget name='navigation/bottom-navigation-bar'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />

--- a/docs/content/docs/widgets/navigation/breadcrumb.mdx
+++ b/docs/content/docs/widgets/navigation/breadcrumb.mdx
@@ -18,7 +18,7 @@ import breadcrumbItemCollapsedTilesUsage from '@/snippets/usages/navigation/brea
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='breadcrumb' height={400}/>
+    <Widget name='navigation/breadcrumb' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -57,7 +57,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='breadcrumb' variant='tiles' height={400}/>
+    <Widget name='navigation/breadcrumb' variant='tiles' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={tilesSnippet} />
@@ -68,7 +68,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='breadcrumb' variant='divider' height={400}/>
+    <Widget name='navigation/breadcrumb' variant='divider' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={dividerSnippet} />

--- a/docs/content/docs/widgets/navigation/header.mdx
+++ b/docs/content/docs/widgets/navigation/header.mdx
@@ -17,7 +17,7 @@ import headerNestedUsage from '@/snippets/usages/navigation/header/nested.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='header'/>
+    <Widget name='navigation/header'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -30,7 +30,7 @@ It is typically used on nested pages or sheets.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='header' variant='nested'/>
+    <Widget name='navigation/header' variant='nested'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={nestedSnippet} />
@@ -72,7 +72,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='header'/>
+    <Widget name='navigation/header'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -83,7 +83,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='header' variant='nested' />
+    <Widget name='navigation/header' variant='nested' />
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={nestedSnippet} />
@@ -94,7 +94,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='header' variant='nested-x' />
+    <Widget name='navigation/header' variant='nested-x' />
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={nestedXSnippet} />

--- a/docs/content/docs/widgets/navigation/pagination.mdx
+++ b/docs/content/docs/widgets/navigation/pagination.mdx
@@ -17,7 +17,7 @@ import paginationUsage from '@/snippets/usages/navigation/pagination/pagination.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='pagination' height={400}/>
+    <Widget name='navigation/pagination' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -47,7 +47,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='pagination' variant='siblings' height={400}/>
+    <Widget name='navigation/pagination' variant='siblings' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={siblingsSnippet} />
@@ -58,7 +58,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='pagination' variant='hide-edges' height={400}/>
+    <Widget name='navigation/pagination' variant='hide-edges' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={hideEdgesSnippet} />
@@ -69,7 +69,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='pagination' variant='custom-icon' height={400}/>
+    <Widget name='navigation/pagination' variant='custom-icon' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={customIconSnippet} />
@@ -80,7 +80,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='pagination' variant='page-view' height={400}/>
+    <Widget name='navigation/pagination' variant='page-view' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={pageViewSnippet} />

--- a/docs/content/docs/widgets/navigation/sidebar.mdx
+++ b/docs/content/docs/widgets/navigation/sidebar.mdx
@@ -25,7 +25,7 @@ import sidebarItemUsage from '@/snippets/usages/navigation/sidebar/sidebarItem.j
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='sidebar' height={500}/>
+    <Widget name='navigation/sidebar' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -101,7 +101,7 @@ Suited for devices with limited screen space.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='sidebar' variant='sheet' height={500} />
+    <Widget name='navigation/sidebar' variant='sheet' height={500} />
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={sheetSnippet} />
@@ -112,7 +112,7 @@ Suited for devices with limited screen space.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='sidebar' variant='custom-width' height={300} />
+    <Widget name='navigation/sidebar' variant='custom-width' height={300} />
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={customWidthSnippet} />
@@ -123,7 +123,7 @@ Suited for devices with limited screen space.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='sidebar' variant='nested' height={500} />
+    <Widget name='navigation/sidebar' variant='nested' height={500} />
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={nestedSnippet} />

--- a/docs/content/docs/widgets/navigation/tabs.mdx
+++ b/docs/content/docs/widgets/navigation/tabs.mdx
@@ -16,7 +16,7 @@ import tabEntryUsage from '@/snippets/usages/navigation/tabs/tabEntry.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='tabs' height={500}/>
+    <Widget name='navigation/tabs' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -53,7 +53,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='tabs' variant='swipeable' height={500}/>
+    <Widget name='navigation/tabs' variant='swipeable' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={swipeableSnippet} />

--- a/docs/content/docs/widgets/overlay/dialog.mdx
+++ b/docs/content/docs/widgets/overlay/dialog.mdx
@@ -18,7 +18,7 @@ import dialogRawUsage from '@/snippets/usages/overlay/dialog/raw.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='dialog' height={400}/>
+    <Widget name='overlay/dialog' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -62,7 +62,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='dialog' height={400}/>
+    <Widget name='overlay/dialog' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -75,7 +75,7 @@ We recommend using the vertical layout on mobile devices.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='dialog' variant='vertical' height={400}/>
+    <Widget name='overlay/dialog' variant='vertical' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={verticalSnippet} />
@@ -86,7 +86,7 @@ We recommend using the vertical layout on mobile devices.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='dialog' variant='blurred' height={400}/>
+    <Widget name='overlay/dialog' variant='blurred' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={blurredSnippet} />

--- a/docs/content/docs/widgets/overlay/persistent-sheet.mdx
+++ b/docs/content/docs/widgets/overlay/persistent-sheet.mdx
@@ -29,7 +29,7 @@ It is part of [FScaffold](/docs/widgets/layout/scaffold), which should be prefer
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='persistent-sheet' height={500}/>
+    <Widget name='overlay/persistent-sheet' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -62,7 +62,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='persistent-sheet' variant='keep-alive-offstage' height={500}/>
+    <Widget name='overlay/persistent-sheet' variant='keep-alive-offstage' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={keepAliveOffstageSnippet} />
@@ -73,7 +73,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='persistent-sheet' variant='draggable' height={400}/>
+    <Widget name='overlay/persistent-sheet' variant='draggable' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={draggableSnippet} />

--- a/docs/content/docs/widgets/overlay/popover-menu.mdx
+++ b/docs/content/docs/widgets/overlay/popover-menu.mdx
@@ -17,7 +17,7 @@ import popoverMenuTilesUsage from '@/snippets/usages/overlay/popover_menu/popove
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='popover-menu' height={500}/>
+    <Widget name='overlay/popover-menu' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -50,7 +50,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='popover-menu' variant='nested' height={500}/>
+    <Widget name='overlay/popover-menu' variant='nested' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={nestedSnippet} />
@@ -61,7 +61,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='popover-menu' variant='tiles' height={500}/>
+    <Widget name='overlay/popover-menu' variant='tiles' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={tilesSnippet} />
@@ -72,7 +72,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='popover-menu' variant='blurred' height={500}/>
+    <Widget name='overlay/popover-menu' variant='blurred' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={blurredSnippet} />

--- a/docs/content/docs/widgets/overlay/popover.mdx
+++ b/docs/content/docs/widgets/overlay/popover.mdx
@@ -20,7 +20,7 @@ import popoverUsage from '@/snippets/usages/overlay/popover/popover.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='popover' height={500}/>
+    <Widget name='overlay/popover' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -56,7 +56,7 @@ To prevent this, make both widgets share the same `groupId`.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='popover' variant='nested' height={500}/>
+    <Widget name='overlay/popover' variant='nested' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={nestedSnippet} />
@@ -69,7 +69,7 @@ You can change how the popover is aligned to the button.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='popover' variant='horizontal' height={500}/>
+    <Widget name='overlay/popover' variant='horizontal' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={horizontalSnippet} />
@@ -80,7 +80,7 @@ You can change how the popover is aligned to the button.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='popover' variant='no-hide-region' height={500}/>
+    <Widget name='overlay/popover' variant='no-hide-region' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={noHideRegionSnippet} />
@@ -91,7 +91,7 @@ You can change how the popover is aligned to the button.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='popover' variant='blurred' height={500}/>
+    <Widget name='overlay/popover' variant='blurred' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={blurredSnippet} />
@@ -104,7 +104,7 @@ The popover can be flipped along the overflowing axis to stay within the viewpor
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='popover' variant='flip' height={500}/>
+    <Widget name='overlay/popover' variant='flip' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={flipSnippet} />
@@ -117,7 +117,7 @@ The popover can be slid along the overflowing axis to stay within the viewport b
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='popover' variant='slide' height={500}/>
+    <Widget name='overlay/popover' variant='slide' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={slideSnippet} />
@@ -130,7 +130,7 @@ The popover is not shifted to stay within the viewport boundaries, even if it ov
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='popover' variant='allow-overflow' height={500}/>
+    <Widget name='overlay/popover' variant='allow-overflow' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={allowOverflowSnippet} />

--- a/docs/content/docs/widgets/overlay/sheet.mdx
+++ b/docs/content/docs/widgets/overlay/sheet.mdx
@@ -24,7 +24,7 @@ It navigates to a new page each time.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='modal-sheet' height={500}/>
+    <Widget name='overlay/modal-sheet' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -57,7 +57,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='modal-sheet' variant='blurred' height={500}/>
+    <Widget name='overlay/modal-sheet' variant='blurred' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={blurredSnippet} />
@@ -68,7 +68,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='modal-sheet' variant='draggable' height={400}/>
+    <Widget name='overlay/modal-sheet' variant='draggable' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={draggableSnippet} />

--- a/docs/content/docs/widgets/overlay/toast.mdx
+++ b/docs/content/docs/widgets/overlay/toast.mdx
@@ -42,7 +42,7 @@ import customAlignmentSnippet from '@/snippets/examples/overlay/toast/custom-ali
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='toast' height={500}/>
+    <Widget name='overlay/toast' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -93,7 +93,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='toast' variant='destructive' height={300}/>
+    <Widget name='overlay/toast' variant='destructive' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={destructiveSnippet} />
@@ -104,7 +104,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='toast' variant='custom-alignment' height={300}/>
+    <Widget name='overlay/toast' variant='custom-alignment' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={customAlignmentSnippet} />
@@ -115,7 +115,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='toast' variant='no-auto-dismiss' height={300}/>
+    <Widget name='overlay/toast' variant='no-auto-dismiss' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={noAutoDismissSnippet} />
@@ -126,7 +126,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='toast' variant='raw' height={620}/>
+    <Widget name='overlay/toast' variant='raw' height={620}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={rawSnippet} />
@@ -139,7 +139,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='toast' variant='always-expand' height={300}/>
+    <Widget name='overlay/toast' variant='always-expand' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={alwaysExpandSnippet} />
@@ -150,7 +150,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='toast' variant='disabled-expand'/>
+    <Widget name='overlay/toast' variant='disabled-expand'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={disabledExpandSnippet} />
@@ -165,7 +165,7 @@ By default, toasts are dismissible by horizontally swiping towards the closest e
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='toast' variant='swipe' height={300}/>
+    <Widget name='overlay/toast' variant='swipe' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={swipeSnippet} />
@@ -176,7 +176,7 @@ By default, toasts are dismissible by horizontally swiping towards the closest e
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='toast' variant='swipe-down' height={300}/>
+    <Widget name='overlay/toast' variant='swipe-down' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={swipeDownSnippet} />
@@ -187,7 +187,7 @@ By default, toasts are dismissible by horizontally swiping towards the closest e
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='toast' variant='swipe-disabled' height={300}/>
+    <Widget name='overlay/toast' variant='swipe-disabled' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={swipeDisabledSnippet} />

--- a/docs/content/docs/widgets/overlay/tooltip.mdx
+++ b/docs/content/docs/widgets/overlay/tooltip.mdx
@@ -16,7 +16,7 @@ import groupSnippet from '@/snippets/examples/overlay/tooltip/group.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='tooltip' height={300}/>
+    <Widget name='overlay/tooltip' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={defaultSnippet} />
@@ -48,7 +48,7 @@ Wrap multiple tooltips in an `FTooltipGroup` so that subsequent tooltips appear 
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='tooltip' variant='group' height={300}/>
+    <Widget name='overlay/tooltip' variant='group' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={groupSnippet} />
@@ -61,7 +61,7 @@ You can change how the tooltip is aligned to the button.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='tooltip' variant='horizontal' height={300}/>
+    <Widget name='overlay/tooltip' variant='horizontal' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={horizontalSnippet} />
@@ -72,7 +72,7 @@ You can change how the tooltip is aligned to the button.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='tooltip' variant='long-press-only' height={300}/>
+    <Widget name='overlay/tooltip' variant='long-press-only' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={longPressOnlySnippet} />

--- a/docs/content/docs/widgets/tile/select-menu-tile.mdx
+++ b/docs/content/docs/widgets/tile/select-menu-tile.mdx
@@ -23,7 +23,7 @@ import selectMenuTileForm from '@/snippets/examples/tile/select-menu-tile/form.j
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select-menu-tile' height={400}/>
+    <Widget name='tile/select-menu-tile' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={selectMenuTileDefault} />
@@ -56,7 +56,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select-menu-tile' variant='no-auto-hide' height={400}/>
+    <Widget name='tile/select-menu-tile' variant='no-auto-hide' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={selectMenuTileNoAutoHide} />
@@ -67,7 +67,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select-menu-tile' variant='scrollable' height={500}/>
+    <Widget name='tile/select-menu-tile' variant='scrollable' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={selectMenuTileScrollable} />
@@ -78,7 +78,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select-menu-tile' variant='lazy' height={500}/>
+    <Widget name='tile/select-menu-tile' variant='lazy' height={500}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={selectMenuTileLazy} />
@@ -89,7 +89,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select-menu-tile' variant='form' height={300}/>
+    <Widget name='tile/select-menu-tile' variant='form' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={selectMenuTileForm} />

--- a/docs/content/docs/widgets/tile/select-tile-group.mdx
+++ b/docs/content/docs/widgets/tile/select-tile-group.mdx
@@ -28,7 +28,7 @@ import selectTileGroupNoDivider from '@/snippets/examples/tile/select-tile-group
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select-tile-group' height={300}/>
+    <Widget name='tile/select-tile-group' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={selectTileGroupDefault} />
@@ -69,7 +69,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select-tile-group' variant='scrollable' height={300}/>
+    <Widget name='tile/select-tile-group' variant='scrollable' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={selectTileGroupScrollable} />
@@ -80,7 +80,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select-tile-group' variant='lazy' height={300}/>
+    <Widget name='tile/select-tile-group' variant='lazy' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={selectTileGroupLazy} />
@@ -91,7 +91,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select-tile-group' variant='multi-value' height={400}/>
+    <Widget name='tile/select-tile-group' variant='multi-value' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={selectTileGroupMultiValue} />
@@ -102,7 +102,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select-tile-group' variant='radio' height={400}/>
+    <Widget name='tile/select-tile-group' variant='radio' height={400}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={selectTileGroupRadio} />
@@ -115,7 +115,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select-tile-group' variant='suffix'/>
+    <Widget name='tile/select-tile-group' variant='suffix'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={selectTileGroupSuffix} />
@@ -126,7 +126,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select-tile-group' variant='full-divider' height={300}/>
+    <Widget name='tile/select-tile-group' variant='full-divider' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={selectTileGroupFullDivider} />
@@ -137,7 +137,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='select-tile-group' variant='no-divider' height={300}/>
+    <Widget name='tile/select-tile-group' variant='no-divider' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={selectTileGroupNoDivider} />

--- a/docs/content/docs/widgets/tile/tile-group.mdx
+++ b/docs/content/docs/widgets/tile/tile-group.mdx
@@ -21,7 +21,7 @@ import tileGroupNoDivider from '@/snippets/examples/tile/tile-group/no-divider.j
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='tile-group'/>
+    <Widget name='tile/tile-group'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={tileGroupDefault} />
@@ -74,7 +74,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='tile-group' variant='scrollable' height={300}/>
+    <Widget name='tile/tile-group' variant='scrollable' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={tileGroupScrollable} />
@@ -85,7 +85,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='tile-group' variant='lazy' height={300}/>
+    <Widget name='tile/tile-group' variant='lazy' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={tileGroupLazy} />
@@ -99,7 +99,7 @@ several sections.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='tile-group' variant='merge' height={300}/>
+    <Widget name='tile/tile-group' variant='merge' height={300}/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={tileGroupMerge} />
@@ -112,7 +112,7 @@ several sections.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='tile-group' variant='full-divider'/>
+    <Widget name='tile/tile-group' variant='full-divider'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={tileGroupFullDivider} />
@@ -123,7 +123,7 @@ several sections.
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='tile-group' variant='no-divider'/>
+    <Widget name='tile/tile-group' variant='no-divider'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={tileGroupNoDivider} />

--- a/docs/content/docs/widgets/tile/tile.mdx
+++ b/docs/content/docs/widgets/tile/tile.mdx
@@ -24,7 +24,7 @@ import tileDestructive from '@/snippets/examples/tile/tile/destructive.json';
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='tile'/>
+    <Widget name='tile/tile'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={tileDefault} />
@@ -67,7 +67,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='tile' variant='destructive'/>
+    <Widget name='tile/tile' variant='destructive'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={tileDestructive} />
@@ -78,7 +78,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='tile' variant='untappable'/>
+    <Widget name='tile/tile' variant='untappable'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={tileUntappable} />
@@ -89,7 +89,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='tile' variant='disabled'/>
+    <Widget name='tile/tile' variant='disabled'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={tileDisabled} />
@@ -100,7 +100,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='tile' variant='subtitle'/>
+    <Widget name='tile/tile' variant='subtitle'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={tileSubtitle} />
@@ -111,7 +111,7 @@ To generate a specific style for customization:
 
 <Tabs items={['Preview', 'Code']}>
   <Tab value="Preview">
-    <Widget name='tile' variant='details'/>
+    <Widget name='tile/tile' variant='details'/>
   </Tab>
   <Tab value="Code">
     <CodeSnippet snippet={tileDetails} />


### PR DESCRIPTION
**Describe the changes**
- Fix all `<Widget name='...'/>` references in docs MDX files to include the category prefix (e.g., `data/`, `form/`, `overlay/`) after the docs site was reorganized to nest widget categories under `/docs/widgets/` in #1032.
- 55 files updated, 249 widget preview references fixed.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [x] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.