### PR TITLE
Add alignment configuration to `FDialogContentStyle`

### DIFF
--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.23.1
+
+### `FDialog`
+* Add `FDialogContentStyle.crossAxisAlignment`.
+* Add `FDialogContentStyle.titleTextAlign`.
+* Add `FDialogContentStyle.bodyTextAlign`.
+
+
 ## 0.23.0
 
 This update introduces the long-awaited context menu, a revamped calendar, and support for multiple typefaces.

--- a/forui/lib/src/widgets/dialog/dialog_content.dart
+++ b/forui/lib/src/widgets/dialog/dialog_content.dart
@@ -14,24 +14,18 @@ sealed class Content extends StatelessWidget {
   final FDialogContentStyle style;
   final bool slideableActions;
   final Future<void> Function() slidePressHapticFeedback;
-  final CrossAxisAlignment alignment;
   final Widget? image;
   final Widget? title;
-  final TextAlign titleTextAlign;
   final Widget? body;
-  final TextAlign bodyTextAlign;
   final List<Widget> actions;
 
   const Content({
     required this.style,
     required this.slideableActions,
     required this.slidePressHapticFeedback,
-    required this.alignment,
     required this.image,
     required this.title,
-    required this.titleTextAlign,
     required this.body,
-    required this.bodyTextAlign,
     required this.actions,
     super.key,
   });
@@ -41,7 +35,7 @@ sealed class Content extends StatelessWidget {
     padding: style.padding,
     child: Column(
       mainAxisSize: .min,
-      crossAxisAlignment: alignment,
+      crossAxisAlignment: style.crossAxisAlignment,
       children: [
         ?image,
         if (image != null && (title != null || body != null)) SizedBox(height: style.imageSpacing),
@@ -50,7 +44,7 @@ sealed class Content extends StatelessWidget {
             padding: style.titlePadding,
             child: Semantics(
               container: true,
-              child: DefaultTextStyle.merge(textAlign: titleTextAlign, style: style.titleTextStyle, child: title),
+              child: DefaultTextStyle.merge(textAlign: style.titleTextAlign, style: style.titleTextStyle, child: title),
             ),
           ),
         if (title != null && body != null) SizedBox(height: style.titleSpacing),
@@ -60,7 +54,7 @@ sealed class Content extends StatelessWidget {
               padding: style.bodyPadding,
               child: Semantics(
                 container: true,
-                child: DefaultTextStyle.merge(textAlign: bodyTextAlign, style: style.bodyTextStyle, child: body),
+                child: DefaultTextStyle.merge(textAlign: style.bodyTextAlign, style: style.bodyTextStyle, child: body),
               ),
             ),
           ),
@@ -83,9 +77,6 @@ sealed class Content extends StatelessWidget {
       ..add(DiagnosticsProperty('style', style))
       ..add(FlagProperty('slideableActions', value: slideableActions, ifTrue: 'slideableActions'))
       ..add(ObjectFlagProperty.has('slidePressHapticFeedback', slidePressHapticFeedback))
-      ..add(EnumProperty('alignment', alignment))
-      ..add(EnumProperty('titleTextAlign', titleTextAlign))
-      ..add(EnumProperty('bodyTextAlign', bodyTextAlign))
       ..add(IterableProperty('actions', actions));
   }
 }
@@ -101,7 +92,7 @@ class HorizontalContent extends Content {
     required super.body,
     required super.actions,
     super.key,
-  }) : super(alignment: .start, titleTextAlign: .start, bodyTextAlign: .start);
+  });
 
   @override
   Widget _actions(BuildContext context) => Row(
@@ -122,7 +113,7 @@ class VerticalContent extends Content {
     required super.body,
     required super.actions,
     super.key,
-  }) : super(alignment: .start, titleTextAlign: .start, bodyTextAlign: .start);
+  });
 
   @override
   Widget _actions(BuildContext context) => Column(mainAxisSize: .min, spacing: style.actionSpacing, children: actions);
