### PR TITLE
Add FTextField spotlight demo

### DIFF
--- a/spotlight/lib/main.dart
+++ b/spotlight/lib/main.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart' hide Autocomplete, Badge, Dialog, Tooltip;
+import 'package:flutter/material.dart' hide Autocomplete, Badge, Dialog, TextField, Tooltip;
 
 import 'package:forui/forui.dart';
 import 'package:marionette_flutter/marionette_flutter.dart';
 
-import 'widgets/dialog.dart';
+import 'widgets/text_field.dart';
 
 void main() {
   if (kDebugMode) {
@@ -30,7 +30,7 @@ class Application extends StatelessWidget {
         data: theme,
         child: FToaster(child: FTooltipGroup(child: child!)),
       ),
-      home: const FScaffold(child: Dialog()),
+      home: const FScaffold(child: TextField()),
     );
   }
 }

--- a/spotlight/lib/widgets/text_field.dart
+++ b/spotlight/lib/widgets/text_field.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+import 'package:forui/forui.dart';
+
+class TextField extends StatelessWidget {
+  const TextField({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SizedBox(
+        width: 350,
+        child: Column(
+          mainAxisSize: .min,
+          spacing: 24,
+          children: [
+            const FTextField(
+              label: Text('Username'),
+              hint: 'JaneDoe',
+              description: Text('Please enter your username.'),
+            ),
+            FTextField(
+              label: const Text('Search'),
+              prefixBuilder: (context, style, variants) =>
+                  FTextField.prefixIconBuilder(context, style, variants, const Icon(FLucideIcons.search)),
+              control: const .managed(initial: TextEditingValue(text: 'forui')),
+              clearable: (value) => value.text.isNotEmpty,
+            ),
+            FTextField.password(
+              control: const .managed(initial: TextEditingValue(text: 'My password')),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
**Describe the changes**

- Add an `FTextField` demo to the spotlight app (`spotlight/lib/widgets/text_field.dart`).
- Showcase three representative variants in a single screen:
  - default field with `label`, `hint`, and `description`
  - search field with a `prefixBuilder` icon and `clearable`
  - `FTextField.password` with the built-in visibility toggle
- Point the spotlight `home` at the new `TextField` demo in `spotlight/lib/main.dart`.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.
