### PR TITLE
Add FBadge demo widget

### DIFF
--- a/demo/lib/main.dart
+++ b/demo/lib/main.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/material.dart' hide Autocomplete, Tooltip;
+import 'package:flutter/material.dart' hide Autocomplete, Badge, Tooltip;
 import 'package:forui/forui.dart';
 
-import 'widgets/avatar.dart';
+import 'widgets/badge.dart';
 
 void main() {
   runApp(const Application());
@@ -12,7 +12,18 @@ class Application extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = FThemes.zinc.light.desktop;
+    final theme = FThemes.zinc.light.desktop.copyWith(
+      badgeStyles: FVariantsDelta.delta([
+        FVariantOperation.all(
+          FBadgeStyleDelta.delta(
+            contentStyle: FBadgeContentStyleDelta.delta(
+              padding: const EdgeInsetsGeometryDelta.scale(4),
+              labelTextStyle: const TextStyleDelta.delta(fontSize: 48),
+            ),
+          ),
+        ),
+      ]),
+    );
 
     return MaterialApp(
       title: 'Forui Widget Spotlight',
@@ -29,7 +40,7 @@ class Application extends StatelessWidget {
         ),
       ),
       home: const FScaffold(
-        child: Avatar(),
+        child: Badge(),
       ),
     );
   }

--- a/demo/lib/widgets/badge.dart
+++ b/demo/lib/widgets/badge.dart
@@ -1,0 +1,60 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:forui/forui.dart';
+
+class Badge extends StatefulWidget {
+  const Badge({super.key});
+
+  @override
+  State<Badge> createState() => _BadgeState();
+}
+
+class _BadgeState extends State<Badge> {
+  static const List<FBadgeVariant> _variants = [.primary, .secondary, .outline, .destructive];
+  static const List<String> _labels = ['Primary', 'Secondary', 'Outline', 'Destructive'];
+
+  late Timer _timer;
+  int _index = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
+      setState(() => _index = (_index + 1) % _variants.length);
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: AnimatedSize(
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOut,
+        child: AnimatedSwitcher(
+          duration: const Duration(milliseconds: 200),
+          switchInCurve: Curves.easeOut,
+          switchOutCurve: Curves.easeIn,
+          transitionBuilder: (child, animation) => FadeTransition(
+            opacity: animation,
+            child: ScaleTransition(
+              scale: Tween<double>(begin: 0.92, end: 1.0).animate(animation),
+              child: child,
+            ),
+          ),
+          child: FBadge(
+            key: ValueKey(_index),
+            variant: _variants[_index],
+            child: Text(_labels[_index]),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
**Describe the changes**
Adds an `FBadge` widget spotlight to the demo app. The demo cycles through the four `FBadge` variants (primary, secondary, outline, destructive) on a 1-second timer with fade, scale, and size transitions, and overrides the badge theme to render at a larger size suitable for the spotlight surface.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.