@@ -134,9 +125,22 @@ class FDialogContentStyle with Diagnosticable, _$FDialogContentStyleFunctions {
   @override
   final TextStyle titleTextStyle;
 
+  /// The title's text alignment. Defaults to [TextAlign.start].
+  @override
+  final TextAlign titleTextAlign;
+
   /// The body's [TextStyle].
   @override
   final TextStyle bodyTextStyle;
+
+  /// The body's text alignment. Defaults to [TextAlign.start].
+  @override
+  final TextAlign bodyTextAlign;
+
+  /// How the content (image, title, body, and actions) is aligned along the cross axis. Defaults to
+  /// [CrossAxisAlignment.start].
+  @override
+  final CrossAxisAlignment crossAxisAlignment;
 
   /// The padding surrounding the content. Defaults to `EdgeInsets.only(left: 16, right: 16, top: 18, bottom: 18)`.
   @override
@@ -174,6 +178,9 @@ class FDialogContentStyle with Diagnosticable, _$FDialogContentStyleFunctions {
   FDialogContentStyle({
     required this.titleTextStyle,
     required this.bodyTextStyle,
+    this.titleTextAlign = .start,
+    this.bodyTextAlign = .start,
+    this.crossAxisAlignment = .start,
     this.padding = const .only(left: 16, right: 16, top: 18, bottom: 18),
     this.titlePadding = const .symmetric(horizontal: 8),
     this.bodyPadding = const .symmetric(horizontal: 8),

--- a/forui/test/src/widgets/dialog/dialog_test.dart
+++ b/forui/test/src/widgets/dialog/dialog_test.dart
@@ -180,6 +180,55 @@ void main() {
         expect(const FDialog.raw(builder: _emptyBuilder).resizeToAvoidInsets, true);
       });
     });
+
+    group('content alignment', () {
+      for (final direction in Axis.values) {
+        for (final (crossAxisAlignment, textAlign) in [
+          (CrossAxisAlignment.start, TextAlign.start),
+          (CrossAxisAlignment.center, TextAlign.center),
+          (CrossAxisAlignment.end, TextAlign.end),
+        ]) {
+          testWidgets('$direction $crossAxisAlignment / $textAlign flows from style', (tester) async {
+            await tester.pumpWidget(
+              TestScaffold(
+                child: FDialog(
+                  direction: direction,
+                  style: .delta(
+                    contentStyle: .delta([
+                      .all(
+                        .delta(
+                          crossAxisAlignment: crossAxisAlignment,
+                          titleTextAlign: textAlign,
+                          bodyTextAlign: textAlign,
+                        ),
+                      ),
+                    ]),
+                  ),
+                  title: const Text('Title'),
+                  body: const Text('Body'),
+                  actions: [FButton(onPress: () {}, child: const Text('OK'))],
+                ),
+              ),
+            );
+
+            final column = tester.widget<Column>(
+              find.ancestor(of: find.text('Title'), matching: find.byType(Column)).first,
+            );
+            expect(column.crossAxisAlignment, crossAxisAlignment);
+
+            final title = tester.widget<DefaultTextStyle>(
+              find.ancestor(of: find.text('Title'), matching: find.byType(DefaultTextStyle)).first,
+            );
+            expect(title.textAlign, textAlign);
+
+            final body = tester.widget<DefaultTextStyle>(
+              find.ancestor(of: find.text('Body'), matching: find.byType(DefaultTextStyle)).first,
+            );
+            expect(body.textAlign, textAlign);
+          });
+        }
+      }
+    });
   });
 }
 


### PR DESCRIPTION
**Describe the changes**

First off, thank you for Forui. I've been using it for several months now and the
experience has been great.

While moving to the latest version, I noticed the dialog styling changed. Most of it can
be adjusted through `FThemeData.dialogStyle`, but the content's cross-axis (vertical)
alignment cannot. The earlier changelog notes this change:

> **Breaking** Change `VerticalContent` alignment from center to start.

I personally prefer the previous centered content alignment. Right now the only way to get
it back is a custom `FDialog.raw`, which is awkward to apply consistently across an entire
app. Being able to set it once on `FThemeData.dialogStyle` would be much simpler, so this PR
adds that:

- Add `FDialogContentStyle.crossAxisAlignment` to control how the image, title, body, and
  actions align along the cross axis.
- Add `FDialogContentStyle.titleTextAlign` and `FDialogContentStyle.bodyTextAlign` to control
  the title/body text alignment.
- All three default to `start`, so existing behavior is unchanged (non-breaking).
- `Content` now reads these from the style instead of hardcoding them. Because the fields are
  keyed by the dialog's axis variant, horizontal and vertical layouts can be aligned
  independently.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.
