### PR TITLE
Add FSidebar demo widget and fix docs sidebar logo URL

### DIFF
--- a/demo/lib/main.dart
+++ b/demo/lib/main.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/material.dart' hide Autocomplete, Badge, Slider, Tooltip;
+import 'package:flutter/material.dart' hide Autocomplete, Badge, Tooltip;
 import 'package:forui/forui.dart';
 
-import 'widgets/slider.dart';
+import 'widgets/sidebar.dart';
 
 void main() {
   runApp(const Application());
@@ -22,15 +22,9 @@ class Application extends StatelessWidget {
       theme: theme.toApproximateMaterialTheme(),
       builder: (_, child) => FTheme(
         data: theme,
-        child: FToaster(
-          child: FTooltipGroup(
-            child: child!,
-          ),
-        ),
+        child: FToaster(child: FTooltipGroup(child: child!)),
       ),
-      home: const FScaffold(
-        child: Slider(),
-      ),
+      home: const FScaffold(child: Sidebar()),
     );
   }
 }

--- a/demo/lib/widgets/sidebar.dart
+++ b/demo/lib/widgets/sidebar.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/widgets.dart';
+
+import 'package:forui/forui.dart';
+
+class Sidebar extends StatelessWidget {
+  const Sidebar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = context.theme;
+
+    return Center(
+      child: Padding(
+        padding: const .symmetric(vertical: 24),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxHeight: 640),
+          child: FSidebar(
+            style: .delta(
+              decoration: .value(BoxDecoration(color: theme.colors.background)),
+            ),
+            header: Padding(
+              padding: const .symmetric(horizontal: 16),
+              child: Column(
+                crossAxisAlignment: .start,
+                children: [
+                  Padding(
+                    padding: const .fromLTRB(16, 8, 16, 16),
+                    child: Image.network(
+                      theme.colors.brightness == .light
+                          ? 'https://forui.dev/logos/light_logo.png'
+                          : 'https://forui.dev/logos/dark_logo.png',
+                      height: 24,
+                      webHtmlElementStrategy: .fallback,
+                    ),
+                  ),
+                  const FDivider(style: .delta(padding: .value(.zero))),
+                ],
+              ),
+            ),
+            footer: Padding(
+              padding: const .symmetric(horizontal: 16),
+              child: FCard.raw(
+                child: Padding(
+                  padding: const .symmetric(vertical: 12, horizontal: 16),
+                  child: Row(
+                    spacing: 10,
+                    children: [
+                      FAvatar.raw(
+                        child: Icon(
+                          FLucideIcons.userRound,
+                          size: 18,
+                          color: theme.colors.mutedForeground,
+                        ),
+                      ),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: .start,
+                          spacing: 2,
+                          children: [
+                            Text(
+                              'Dash',
+                              style: theme.typography.sm.copyWith(
+                                fontWeight: .bold,
+                                color: theme.colors.foreground,
+                              ),
+                              overflow: .ellipsis,
+                            ),
+                            Text(
+                              'dash@forui.dev',
+                              style: theme.typography.xs.copyWith(
+                                color: theme.colors.mutedForeground,
+                              ),
+                              overflow: .ellipsis,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            children: [
+              FSidebarGroup(
+                label: const Text('Overview'),
+                children: [
+                  FSidebarItem(
+                    icon: const Icon(FLucideIcons.school),
+                    label: const Text('Getting Started'),
+                    initiallyExpanded: true,
+                    onPress: () {},
+                    children: [
+                      FSidebarItem(
+                        label: const Text('Installation'),
+                        selected: true,
+                        onPress: () {},
+                      ),
+                      FSidebarItem(label: const Text('Themes'), onPress: () {}),
+                      FSidebarItem(
+                        label: const Text('Typography'),
+                        onPress: () {},
+                      ),
+                    ],
+                  ),
+                  FSidebarItem(
+                    icon: const Icon(FLucideIcons.code),
+                    label: const Text('API Reference'),
+                    onPress: () {},
+                  ),
+                  FSidebarItem(
+                    icon: const Icon(FLucideIcons.box),
+                    label: const Text('Pub Dev'),
+                    onPress: () {},
+                  ),
+                ],
+              ),
+              FSidebarGroup(
+                label: const Text('Widgets'),
+                action: const Icon(FLucideIcons.plus),
+                onActionPress: () {},
+                children: [
+                  FSidebarItem(
+                    icon: const Icon(FLucideIcons.circleSlash),
+                    label: const Text('Divider'),
+                    onPress: () {},
+                  ),
+                  FSidebarItem(
+                    icon: const Icon(FLucideIcons.scaling),
+                    label: const Text('Resizable'),
+                    onPress: () {},
+                  ),
+                  FSidebarItem(
+                    icon: const Icon(FLucideIcons.layoutDashboard),
+                    label: const Text('Scaffold'),
+                    onPress: () {},
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/docs_snippets/lib/examples/navigation/sidebar.dart
+++ b/docs_snippets/lib/examples/navigation/sidebar.dart
@@ -22,8 +22,8 @@ class SidebarPage extends Example {
               padding: const .fromLTRB(16, 8, 16, 16),
               child: SvgPicture.network(
                 context.theme.colors.brightness == .light
-                    ? 'https://forui.dev/light_logo.svg'
-                    : 'https://forui.dev/dark_logo.svg',
+                    ? 'https://forui.dev/logos/light_logo.svg'
+                    : 'https://forui.dev/logos/dark_logo.svg',
                 height: 24,
                 colorFilter: ColorFilter.mode(context.theme.colors.foreground, .srcIn),
               ),
@@ -171,8 +171,8 @@ class SheetSidebarPage extends Example {
                     padding: const .fromLTRB(16, 8, 16, 16),
                     child: SvgPicture.network(
                       context.theme.colors.brightness == .light
-                          ? 'https://forui.dev/light_logo.svg'
-                          : 'https://forui.dev/dark_logo.svg',
+                          ? 'https://forui.dev/logos/light_logo.svg'
+                          : 'https://forui.dev/logos/dark_logo.svg',
                       height: 24,
                       colorFilter: ColorFilter.mode(context.theme.colors.foreground, .srcIn),
                     ),


### PR DESCRIPTION
**Describe the changes**

- Add a centered `FSidebar` spotlight demo to the demo app (`demo/lib/widgets/sidebar.dart`), wired up in `demo/lib/main.dart` (replacing the previous `FSlider` spotlight). It renders a logo header, grouped/nested navigation items, and a user-card footer.
- Fix the logo URLs in the docs sidebar examples (`docs_snippets/lib/examples/navigation/sidebar.dart`) to `https://forui.dev/logos/...`; the previous paths returned 404, so the logo rendered blank in the live interactive example.

**Checklist**
- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.
