### PR TITLE
Add FBreadcrumb demo widget

### DIFF
--- a/demo/lib/main.dart
+++ b/demo/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart' hide Autocomplete, Badge, Tooltip;
 import 'package:forui/forui.dart';
 
-import 'widgets/sidebar.dart';
+import 'widgets/breadcrumb.dart';
 
 void main() {
   runApp(const Application());
@@ -24,7 +24,7 @@ class Application extends StatelessWidget {
         data: theme,
         child: FToaster(child: FTooltipGroup(child: child!)),
       ),
-      home: const FScaffold(child: Sidebar()),
+      home: const FScaffold(child: Breadcrumb()),
     );
   }
 }

--- a/demo/lib/widgets/breadcrumb.dart
+++ b/demo/lib/widgets/breadcrumb.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/widgets.dart';
+import 'package:forui/forui.dart';
+
+class _Crumb {
+  final String title;
+  final IconData icon;
+
+  const _Crumb(this.title, this.icon);
+}
+
+const _trail = [
+  _Crumb('Forui', FLucideIcons.house),
+  _Crumb('Docs', FLucideIcons.book),
+  _Crumb('Widgets', FLucideIcons.box),
+  _Crumb('Navigation', FLucideIcons.compass),
+  _Crumb('Breadcrumb', FLucideIcons.list),
+];
+
+class Breadcrumb extends StatefulWidget {
+  const Breadcrumb({super.key});
+
+  @override
+  State<Breadcrumb> createState() => _BreadcrumbState();
+}
+
+class _BreadcrumbState extends State<Breadcrumb> {
+  int _current = _trail.length - 1;
+
+  void _navigate(int index) => setState(() => _current = index);
+
+  @override
+  Widget build(BuildContext context) =>
+      Center(child: Row(mainAxisAlignment: .center, children: [FBreadcrumb(children: _crumbs())]));
+
+  List<Widget> _crumbs() {
+    final last = _current;
+
+    if (last < 3) {
+      return [for (var i = 0; i <= last; i++) _crumb(i)];
+    }
+
+    return [
+      _crumb(0),
+      FBreadcrumbItem.collapsed(
+        menu: [
+          FItemGroup(
+            children: [
+              for (var i = 1; i <= last - 2; i++)
+                FItem(prefix: Icon(_trail[i].icon), title: Text(_trail[i].title), onPress: () => _navigate(i)),
+            ],
+          ),
+        ],
+      ),
+      _crumb(last - 1),
+      _crumb(last),
+    ];
+  }
+
+  FBreadcrumbItem _crumb(int index) => FBreadcrumbItem(
+    current: index == _current,
+    onPress: index == _current ? null : () => _navigate(index),
+    child: Text(_trail[index].title),
+  );
+}


### PR DESCRIPTION
**Describe the changes**
- Add an interactive `FBreadcrumb` demo to the `/demo` widget-spotlight app (`demo/lib/widgets/breadcrumb.dart`).
- The breadcrumb walks a sample hierarchy (`Forui › … › Navigation › Breadcrumb`) and collapses the middle into a popover via `FBreadcrumbItem.collapsed`.
- Clicking any crumb or popover entry jumps back up the trail and reshapes it; the deepest page loads first so the collapsed `…` is visible immediately.
- Point `demo/lib/main.dart`'s `home` at the new `Breadcrumb` widget (consistent with prior demo PRs, e.g. #1047, #1048).

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests. <!-- N/A: demo-only, no library code changed -->
- [ ] I have included the relevant samples. <!-- N/A: this is the sample -->
- [ ] I have updated the documentation accordingly. <!-- N/A -->
- [ ] I have added the required flutters_hook for widget controllers. <!-- N/A -->
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary. <!-- N/A: /demo is not a published package -->
