### PR TITLE
Fix FTappable null check crash when unmounted mid-gesture in a group

### DIFF
--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -102,6 +102,10 @@ and an API similar to other widgets.
 * Fix `FSwitch` registering two focus nodes, causing it to be a duplicate stop when tabbing through.
 
 
+### `FTappable` & `FTappableGroup`
+* Fix `FTappable` throwing a null check error when unmounted mid-gesture inside an `FTappableGroup`.
+
+
 ### `FTypography` & `FTypeface`
 
 We've added support for multiple typefaces by introducing a `FTypeface` that contains a text scale and changing 

--- a/forui/lib/src/foundation/tappable/tappable.dart
+++ b/forui/lib/src/foundation/tappable/tappable.dart
@@ -719,6 +719,13 @@ class _FTappableState<T extends FTappable> extends State<T> {
 
   Future<void> _cancel() async {
     ++_monotonic;
+    // Check if it's mounted due to a non-deterministic race condition, https://github.com/duobaseio/forui/issues/482.
+    // A grouped tappable can be unmounted mid-gesture while the group's recognizer still holds its entry and calls
+    // exit (this).
+    if (!mounted) {
+      return;
+    }
+
     if (widget._animate(_buttons)) {
       onPressEnd();
     }

--- a/forui/test/src/foundation/tappable/tappable_test.dart
+++ b/forui/test/src/foundation/tappable/tappable_test.dart
@@ -781,6 +781,49 @@ void main() {
         ]),
       );
     });
+
+    testWidgets('entry unmounted mid-gesture does not crash on cancel', (tester) async {
+      late StateSetter setState;
+      var show = true;
+
+      await tester.pumpWidget(
+        TestScaffold(
+          child: FTappableGroup(
+            child: StatefulBuilder(
+              builder: (_, setter) {
+                setState = setter;
+                return Column(
+                  children: [
+                    if (show)
+                      FTappable(
+                        builder: (_, _, _) => const SizedBox(width: 50, height: 50, child: Text('A')),
+                        onPress: () {},
+                      ),
+                    const SizedBox(width: 50, height: 50, child: Text('keepalive')),
+                  ],
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      // Press down on A — the group's recognizer captures A's entry as its current target.
+      final gesture = await tester.startGesture(tester.getCenter(find.text('A')));
+      await tester.pump();
+
+      // Unmount A while the gesture is in progress. The recognizer (owned by the still-alive group) keeps its
+      // reference to A's now-defunct entry.
+      setState(() => show = false);
+      await tester.pump();
+
+      // Cancelling routes a PointerCancelEvent to the recognizer, which calls entry.exit() (FTappable._cancel) on the
+      // defunct State.
+      await gesture.cancel();
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), null);
+    });
   });
 
   testWidgets('returns focused state on primary focus', (tester) async {


### PR DESCRIPTION
**Describe the changes**

- Fix `FTappable` throwing `Null check operator used on a null value` when it is unmounted mid-gesture while inside an `FTappableGroup`.
- Root cause: `FTappableGroup`'s recognizer keeps a reference to a tappable's `GroupEntry` and invokes its `exit` callback (`_cancel`) on pointer move/cancel/reject. If the tappable was unmounted during the gesture (e.g. an item removed from a list while pressed), `_cancel` called `setState` on the defunct `State`, hitting `_element!.markNeedsBuild()`, which is the null check crash in release/profile mode.
- Fix: guard `_cancel` with a `mounted` check before touching `widget`/`setState`, matching the existing guards in `_start` and `_end` (and the issue #482 pattern).
- Added a regression test (`in FTappableGroup entry unmounted mid-gesture does not crash on cancel`) that reproduces the crash on the old code and passes with the fix.
- Updated `CHANGELOG.md` under a new `FTappable` & `FTappableGroup` section.

**Checklist**
- [x] I have read the CONTRIBUTING.md.
- [x] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples. (N/A, internal crash fix, no API/sample change)
- [ ] I have updated the documentation accordingly. (N/A, no API change)
- [ ] I have added the required flutters_hook for widget controllers. (N/A, no controller change)
- [x] I have updated the CHANGELOG.md if necessary.
