### PR TITLE
Add docs SEO (sitemap, robots, canonicals)

### DIFF
--- a/docs/app/(home)/enterprise/page.tsx
+++ b/docs/app/(home)/enterprise/page.tsx
@@ -41,6 +41,9 @@ const services = [
 
 export const metadata: Metadata = {
   title: 'Enterprise',
+  alternates: {
+    canonical: '/enterprise',
+  },
 };
 
 const contact = 'https://forms.gle/wdxmjUMbYEhoJTsN8';

--- a/docs/app/(home)/page.tsx
+++ b/docs/app/(home)/page.tsx
@@ -1,9 +1,20 @@
+import type { Metadata } from 'next';
 import Image from 'next/image';
 import Link from 'next/link';
 
 import { Button } from '@/components/ui/button';
 import { Footer } from '@/components/footer';
 import { ImageZoom } from 'fumadocs-ui/components/image-zoom';
+
+export const metadata: Metadata = {
+  title: { absolute: 'Forui: Flutter UI library inspired by shadcn/ui' },
+  description:
+    'Forui is a Flutter UI library with beautifully designed, minimalistic widgets, heavily inspired by shadcn/ui. ' +
+    'Fully customizable, free, and open source.',
+  alternates: {
+    canonical: '/',
+  },
+};
 
 export default function HomePage() {
   return (
@@ -14,8 +25,8 @@ export default function HomePage() {
             Beautifully designed minimalistic Flutter widgets
           </h1>
           <p className="text-base sm:text-lg text-muted-foreground max-w-2xl mb-6">
-            A flutter platform-agnostic UI library for developers seeking consistent and elegant UIs across all devices.
-            Fully customizable, free, and open source.
+            A platform-agnostic Flutter UI library for developers seeking consistent and elegant UIs across all
+            devices. Designs are heavily inspired by shadcn/ui, fully customizable, free, and open source.
           </p>
           <div className="flex gap-4">
             <Button asChild>

--- a/docs/app/docs/[[...slug]]/page.tsx
+++ b/docs/app/docs/[[...slug]]/page.tsx
@@ -50,5 +50,8 @@ export async function generateMetadata(props: PageProps<'/docs/[[...slug]]'>): P
   return {
     title: page.data.title,
     description: page.data.description,
+    alternates: {
+      canonical: page.url,
+    },
   };
 }

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -2,9 +2,10 @@ import { RootProvider } from 'fumadocs-ui/provider/next';
 import { GoogleAnalytics } from '@next/third-parties/google';
 import './global.css';
 import { Inter } from 'next/font/google';
+import { siteUrl } from '@/lib/site';
 
 export const metadata = {
-  metadataBase: new URL('https://forui.dev'),
+  metadataBase: new URL(siteUrl),
   title: {
     default: 'Forui',
     template: '%s | Forui',

--- a/docs/app/robots.ts
+++ b/docs/app/robots.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from 'next';
+import { siteUrl } from '@/lib/site';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}

--- a/docs/app/sitemap.ts
+++ b/docs/app/sitemap.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from 'next';
+import { source } from '@/lib/source';
+import { siteUrl } from '@/lib/site';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const docs = source.getPages().map((page) => ({
+    url: `${siteUrl}${page.url}`,
+  }));
+
+  // Non-MDX pages must be added manually.
+  const pages = ['', '/enterprise'].map((path) => ({
+    url: `${siteUrl}${path}`,
+  }));
+
+  return [...pages, ...docs];
+}

--- a/docs/lib/site.ts
+++ b/docs/lib/site.ts
@@ -1,0 +1,2 @@
+// Single source of truth for the site's canonical origin, used by metadata, robots, and the sitemap.
+export const siteUrl = 'https://forui.dev';

--- a/forui/README.md
+++ b/forui/README.md
@@ -21,6 +21,7 @@
 
 <p align="center">
   Forui is a Flutter UI library that provides a set of beautifully designed, minimalistic widgets.
+  Designs are heavily inspired by shadcn/ui and are fully customizable.
 </p>
 
 <br />
@@ -38,6 +39,14 @@
 * ✅ [Well-tested](https://app.codecov.io/gh/duobaseio/forui).
 * 🌍 I10n support.
 * 🪝 First-class [Flutter Hooks](https://pub.dev/packages/flutter_hooks) integration via [`forui_hooks`](https://pub.dev/packages/forui_hooks).
+
+## Support Forui
+
+If Forui helps you build better apps, please consider supporting it. It only takes a few seconds, and it helps
+other Flutter developers discover the library.
+
+* ⭐ [Star Forui on GitHub](https://github.com/duobaseio/forui)
+* 👍 [Like Forui on pub.dev](https://pub.dev/packages/forui)
 
 ## Documentation
 

--- a/forui/README.md
+++ b/forui/README.md
@@ -45,8 +45,8 @@
 If Forui helps you build better apps, please consider supporting it. It only takes a few seconds, and it helps
 other Flutter developers discover the library.
 
-* ⭐ [Star Forui on GitHub](https://github.com/duobaseio/forui)
-* 👍 [Like Forui on pub.dev](https://pub.dev/packages/forui)
+⭐ [Star Forui on GitHub](https://github.com/duobaseio/forui)<br />
+👍 [Like Forui on pub.dev](https://pub.dev/packages/forui)
 
 ## Documentation
 

--- a/forui/README.md
+++ b/forui/README.md
@@ -45,8 +45,8 @@
 If Forui helps you build better apps, please consider supporting it. It only takes a few seconds, and it helps
 other Flutter developers discover the library.
 
-⭐ [Star Forui on GitHub](https://github.com/duobaseio/forui)<br />
-👍 [Like Forui on pub.dev](https://pub.dev/packages/forui)
+* ⭐ [Star Forui on GitHub](https://github.com/duobaseio/forui)
+* 👍 [Like Forui on pub.dev](https://pub.dev/packages/forui)
 
 ## Documentation
 

--- a/forui/pubspec.yaml
+++ b/forui/pubspec.yaml
@@ -1,5 +1,5 @@
 name: forui
-description: Beautifully designed, minimalistic widgets for desktop & touch devices.
+description: Beautifully designed, minimalistic Flutter widgets for desktop & touch devices. Designs are heavily inspired by shadcn/ui and are fully customizable.
 version: 0.22.3
 homepage: https://forui.dev/
 documentation: https://forui.dev/docs

--- a/forui/pubspec.yaml
+++ b/forui/pubspec.yaml
@@ -1,5 +1,7 @@
 name: forui
-description: Beautifully designed, minimalistic Flutter widgets for desktop & touch devices. Designs are heavily inspired by shadcn/ui and are fully customizable.
+description: >-
+  Beautifully designed, minimalistic Flutter widgets for desktop & touch devices. Designs are heavily
+  inspired by shadcn/ui and are fully customizable.
 version: 0.22.3
 homepage: https://forui.dev/
 documentation: https://forui.dev/docs


### PR DESCRIPTION
**Describe the changes**

SEO improvements for the documentation site (forui.dev) and pub.dev/GitHub discoverability, plus positioning
Forui for "shadcn flutter" / "flutter shadcn" search queries.

- **Sitemap**: add `docs/app/sitemap.ts`, generated from `source.getPages()` so new docs pages are included
  automatically (76 URLs today). Previously `forui.dev/sitemap.xml` 404'd.
- **robots.txt**: add `docs/app/robots.ts` allowing all crawlers and referencing the sitemap (now
  version-controlled instead of relying solely on the Cloudflare-managed file).
- **Canonical URLs**: add per-page `alternates.canonical` to docs pages (derived from `page.url`), plus the home
  and enterprise pages. Next.js does not emit these automatically.
- **Shared constant**: add `docs/lib/site.ts` (`siteUrl`), now used by `metadataBase`, robots, and the sitemap.
- **Homepage metadata**: set `<title>` to "Forui: Flutter UI library inspired by shadcn/ui" and add a
  keyword-aware meta description.
- **Positioning copy**: note "heavily inspired by shadcn/ui" in the homepage subhead, the README tagline, and the
  `forui/pubspec.yaml` description (which feeds pub.dev search and the Google snippet).
- **README**: add a "Support Forui" section (star on GitHub / like on pub.dev).

> Note: fully unblocking AI crawlers also requires disabling the Cloudflare-managed robots.txt / "Block AI bots"
> rule in the dashboard, and the sitemap should be submitted in Google Search Console after deploy.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests. (N/A: docs/SEO and copy only)
- [ ] I have included the relevant samples. (N/A)
- [x] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers. (N/A)
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary. (N/A: no library API changes)
