### PR TITLE
Add FTabs spotlight demo

### DIFF
--- a/spotlight/lib/main.dart
+++ b/spotlight/lib/main.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart' hide Autocomplete, Badge, Dialog, TextFie
 import 'package:forui/forui.dart';
 import 'package:marionette_flutter/marionette_flutter.dart';
 
-import 'widgets/text_field.dart';
+import 'widgets/tabs.dart';
 
 void main() {
   if (kDebugMode) {
@@ -30,7 +30,7 @@ class Application extends StatelessWidget {
         data: theme,
         child: FToaster(child: FTooltipGroup(child: child!)),
       ),
-      home: const FScaffold(child: TextField()),
+      home: const FScaffold(child: Tabs()),
     );
   }
 }

--- a/spotlight/lib/widgets/tabs.dart
+++ b/spotlight/lib/widgets/tabs.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/widgets.dart';
+import 'package:forui/forui.dart';
+
+typedef _Player = ({String name, String points});
+
+const _today = <_Player>[
+  (name: 'Ava Chen', points: '2,480'),
+  (name: 'Liam Wong', points: '2,310'),
+  (name: 'Noah Park', points: '1,905'),
+  (name: 'Priya Rao', points: '1,640'),
+];
+
+const _week = <_Player>[
+  (name: 'Noah Park', points: '14,220'),
+  (name: 'Ava Chen', points: '12,980'),
+  (name: 'Mia Torres', points: '11,540'),
+  (name: 'Liam Wong', points: '10,870'),
+];
+
+const _allTime = <_Player>[
+  (name: 'Ava Chen', points: '98,400'),
+  (name: 'Mia Torres', points: '87,110'),
+  (name: 'Noah Park', points: '76,050'),
+  (name: 'Priya Rao', points: '68,320'),
+];
+
+class Tabs extends StatelessWidget {
+  const Tabs({super.key});
+
+  @override
+  Widget build(BuildContext context) => Center(
+    child: SizedBox(
+      width: 360,
+      child: FTabs(
+        children: [
+          .entry(label: const Text('Today'), child: _Leaderboard(_today)),
+          .entry(label: const Text('Week'), child: _Leaderboard(_week)),
+          .entry(label: const Text('All time'), child: _Leaderboard(_allTime)),
+        ],
+      ),
+    ),
+  );
+}
+
+class _Leaderboard extends StatelessWidget {
+  final List<_Player> players;
+
+  const _Leaderboard(this.players);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = context.theme;
+    return FItemGroup(
+      children: [
+        for (final (index, player) in players.indexed)
+          FItem(
+            prefix: SizedBox(
+              width: 20,
+              child: Text(
+                '${index + 1}',
+                textAlign: .center,
+                style: theme.typography.body.sm.copyWith(color: theme.colors.mutedForeground),
+              ),
+            ),
+            title: Text(player.name),
+            suffix: Text(player.points, style: theme.typography.body.sm.copyWith(fontWeight: FontWeight.w600)),
+          ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
**Describe the changes**

- Add an `FTabs` spotlight demo (`spotlight/lib/widgets/tabs.dart`): a leaderboard that
  switches between **Today / Week / All time**, each an `FItemGroup` of ranked players
  (rank · name · score). Kept the content deliberately minimal so the tab bar stays the focus.
- Point `spotlight/lib/main.dart` at the new demo.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests. <!-- N/A: internal spotlight playground -->
- [ ] I have included the relevant samples. <!-- N/A: this is the sample -->
- [ ] I have updated the documentation accordingly. <!-- N/A: internal spotlight playground -->
- [ ] I have added the required flutters_hook for widget controllers. <!-- N/A -->
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary. <!-- N/A: no published package change -->