### PR TITLE
Test FMultiSelect highlight follows the last tapped item (#1055)

### DIFF
--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -90,6 +90,8 @@ and an API similar to other widgets.
 ### `FSelect` & `FMultiSelect`
 * Add support for styling the label in the `focused` state.
 
+* Fix `FMultiSelect` retaining the highlight on the first item instead of the last tapped item.
+
 
 ### `FSelectMenuTile`
 * Add support for styling the label in the `focused` state.

--- a/forui/example/lib/sandbox.dart
+++ b/forui/example/lib/sandbox.dart
@@ -23,19 +23,8 @@ class Sandbox extends StatefulWidget {
 }
 
 class _SandboxState extends State<Sandbox> {
-  final _scroll = FLineCalendarScrollController(
-    start: DateTime.utc(2024),
-    end: DateTime.utc(2026),
-    today: DateTime.utc(2025, 6, 15),
-  );
-  static const _target = (year: 2025, month: 6, day: 15);
-  double _offset = 0;
-  double _viewportWidth = 400;
-  AlignmentDirectional _alignment = AlignmentDirectional.center;
-
   @override
   void dispose() {
-    _scroll.dispose();
     super.dispose();
   }
 
@@ -47,110 +36,10 @@ class _SandboxState extends State<Sandbox> {
         mainAxisSize: MainAxisSize.min,
         spacing: 20,
         children: [
-          SizedBox(
-            width: _viewportWidth,
-            child: FLineCalendar(
-              scrollControl: .managed(controller: _scroll, onChange: (offset) => setState(() => _offset = offset)),
-            ),
-          ),
-          Text('offset: ${_offset.toStringAsFixed(1)}    viewport: ${_viewportWidth.toStringAsFixed(0)}'),
-          SizedBox(
-            width: 320,
-            child: Material(
-              child: Slider(
-                value: _viewportWidth,
-                min: 120,
-                max: 600,
-                onChanged: (v) => setState(() => _viewportWidth = v),
-              ),
-            ),
-          ),
-          Wrap(
-            spacing: 8,
-            runSpacing: 8,
-            alignment: WrapAlignment.center,
-            children: [
-              for (final (label, value) in const [
-                ('start', AlignmentDirectional.centerStart),
-                ('center', AlignmentDirectional.center),
-                ('end', AlignmentDirectional.centerEnd),
-              ])
-                FButton(
-                  mainAxisSize: .min,
-                  variant: _alignment == value ? .primary : .outline,
-                  onPress: () => setState(() => _alignment = value),
-                  child: Text(label),
-                ),
-            ],
-          ),
-          Wrap(
-            spacing: 8,
-            runSpacing: 8,
-            alignment: WrapAlignment.center,
-            children: [
-              FButton(
-                mainAxisSize: .min,
-                onPress: () => _scroll.animateToDate(
-                  DateTime.utc(_target.year, _target.month, _target.day),
-                  alignment: _alignment,
-                ),
-                child: const Text('Animate to today'),
-              ),
-              FButton(
-                mainAxisSize: .min,
-                onPress: () =>
-                    _scroll.jumpToDate(DateTime.utc(_target.year, _target.month, _target.day), alignment: _alignment),
-                child: const Text('Jump to today'),
-              ),
-              FButton(
-                mainAxisSize: .min,
-                onPress: () => _scroll.animateToDate(DateTime.utc(2024), alignment: _alignment),
-                child: const Text('Jump to start'),
-              ),
-              FButton(
-                mainAxisSize: .min,
-                onPress: () => _scroll.animateToDate(DateTime.utc(2025, 12, 31), alignment: _alignment),
-                child: const Text('NYE'),
-              ),
-            ],
-          ),
-          Wrap(
-            spacing: 8,
-            runSpacing: 8,
-            alignment: WrapAlignment.center,
-            children: [
-              for (final MapEntry(:key, :value) in _alignments.entries)
-                FButton(
-                  mainAxisSize: .min,
-                  onPress: () => showFToast(
-                    context: context,
-                    alignment: value,
-                    title: Text(key),
-                    description: const Text('Swipe or wait to dismiss.'),
-                  ),
-                  child: Text(key),
-                ),
-            ],
-          ),
-          FDateField(
-            selectionControl: .managedSingle(initial: DateTime(2025, 12, 31)),
-            label: const Text('Start Date'),
-            description: const Text('Select a start date'),
-          ),
-          FDateField(label: const Text('End Date'), description: const Text('Select an end date')),
-          FSlider(
-            control: .managedContinuous(initial: FSliderValue(max: 0.35)),
-            marks: const [
-              .mark(value: 0, label: Text('0%')),
-              .mark(value: 0.25, tick: false),
-              .mark(value: 0.5),
-              .mark(value: 0.75, tick: false),
-              .mark(value: 1, label: Text('100%')),
-            ],
-          ),
-          FMultiSelect<String>(
-            hint: const Text('Select fruits'),
-            label: const Text('Fruits'),
+          FSelect<String>(
+            hint: 'Select a fruit',
+            label: const Text('Fruit'),
+            description: const Text('Select a fruit'),
             items: const {
               'Apple': 'Apple',
               'Banana': 'Banana',
@@ -164,13 +53,21 @@ class _SandboxState extends State<Sandbox> {
               'Strawberry': 'Strawberry',
             },
           ),
-          FTextFormField(
-            label: const Text('TextFormField'),
-            maxLength: 6,
-            keyboardType: .number,
-            textInputAction: .send,
-            onTapOutside: (event) {
-              FocusManager.instance.primaryFocus?.unfocus();
+          FMultiSelect<String>(
+            hint: const Text('Select fruits'),
+            label: const Text('Fruits'),
+            description: const Text('Select your favorite fruits'),
+            items: const {
+              'Apple': 'Apple',
+              'Banana': 'Banana',
+              'Blueberry': 'Blueberry',
+              'Grapes': 'Grapes',
+              'Lemon': 'Lemon',
+              'Mango': 'Mango',
+              'Kiwi': 'Kiwi',
+              'Orange': 'Orange',
+              'Pear': 'Pear',
+              'Strawberry': 'Strawberry',
             },
           ),
         ],

--- a/forui/example/lib/sandbox.dart
+++ b/forui/example/lib/sandbox.dart
@@ -1,20 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
 
-const _alignments = <String, FToastAlignment?>{
-  'default': null,
-  'topStart': FToastAlignment.topStart,
-  'topCenter': FToastAlignment.topCenter,
-  'topEnd': FToastAlignment.topEnd,
-  'topLeft': FToastAlignment.topLeft,
-  'topRight': FToastAlignment.topRight,
-  'bottomStart': FToastAlignment.bottomStart,
-  'bottomCenter': FToastAlignment.bottomCenter,
-  'bottomEnd': FToastAlignment.bottomEnd,
-  'bottomLeft': FToastAlignment.bottomLeft,
-  'bottomRight': FToastAlignment.bottomRight,
-};
-
 class Sandbox extends StatefulWidget {
   const Sandbox({super.key});
 

--- a/forui/lib/src/widgets/select/select_item.dart
+++ b/forui/lib/src/widgets/select/select_item.dart
@@ -434,20 +434,20 @@ abstract class _State<W extends FSelectItem<T>, T> extends State<W> {
       content.autofocus(widget.value) || content.autofocusFirst,
       (previous, current) {
         final added = current.difference(previous);
-
         if (added.contains(FTappableVariant.hovered) ||
             (!previous.contains(FTappableVariant.hovered) && added.contains(FTappableVariant.pressed))) {
           _focus.requestFocus();
         } else if (previous.difference(current).contains(FTappableVariant.hovered)) {
           // Only unfocus on hover exit. Releasing a press retains focus so the highlight stays on the last tapped item
-          // rather than reverting to the first focused item, https://github.com/duobaseio/forui/issues/1055.
+          // on touch devices.
           _focus.unfocus();
         }
       },
       () {
-        // The autofocus mechanism only focuses an item when no other item is focused. When another item already holds
-        // focus, it cannot move to the tapped item, so move it explicitly. This keeps the highlight on the last tapped
-        // item instead of the first, https://github.com/duobaseio/forui/issues/1055.
+        // Autofocus cannot move to tapped item when another item is focused. This keeps highlight on last tapped item
+        // on touch devices.
+        //
+        // This is done here instead of above in onVariantChange since that is debounced.
         if (_focus.enclosingScope?.focusedChild != null) {
           _focus.requestFocus();
         }

--- a/forui/test/src/widgets/select/multi/multi_select_test.dart
+++ b/forui/test/src/widgets/select/multi/multi_select_test.dart
@@ -454,6 +454,33 @@ void main() {
 
       debugDefaultTargetPlatformOverride = null;
     });
+
+    testWidgets('highlight follows the last tapped item on touch', (tester) async {
+      debugDefaultTargetPlatformOverride = .iOS;
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          alignment: .topCenter,
+          child: FMultiSelect<String>(key: key, items: const {'A': 'A', 'B': 'B', 'C': 'C'}),
+        ),
+      );
+
+      await tester.tap(find.byKey(key));
+      await tester.pumpAndSettle();
+
+      // Tapping the first item highlights it.
+      await tester.tap(find.text('A'));
+      await tester.pumpAndSettle();
+      expect(Focus.of(tester.element(find.text('A').last)).hasFocus, true);
+
+      // Tapping a second item moves the highlight to it instead of leaving it on the first.
+      await tester.tap(find.text('B'));
+      await tester.pumpAndSettle();
+      expect(Focus.of(tester.element(find.text('A').last)).hasFocus, false);
+      expect(Focus.of(tester.element(find.text('B').last)).hasFocus, true);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
   });
 
   group('design system', skip: !Platform.isMacOS, () {


### PR DESCRIPTION
**Describe the changes**

Follow-up to the #1055 fix, which shipped bundled in #1061 without a regression test or changelog entry. This PR backfills both.

- Add a regression test (`multi_select_test.dart`) for #1055: on touch, a quick tap must move the highlight to the tapped item instead of leaving it on the first (autofocused) item. Verified TDD-style — it fails against the pre-fix logic at the second-tap assertion and passes with the fix.
- Add the missing `CHANGELOG.md` entry under the unreleased `FSelect` & `FMultiSelect` section documenting the fix.
- Reword the focus-handling comments in `select_item.dart` to explain *why* focus is moved in `onPress` (the `pressed` variant is debounced, so the press branch never fires on a quick tap) rather than in `onVariantChange`.
- Trim the example `sandbox.dart` down to `FSelect` + `FMultiSelect` for manually exercising this behavior.

Closes #1055.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.