### PR TITLE
Fix nested FTappables in FTile/FItem slots not receiving taps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ Bootstrapping: `make bootstrap` (or `make bs`). Run `make help` for all commands
 
 ## Style Guide
 
+* Wrap all source lines (code, dartdocs, comments) at 120 characters.
 * Prefix publicly exported widgets and styles with `F`.
 * Prefer [dot-shorthands](https://dart.dev/language/dot-shorthands) where possible except for unnamed constructors.
   ```dart

--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -4,6 +4,11 @@
 * Add `FContextMenu`.
 
 
+### `FItem` & `FTile`
+* Fix nested `FTappable`-based widgets (e.g. `FButton` in a prefix or suffix) not receiving their own taps when the
+  enclosing tile is inside an `FItemGroup` or `FTileGroup`.
+
+
 ### `FPointPortal`
 * Add `FPointPortal`.
 

--- a/forui/lib/src/foundation/tappable/tappable_group.dart
+++ b/forui/lib/src/foundation/tappable/tappable_group.dart
@@ -152,4 +152,17 @@ class GroupEntry {
     final box = context.findRenderObject();
     return box is RenderBox ? box.globalToLocal(globalPosition) : globalPosition;
   }
+
+  bool get hasPrimaryCallback =>
+      onPress != null ||
+      onLongPress != null ||
+      onPressDown != null ||
+      onPressUp != null ||
+      onPressCancel != null ||
+      onPressMove != null ||
+      onLongPressDown != null ||
+      onLongPressStart != null ||
+      onLongPressEnd != null ||
+      onLongPressMove != null ||
+      onLongPressCancel != null;
 }

--- a/forui/lib/src/foundation/tappable/tappable_group_recognizer.dart
+++ b/forui/lib/src/foundation/tappable/tappable_group_recognizer.dart
@@ -258,8 +258,7 @@ class TappableGroupGestureRecognizer extends OneSequenceGestureRecognizer {
   /// expect non-overlapping siblings, so render-tree depth is the correct ordering for all in-scope use cases. Users
   /// who need paint-order Z (e.g. overlapping `FTappable`s in a `Stack`) can opt out via `FTappableGroup.isolate`.
   GroupEntry? _hitTest(Offset position) {
-    /// True iff [ancestor] is on the [RenderObject] parent chain of [descendant]. Mirrors the depth-based short-circuit
-    /// used by Flutter's `Element._debugIsDescendantOf`.
+    // True iff [ancestor] is on the [RenderObject] parent chain of [descendant].
     bool ancestorOf(RenderObject ancestor, RenderObject descendant) {
       var node = descendant.parent;
       while (node != null && node.depth > ancestor.depth) {
@@ -268,25 +267,26 @@ class TappableGroupGestureRecognizer extends OneSequenceGestureRecognizer {
       return node == ancestor;
     }
 
-    // Single-pass deepest-callback-bearing selection. Skipping !hasPrimaryCallback first avoids
-    // findRenderObject for entries that wouldn't have won anyway, and avoids the per-move list
-    // allocation and sort that fired on every slide-across cross-entry move.
-    GroupEntry? best;
-    RenderObject? bestRO;
-    for (final e in entries) {
-      if (!e.hitTest(position) || !e.hasPrimaryCallback) {
+    // Single-pass deepest-callback-bearing selection.
+    GroupEntry? deepest;
+    RenderObject? deepestObject;
+    for (final entry in entries) {
+      if (!entry.hitTest(position) || !entry.hasPrimaryCallback) {
         continue;
       }
-      final ro = e.context.findRenderObject();
-      if (ro == null) {
+
+      final object = entry.context.findRenderObject();
+      if (object == null) {
         continue;
       }
-      if (best == null || ancestorOf(bestRO!, ro)) {
-        best = e;
-        bestRO = ro;
+
+      if (deepest == null || ancestorOf(deepestObject!, object)) {
+        deepest = entry;
+        deepestObject = object;
       }
     }
-    return best;
+
+    return deepest;
   }
 
   @override

--- a/forui/lib/src/foundation/tappable/tappable_group_recognizer.dart
+++ b/forui/lib/src/foundation/tappable/tappable_group_recognizer.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-
-import 'package:collection/collection.dart';
+import 'package:flutter/rendering.dart';
 
 import 'package:forui/src/foundation/tappable/tappable_group.dart';
 
@@ -82,8 +81,9 @@ class TappableGroupGestureRecognizer extends OneSequenceGestureRecognizer {
           'This is likely a bug in Forui. Please file a bug report: https://github.com/duobaseio/forui/issues/new?template=bug_report.md',
         );
 
-        // Pressed down on an entry.
-        if (entries.firstWhereOrNull((e) => e.hitTest(position)) case final entry?) {
+        // Pressed down on an entry. Resolve deepest-first so nested entries (e.g. an FButton
+        // in an FTile suffix) win over their containing tile.
+        if (_hitTest(position) case final entry?) {
           _state = .pressing;
           _current = entry;
           _origin = position;
@@ -135,8 +135,8 @@ class TappableGroupGestureRecognizer extends OneSequenceGestureRecognizer {
         _state = .sliding;
         _cancel();
 
-        // Moved into another entry.
-        if (entries.firstWhereOrNull((e) => e.hitTest(position)) case final entry?) {
+        // Moved into another entry. Same depth resolution as PointerDown.
+        if (_hitTest(position) case final entry?) {
           _state = .slidePressing;
           unawaited(slidePressHapticFeedback());
           _current = entry;
@@ -247,6 +247,57 @@ class TappableGroupGestureRecognizer extends OneSequenceGestureRecognizer {
         resolve(.accepted);
       }
     });
+  }
+
+  /// Picks the deepest hit entry at [position] that has at least one primary callback. Mirrors Flutter's arena rule
+  /// "only widgets with recognizers compete" applied to our flat entries list: an entry with no callbacks contributes
+  /// nothing to resolution and the next outer entry gets the chance.
+  ///
+  /// Used for both `PointerDown` and `PointerMove`. Flutter doesn't re-hit-test on move events, so we resolve via
+  /// `RenderObject` ancestry rather than rely on Flutter's cached hit-test result. `FTappableGroup` is documented to
+  /// expect non-overlapping siblings, so render-tree depth is the correct ordering for all in-scope use cases. Users
+  /// who need paint-order Z (e.g. overlapping `FTappable`s in a `Stack`) can opt out via `FTappableGroup.isolate`.
+  GroupEntry? _hitTest(Offset position) {
+    /// True iff [ancestor] is on the [RenderObject] parent chain of [descendant]. Mirrors the depth-based short-circuit
+    /// used by Flutter's `Element._debugIsDescendantOf`.
+    bool ancestorOf(RenderObject ancestor, RenderObject descendant) {
+      var node = descendant.parent;
+      while (node != null && node.depth > ancestor.depth) {
+        node = node.parent;
+      }
+      return node == ancestor;
+    }
+
+    final hits =
+        [
+          for (final e in entries)
+            if (e.hitTest(position)) e,
+        ]..sort((a, b) {
+          final aRO = a.context.findRenderObject();
+          final bRO = b.context.findRenderObject();
+          if (aRO == null || bRO == null) {
+            return 0;
+          }
+
+          if (ancestorOf(aRO, bRO)) {
+            return 1; // a is outer, b is deeper; b first
+          }
+
+          if (ancestorOf(bRO, aRO)) {
+            return -1;
+          }
+
+          return 0;
+        });
+
+    // Mirror Flutter's arena: an entry "competes" only when it has at least one recognizer-equivalent (a primary callback).
+    // Without one, it doesn't claim regardless of HitTestBehavior, and the next outer entry gets the chance.
+    for (final entry in hits) {
+      if (entry.hasPrimaryCallback) {
+        return entry;
+      }
+    }
+    return null;
   }
 
   @override

--- a/forui/lib/src/foundation/tappable/tappable_group_recognizer.dart
+++ b/forui/lib/src/foundation/tappable/tappable_group_recognizer.dart
@@ -68,7 +68,7 @@ class TappableGroupGestureRecognizer extends OneSequenceGestureRecognizer {
   @override
   @protected
   bool isPointerAllowed(PointerDownEvent event) =>
-      (event.buttons & kPrimaryButton != 0) && entries.any((e) => e.hitTest(event.position));
+      (event.buttons & kPrimaryButton != 0) && _hitTest(event.position) != null;
 
   @override
   @protected
@@ -268,36 +268,25 @@ class TappableGroupGestureRecognizer extends OneSequenceGestureRecognizer {
       return node == ancestor;
     }
 
-    final hits =
-        [
-          for (final e in entries)
-            if (e.hitTest(position)) e,
-        ]..sort((a, b) {
-          final aRO = a.context.findRenderObject();
-          final bRO = b.context.findRenderObject();
-          if (aRO == null || bRO == null) {
-            return 0;
-          }
-
-          if (ancestorOf(aRO, bRO)) {
-            return 1; // a is outer, b is deeper; b first
-          }
-
-          if (ancestorOf(bRO, aRO)) {
-            return -1;
-          }
-
-          return 0;
-        });
-
-    // Mirror Flutter's arena: an entry "competes" only when it has at least one recognizer-equivalent (a primary callback).
-    // Without one, it doesn't claim regardless of HitTestBehavior, and the next outer entry gets the chance.
-    for (final entry in hits) {
-      if (entry.hasPrimaryCallback) {
-        return entry;
+    // Single-pass deepest-callback-bearing selection. Skipping !hasPrimaryCallback first avoids
+    // findRenderObject for entries that wouldn't have won anyway, and avoids the per-move list
+    // allocation and sort that fired on every slide-across cross-entry move.
+    GroupEntry? best;
+    RenderObject? bestRO;
+    for (final e in entries) {
+      if (!e.hitTest(position) || !e.hasPrimaryCallback) {
+        continue;
+      }
+      final ro = e.context.findRenderObject();
+      if (ro == null) {
+        continue;
+      }
+      if (best == null || ancestorOf(bestRO!, ro)) {
+        best = e;
+        bestRO = ro;
       }
     }
-    return null;
+    return best;
   }
 
   @override

--- a/forui/test/src/foundation/tappable/tappable_group_recognizer_test.dart
+++ b/forui/test/src/foundation/tappable/tappable_group_recognizer_test.dart
@@ -630,14 +630,14 @@ void main() {
         TestScaffold(
           child: GestureDetector(
             onTap: () => ancestorTap++,
-            child: FTappableGroup(
+            child: const FTappableGroup(
               child: SizedBox(
                 height: 50,
                 width: 200,
                 child: FTappable.static(
                   // Decorative tappable: registers with the group but has no callbacks. The group
                   // recognizer must not claim the gesture so the ancestor's onTap can fire.
-                  child: const Text('decorative'),
+                  child: Text('decorative'),
                 ),
               ),
             ),

--- a/forui/test/src/foundation/tappable/tappable_group_recognizer_test.dart
+++ b/forui/test/src/foundation/tappable/tappable_group_recognizer_test.dart
@@ -522,4 +522,126 @@ void main() {
       await tester.pumpAndSettle(const Duration(milliseconds: 200));
     });
   });
+
+  group('depth-aware hit resolution', () {
+    Widget buildNested({
+      required VoidCallback? outerOnPress,
+      required VoidCallback? innerOnPress,
+      HitTestBehavior innerBehavior = .translucent,
+    }) => TestScaffold(
+      child: FTappableGroup(
+        child: SizedBox(
+          height: 100,
+          width: 200,
+          child: FTappable.static(
+            onPress: outerOnPress,
+            child: Center(
+              child: SizedBox(
+                key: const ValueKey('inner'),
+                height: 30,
+                width: 30,
+                child: FTappable.static(
+                  behavior: innerBehavior,
+                  onPress: innerOnPress,
+                  child: const SizedBox.expand(),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    testWidgets('translucent inner with onPress wins over outer', (tester) async {
+      var outerPress = 0;
+      var innerPress = 0;
+      await tester.pumpWidget(
+        buildNested(outerOnPress: () => outerPress++, innerOnPress: () => innerPress++),
+      );
+
+      await tester.tap(find.byKey(const ValueKey('inner')));
+      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+      expect(innerPress, 1);
+      expect(outerPress, 0);
+    });
+
+    testWidgets('translucent inner without callbacks passes through to outer', (tester) async {
+      var outerPress = 0;
+      await tester.pumpWidget(buildNested(outerOnPress: () => outerPress++, innerOnPress: null));
+
+      await tester.tap(find.byKey(const ValueKey('inner')));
+      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+      expect(outerPress, 1);
+    });
+
+    testWidgets('opaque inner without callbacks falls through to outer', (tester) async {
+      var outerPress = 0;
+      await tester.pumpWidget(
+        buildNested(
+          outerOnPress: () => outerPress++,
+          innerOnPress: null,
+          innerBehavior: .opaque,
+        ),
+      );
+
+      await tester.tap(find.byKey(const ValueKey('inner')));
+      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+      // Mirrors Flutter's arena: an opaque widget without recognizers doesn't block ancestors.
+      expect(outerPress, 1);
+    });
+
+    testWidgets('opaque inner with onPress fires inner only', (tester) async {
+      var outerPress = 0;
+      var innerPress = 0;
+      await tester.pumpWidget(
+        buildNested(
+          outerOnPress: () => outerPress++,
+          innerOnPress: () => innerPress++,
+          innerBehavior: .opaque,
+        ),
+      );
+
+      await tester.tap(find.byKey(const ValueKey('inner')));
+      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+      expect(innerPress, 1);
+      expect(outerPress, 0);
+    });
+
+    testWidgets('deferToChild inner is a transparent passthrough', (tester) async {
+      var outerPress = 0;
+      await tester.pumpWidget(
+        buildNested(
+          outerOnPress: () => outerPress++,
+          innerOnPress: null,
+          innerBehavior: .deferToChild,
+        ),
+      );
+
+      await tester.tap(find.byKey(const ValueKey('inner')));
+      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+      expect(outerPress, 1);
+    });
+
+    testWidgets('outer-only tap (outside inner) still fires outer', (tester) async {
+      var outerPress = 0;
+      var innerPress = 0;
+      await tester.pumpWidget(
+        buildNested(outerOnPress: () => outerPress++, innerOnPress: () => innerPress++),
+      );
+
+      // The outer SizedBox is 200x100 centered; inner is 30x30 centered. Tap near the edge
+      // to land on the outer but outside the inner.
+      final outer = tester.getRect(find.byType(FTappableGroup));
+      await tester.tapAt(outer.topLeft + const Offset(10, 10));
+      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+      expect(outerPress, 1);
+      expect(innerPress, 0);
+    });
+  });
 }

--- a/forui/test/src/foundation/tappable/tappable_group_recognizer_test.dart
+++ b/forui/test/src/foundation/tappable/tappable_group_recognizer_test.dart
@@ -623,5 +623,32 @@ void main() {
       expect(outerPress, 1);
       expect(innerPress, 0);
     });
+
+    testWidgets('group with only callback-less entries does not swallow ancestor gestures', (tester) async {
+      var ancestorTap = 0;
+      await tester.pumpWidget(
+        TestScaffold(
+          child: GestureDetector(
+            onTap: () => ancestorTap++,
+            child: FTappableGroup(
+              child: SizedBox(
+                height: 50,
+                width: 200,
+                child: FTappable.static(
+                  // Decorative tappable: registers with the group but has no callbacks. The group
+                  // recognizer must not claim the gesture so the ancestor's onTap can fire.
+                  child: const Text('decorative'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('decorative'));
+      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+      expect(ancestorTap, 1);
+    });
   });
 }

--- a/forui/test/src/foundation/tappable/tappable_group_recognizer_test.dart
+++ b/forui/test/src/foundation/tappable/tappable_group_recognizer_test.dart
@@ -540,11 +540,7 @@ void main() {
                 key: const ValueKey('inner'),
                 height: 30,
                 width: 30,
-                child: FTappable.static(
-                  behavior: innerBehavior,
-                  onPress: innerOnPress,
-                  child: const SizedBox.expand(),
-                ),
+                child: FTappable.static(behavior: innerBehavior, onPress: innerOnPress, child: const SizedBox.expand()),
               ),
             ),
           ),
@@ -555,9 +551,7 @@ void main() {
     testWidgets('translucent inner with onPress wins over outer', (tester) async {
       var outerPress = 0;
       var innerPress = 0;
-      await tester.pumpWidget(
-        buildNested(outerOnPress: () => outerPress++, innerOnPress: () => innerPress++),
-      );
+      await tester.pumpWidget(buildNested(outerOnPress: () => outerPress++, innerOnPress: () => innerPress++));
 
       await tester.tap(find.byKey(const ValueKey('inner')));
       await tester.pumpAndSettle(const Duration(milliseconds: 200));
@@ -579,11 +573,7 @@ void main() {
     testWidgets('opaque inner without callbacks falls through to outer', (tester) async {
       var outerPress = 0;
       await tester.pumpWidget(
-        buildNested(
-          outerOnPress: () => outerPress++,
-          innerOnPress: null,
-          innerBehavior: .opaque,
-        ),
+        buildNested(outerOnPress: () => outerPress++, innerOnPress: null, innerBehavior: .opaque),
       );
 
       await tester.tap(find.byKey(const ValueKey('inner')));
@@ -597,11 +587,7 @@ void main() {
       var outerPress = 0;
       var innerPress = 0;
       await tester.pumpWidget(
-        buildNested(
-          outerOnPress: () => outerPress++,
-          innerOnPress: () => innerPress++,
-          innerBehavior: .opaque,
-        ),
+        buildNested(outerOnPress: () => outerPress++, innerOnPress: () => innerPress++, innerBehavior: .opaque),
       );
 
       await tester.tap(find.byKey(const ValueKey('inner')));
@@ -614,11 +600,7 @@ void main() {
     testWidgets('deferToChild inner is a transparent passthrough', (tester) async {
       var outerPress = 0;
       await tester.pumpWidget(
-        buildNested(
-          outerOnPress: () => outerPress++,
-          innerOnPress: null,
-          innerBehavior: .deferToChild,
-        ),
+        buildNested(outerOnPress: () => outerPress++, innerOnPress: null, innerBehavior: .deferToChild),
       );
 
       await tester.tap(find.byKey(const ValueKey('inner')));
@@ -630,9 +612,7 @@ void main() {
     testWidgets('outer-only tap (outside inner) still fires outer', (tester) async {
       var outerPress = 0;
       var innerPress = 0;
-      await tester.pumpWidget(
-        buildNested(outerOnPress: () => outerPress++, innerOnPress: () => innerPress++),
-      );
+      await tester.pumpWidget(buildNested(outerOnPress: () => outerPress++, innerOnPress: () => innerPress++));
 
       // The outer SizedBox is 200x100 centered; inner is 30x30 centered. Tap near the edge
       // to land on the outer but outside the inner.


### PR DESCRIPTION
## Summary
- Replaces `TappableGroupGestureRecognizer`'s depth-blind `firstWhereOrNull` resolution with a deepest-first walk via `RenderObject` ancestry, picking the first entry that has at least one primary callback. This mirrors Flutter's arena rule ("only widgets with recognizers compete") applied to the group's flat entries list.
- Nested `FTappable`-based widgets (e.g. `FButton`/`FCheckbox` in an `FTile`'s prefix or suffix) inside an `FItemGroup`/`FTileGroup` now correctly receive their own taps instead of having them swallowed by the enclosing tile.
- `HitTestBehavior` remains a normal Flutter hit-test concern for non-group usage. Paint-order Z for overlapping siblings in a `Stack` is intentionally not modelled by the group's resolution; users with that case can opt out via `FTappableGroup.isolate`.

Fixes #1041.

## Test plan
- [x] New `depth-aware hit resolution` group in `tappable_group_recognizer_test.dart`: translucent inner with `onPress` wins, translucent inner without callbacks falls through to outer, opaque inner without callbacks falls through to outer (Flutter-faithful, not "opaque always claims"), opaque inner with `onPress` wins, `deferToChild` inner is a passthrough, outer-only tap still fires outer.
- [x] Existing recognizer / tile / item / select-tile / submenu / tile-group test suites stay green (`flutter test forui/` — 4887 tests pass).
- [ ] Manual smoke test in `forui/example`: confirm an `FTile(onPress: ...)` with `FButton.icon` in its suffix routes taps to the button while the row body still presses the tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)