### PR TITLE
Add FSlider demo widget

### DIFF
--- a/demo/lib/main.dart
+++ b/demo/lib/main.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/material.dart' hide Autocomplete, Badge, Tooltip;
+import 'package:flutter/material.dart' hide Autocomplete, Badge, Slider, Tooltip;
 import 'package:forui/forui.dart';
 
-import 'widgets/badge.dart';
+import 'widgets/slider.dart';
 
 void main() {
   runApp(const Application());
@@ -12,18 +12,7 @@ class Application extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = FThemes.zinc.light.desktop.copyWith(
-      badgeStyles: FVariantsDelta.delta([
-        FVariantOperation.all(
-          FBadgeStyleDelta.delta(
-            contentStyle: FBadgeContentStyleDelta.delta(
-              padding: const EdgeInsetsGeometryDelta.scale(4),
-              labelTextStyle: const TextStyleDelta.delta(fontSize: 48),
-            ),
-          ),
-        ),
-      ]),
-    );
+    final theme = FThemes.zinc.light.desktop;
 
     return MaterialApp(
       title: 'Forui Widget Spotlight',
@@ -40,7 +29,7 @@ class Application extends StatelessWidget {
         ),
       ),
       home: const FScaffold(
-        child: Badge(),
+        child: Slider(),
       ),
     );
   }

--- a/demo/lib/widgets/slider.dart
+++ b/demo/lib/widgets/slider.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/widgets.dart';
+import 'package:forui/forui.dart';
+
+class Slider extends StatelessWidget {
+  const Slider({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SizedBox(
+        width: 360,
+        child: Column(
+          mainAxisAlignment: .center,
+          spacing: 48,
+          children: [
+            // Continuous range: two thumbs slide smoothly to select a span.
+            FSlider(
+              control: .managedContinuousRange(initial: FSliderValue(min: 0.25, max: 0.75)),
+              label: const Text('Price range'),
+              // The 0–1 track value maps to $0–$100, matching the marks.
+              tooltipBuilder: (_, value) => Text('\$${(value * 100).round()}'),
+              marks: const [
+                .mark(value: 0, label: Text(r'$0')),
+                .mark(value: 0.5, label: Text(r'$50')),
+                .mark(value: 1, label: Text(r'$100')),
+              ],
+            ),
+            // Discrete single value: one thumb snaps to each step.
+            FSlider(
+              control: .managedDiscrete(initial: FSliderValue(max: 0.5)),
+              label: const Text('Brightness'),
+              marks: const [
+                .mark(value: 0, label: Text('Low')),
+                .mark(value: 0.25),
+                .mark(value: 0.5, label: Text('Mid')),
+                .mark(value: 0.75),
+                .mark(value: 1, label: Text('High')),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
**Describe the changes**
Adds an `FSlider` demo to the demo app's widget spotlight. It showcases two sliders: a continuous range slider ("Price range") with a custom `tooltipBuilder` that formats each thumb's position as a dollar amount, and a discrete single-value slider ("Brightness") that snaps to labelled steps. `main.dart` now points the spotlight at the new `Slider` widget (reverting the badge-specific theme override).

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.