### PR TITLE
Add Support section to package READMEs and align README drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 
 <p align="center">
   Forui is a Flutter UI library that provides a set of beautifully designed, minimalistic widgets.
+  Designs are heavily inspired by shadcn/ui and are fully customizable.
 </p>
 
 <br />
@@ -37,10 +38,18 @@
 ## Why Choose Forui?
 
 * 🎨 Over 40+ beautifully crafted widgets.
-* ⚡ Bundled [CLI](https://forui.dev/docs/concepts/themes#themes) to generate themes & styling boilerplate.
+* ⚡ Bundled [CLI](https://forui.dev/docs/concepts/themes) to generate themes & styling boilerplate.
 * ✅ [Well-tested](https://app.codecov.io/gh/duobaseio/forui).
 * 🌍 I10n support.
 * 🪝 First-class [Flutter Hooks](https://pub.dev/packages/flutter_hooks) integration via [`forui_hooks`](https://pub.dev/packages/forui_hooks).
+
+## Support Forui
+
+If Forui helps you build better apps, please consider supporting it. It only takes a few seconds, and it helps
+other Flutter developers discover the library.
+
+* ⭐ [Star Forui on GitHub](https://github.com/duobaseio/forui)
+* 👍 [Like Forui on pub.dev](https://pub.dev/packages/forui)
 
 ## Documentation
 

--- a/forui/README.md
+++ b/forui/README.md
@@ -16,7 +16,7 @@
   <a href="https://forui.dev/docs">📚 Documentation</a> •
   <a href="https://forui.dev/docs/widgets/layout/divider">🖼️ Widgets</a> •
   <a href="https://pub.dev/documentation/forui">🤓 API Reference</a> •
-  <a href="https://github.com/orgs/duobaseio/projects/9">🗺️ Road Map</a>
+  <a href="https://github.com/orgs/duobaseio/projects/4">🗺️ Road Map</a>
 </p>
 
 <p align="center">
@@ -55,7 +55,7 @@ Visit [forui.dev/docs](https://forui.dev/docs) to view the documentation.
 ## Flutter Hooks Integration
 
 <a href="https://github.com/duobaseio/forui/actions/workflows/forui_hooks_build.yaml"><img alt="GitHub Actions Workflow Status" src="https://img.shields.io/github/actions/workflow/status/duobaseio/forui/forui_hooks_build.yaml?branch=main&style=flat&logo=github&label=forui_hooks"></a>
-<a href="https://pub.dev/packages/forui_hooks"><img alt="Pub Version" src="https://img.shields.io/pub/v/forui_hooks?style=flat&logo=dart&label=pub.dev: forui_hooks&color=00589B"></a>
+<a href="https://pub.dev/packages/forui_hooks"><img alt="Pub Version" src="https://img.shields.io/pub/v/forui_hooks?style=flat&logo=dart&label=pub.dev:%20forui_hooks&color=00589B"></a>
 
 Forui provides first class integration with [Flutter Hooks](https://pub.dev/packages/flutter_hooks). All controllers
 are exposed as hooks in the companion `forui_hooks` package.

--- a/forui_assets/README.md
+++ b/forui_assets/README.md
@@ -5,6 +5,14 @@ minimalistic widgets.
 
 It includes icons from [Lucide Icons](https://lucide.dev/icons/).
 
+## Support Forui
+
+If Forui helps you build better apps, please consider supporting it. It only takes a few seconds, and it helps
+other Flutter developers discover the library.
+
+* ⭐ [Star Forui on GitHub](https://github.com/duobaseio/forui)
+* 👍 [Like Forui on pub.dev](https://pub.dev/packages/forui)
+
 ## Documentation
 
 Visit [forui.dev/docs](https://forui.dev/docs) to view the documentation.

--- a/forui_hooks/README.md
+++ b/forui_hooks/README.md
@@ -54,6 +54,14 @@ class Example extends HookWidget {
 }
 ```
 
+## Support Forui
+
+If Forui helps you build better apps, please consider supporting it. It only takes a few seconds, and it helps
+other Flutter developers discover the library.
+
+* ⭐ [Star Forui on GitHub](https://github.com/duobaseio/forui)
+* 👍 [Like Forui on pub.dev](https://pub.dev/packages/forui)
+
 ## Documentation
 
 Visit [forui.dev/docs](https://forui.dev/docs) to view the documentation.

--- a/forui_hooks/lib/src/calendar_controller_hook.dart
+++ b/forui_hooks/lib/src/calendar_controller_hook.dart
@@ -131,8 +131,7 @@ class _CalendarControllerHook<C extends FCalendarController> extends Hook<C> {
   }
 }
 
-class _CalendarControllerHookState<C extends FCalendarController>
-    extends HookState<C, _CalendarControllerHook<C>> {
+class _CalendarControllerHookState<C extends FCalendarController> extends HookState<C, _CalendarControllerHook<C>> {
   late final C _controller;
 
   @override

--- a/forui_hooks/lib/src/date_selection_controller_hook.dart
+++ b/forui_hooks/lib/src/date_selection_controller_hook.dart
@@ -80,7 +80,8 @@ class _DateSelectionControllerHook<T> extends Hook<FDateSelectionController<T>> 
   }
 }
 
-class _DateSelectionControllerHookState<T> extends HookState<FDateSelectionController<T>, _DateSelectionControllerHook<T>> {
+class _DateSelectionControllerHookState<T>
+    extends HookState<FDateSelectionController<T>, _DateSelectionControllerHook<T>> {
   late final FDateSelectionController<T> _controller;
 
   @override


### PR DESCRIPTION
**Describe the changes**

- Add a **Support Forui** section (matching `forui/README.md`) to the root, `forui_hooks`, and `forui_assets` READMEs. Each links to starring the repo and liking the main `forui` package on pub.dev.
- Align drift between the root and `forui` READMEs:
  - Road Map now points to board 4 in both (was board 9 in `forui`).
  - Add the "inspired by shadcn/ui, fully customizable" tagline to the root README.
  - Drop the dead `#themes` anchor from the CLI link (no matching heading exists on the themes docs page).
- Fix the `forui_hooks` pub.dev badge in `forui/README.md`: encode the space in the label (`pub.dev:%20forui_hooks`) so it renders as a badge instead of a "Pub Version" text link.

Notes:
- Internal/non-user-facing READMEs (`forui_internal_gen`, `docs_snippets`, `docs`, `create`, `demo`) were intentionally left untouched.
- Image/link paths that differ between the root and `forui` READMEs (relative vs absolute) are intentional: assets live outside the published package, so pub.dev requires absolute URLs.
- License wording left as-is, pending the planned move to make Forui icon-agnostic.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests. <!-- N/A: docs only -->
- [ ] I have included the relevant samples. <!-- N/A: docs only -->
- [ ] I have updated the documentation accordingly. <!-- N/A: README-only change -->
- [ ] I have added the required flutters_hook for widget controllers. <!-- N/A -->
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary. <!-- N/A: no public API change -->