### PR TITLE
Add FDialog demo widget

### DIFF
--- a/demo/lib/main.dart
+++ b/demo/lib/main.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/material.dart' hide Autocomplete, Badge, Tooltip;
+import 'package:flutter/material.dart' hide Autocomplete, Badge, Dialog, Tooltip;
 import 'package:forui/forui.dart';
 
-import 'widgets/breadcrumb.dart';
+import 'widgets/dialog.dart';
 
 void main() {
   runApp(const Application());
@@ -24,7 +24,7 @@ class Application extends StatelessWidget {
         data: theme,
         child: FToaster(child: FTooltipGroup(child: child!)),
       ),
-      home: const FScaffold(child: Breadcrumb()),
+      home: const FScaffold(child: Dialog()),
     );
   }
 }

--- a/demo/lib/widgets/dialog.dart
+++ b/demo/lib/widgets/dialog.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/widgets.dart';
+import 'package:forui/forui.dart';
+
+class Dialog extends StatelessWidget {
+  const Dialog({super.key});
+
+  @override
+  Widget build(BuildContext context) => Center(
+    child: FButton(
+      variant: .outline,
+      size: .sm,
+      mainAxisSize: .min,
+      onPress: () => showFDialog(
+        context: context,
+        builder: (context, style, animation) => FDialog(
+          style: style,
+          animation: animation,
+          direction: .horizontal,
+          title: const Text('Are you absolutely sure?'),
+          body: const Text(
+            'This action cannot be undone. This will permanently delete your account and '
+            'remove your data from our servers.',
+          ),
+          actions: [
+            FButton(
+              size: .sm,
+              onPress: () => Navigator.of(context).pop(),
+              child: const Text('Continue'),
+            ),
+            FButton(
+              variant: .outline,
+              size: .sm,
+              onPress: () => Navigator.of(context).pop(),
+              child: const Text('Cancel'),
+            ),
+          ],
+        ),
+      ),
+      child: const Text('Show Dialog'),
+    ),
+  );
+}


### PR DESCRIPTION
**Describe the changes**

- Add an `FDialog` demo widget (`demo/lib/widgets/dialog.dart`) to the Widget Spotlight app.
- The demo shows an outline `FButton` that opens a horizontal `FDialog` via `showFDialog`, with title, body, and Continue/Cancel actions.
- The background blurs + dims behind the dialog via the theme's default `FDialogRouteStyle.barrierFilter` (no extra config needed).
- Wire it up as the spotlighted widget in `demo/lib/main.dart` (and hide Material's `Dialog` in the import).

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests. <!-- N/A: demo app only -->
- [ ] I have included the relevant samples. <!-- N/A: this is a demo widget -->
- [ ] I have updated the documentation accordingly. <!-- N/A: no library/API change -->
- [ ] I have added the required flutters_hook for widget controllers. <!-- N/A: no controller -->
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary. <!-- N/A: demo app, not the published library -->
