### PR TITLE
Fix `FResizable` resetting regions on window resize

### DIFF
--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -17,6 +17,10 @@
   `FDateSelectionControl.liftedMulti(...)` or `FDateSelectionControl.liftedRange(...)` instead.
 
 
+### `FResizable`
+* Fix `FResizable` resetting regions to their initial sizes when the main-axis constraint changes (e.g. window resize).
+
+
 ### `FTheme` & `FThemes`
 * Add `FTheme.neutral`.
 

--- a/forui/example/lib/sandbox.dart
+++ b/forui/example/lib/sandbox.dart
@@ -72,8 +72,13 @@ class _SandboxState extends State<Sandbox> {
                   minExtent: 100,
                   builder: (context, data, _) => _Region(label: 'Sidebar (fixed)', data: data),
                 ),
-                .flex(builder: (context, data, _) => _Region(label: 'Content (flex 1)', data: data)),
-                .flex(flex: 2, builder: (context, data, _) => _Region(label: 'Preview (flex 2)', data: data)),
+                .flex(
+                  builder: (context, data, _) => _Region(label: 'Content (flex 1)', data: data),
+                ),
+                .flex(
+                  flex: 2,
+                  builder: (context, data, _) => _Region(label: 'Preview (flex 2)', data: data),
+                ),
               ],
             ),
           ),

--- a/forui/example/lib/sandbox.dart
+++ b/forui/example/lib/sandbox.dart
@@ -56,8 +56,51 @@ class _SandboxState extends State<Sandbox> {
               'Strawberry': 'Strawberry',
             },
           ),
+          // Drag the dividers, then resize the window: the fixed sidebar keeps its pixel width and the flex
+          // regions scale to fill the rest, without resetting to their initial sizes.
+          DecoratedBox(
+            decoration: BoxDecoration(
+              border: Border.all(color: context.theme.colors.border),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: FResizable(
+              axis: .horizontal,
+              crossAxisExtent: 200,
+              children: [
+                .fixed(
+                  extent: 160,
+                  minExtent: 100,
+                  builder: (context, data, _) => _Region(label: 'Sidebar (fixed)', data: data),
+                ),
+                .flex(builder: (context, data, _) => _Region(label: 'Content (flex 1)', data: data)),
+                .flex(flex: 2, builder: (context, data, _) => _Region(label: 'Preview (flex 2)', data: data)),
+              ],
+            ),
+          ),
         ],
       ),
     ),
   );
+}
+
+class _Region extends StatelessWidget {
+  final String label;
+  final FResizableRegionData data;
+
+  const _Region({required this.label, required this.data});
+
+  @override
+  Widget build(BuildContext context) {
+    final FThemeData(:colors, :typography) = context.theme;
+    return Align(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(label, style: typography.body.sm.copyWith(color: colors.foreground)),
+          const SizedBox(height: 4),
+          Text('${data.extent.current.round()} px', style: typography.body.xs.copyWith(color: colors.mutedForeground)),
+        ],
+      ),
+    );
+  }
 }

--- a/forui/lib/src/widgets/resizable/resizable.dart
+++ b/forui/lib/src/widgets/resizable/resizable.dart
@@ -131,8 +131,30 @@ class FResizable extends StatefulWidget {
 }
 
 class _FResizableState extends State<FResizable> {
+  static bool _listEquals(List<FResizableRegion> a, List<FResizableRegion> b) {
+    if (a.length != b.length) {
+      return false;
+    }
+
+    for (final (i, region) in a.indexed) {
+      final same = switch ((region, b[i])) {
+        (FixedResizableRegion(:final extent, :final minExtent), final FixedResizableRegion other) =>
+          extent == other.extent && minExtent == other.minExtent,
+        (FlexResizableRegion(:final flex, :final minFlex), final FlexResizableRegion other) =>
+          flex == other.flex && minFlex == other.minFlex,
+        _ => false,
+      };
+      if (!same) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   late FResizableController _controller;
   late double _hitRegionExtent;
+  bool _dirty = true;
 
   @override
   void initState() {
@@ -153,7 +175,12 @@ class _FResizableState extends State<FResizable> {
     if (updated) {
       _controller = controller;
     }
-    _hitRegionExtent = widget.hitRegionExtent ?? (context.platformVariant.touch ? 60 : 10);
+
+    final extent = widget.hitRegionExtent ?? (context.platformVariant.touch ? 60 : 10);
+    if (extent != _hitRegionExtent || widget.axis != old.axis || !_listEquals(old.children, widget.children)) {
+      _hitRegionExtent = extent;
+      _dirty = true;
+    }
   }
 
   @override
@@ -173,7 +200,13 @@ class _FResizableState extends State<FResizable> {
           builder: (_, constraints) {
             // This isn't ideal but the alternative to create a custom RenderObject, compute the layout, and pipe it to
             // the controller, which is overkill.
-            _update(constraints.maxWidth);
+            if (_dirty || _controller.regions.length != widget.children.length) {
+              _dirty = false;
+              _reset(constraints.maxWidth);
+            } else {
+              _scale(constraints.maxWidth);
+            }
+
             return ListenableBuilder(
               listenable: _controller,
               builder: (_, _) => Stack(
@@ -217,7 +250,12 @@ class _FResizableState extends State<FResizable> {
           builder: (_, constraints) {
             // This isn't ideal but the alternative to create a custom RenderObject, compute the layout, and pipe it to
             // the controller, which is overkill.
-            _update(constraints.maxHeight);
+            if (_dirty || _controller.regions.length != widget.children.length) {
+              _dirty = false;
+              _reset(constraints.maxHeight);
+            } else {
+              _scale(constraints.maxHeight);
+            }
             return ListenableBuilder(
               listenable: _controller,
               builder: (_, _) => Stack(
@@ -256,7 +294,136 @@ class _FResizableState extends State<FResizable> {
     }
   }
 
-  void _update(double constraint) {
+  /// Lays out the regions by keeping their current extents and adjusting them to fit the new [constraint].
+  ///
+  /// Fixed regions keep their extent and flex regions grow or shrink to fill the rest. The fixed ones change only if the
+  /// flex regions can't. Called when only the constraint changed, so the user's resizing is kept.
+  void _scale(double constraint) {
+    final (total, totalMinExtent, remaining, totalFlex) = _constraints(constraint);
+
+    // Start from each region's current extent (what the user dragged it to), kept within its new min and max.
+    final bounds = <(double, double)>[];
+    final extents = <double>[];
+
+    for (final (i, region) in widget.children.indexed) {
+      final minExt = switch (region) {
+        FixedResizableRegion(:final minExtent) => max(minExtent ?? 0, _hitRegionExtent),
+        FlexResizableRegion(:final minFlex?) => max(remaining * minFlex / totalFlex, _hitRegionExtent),
+        FlexResizableRegion() => _hitRegionExtent,
+      };
+      final maxExt = total - totalMinExtent + minExt;
+
+      bounds.add((minExt, maxExt));
+      extents.add(clampDouble(_controller.regions[i].extent.current, minExt, maxExt));
+    }
+
+    // The regions' extents rarely add up to `total`, so grow or shrink them by the difference (`delta`) until they
+    // match it. The flex regions change first, the fixed ones only if the flex regions can't grow or shrink further.
+    // Repeat, since each region can only change until it reaches its min or max.
+    const eps = 1e-9;
+    var delta = total - extents.fold(0.0, (sum, extent) => sum + extent);
+    for (final flexOnly in [true, false]) {
+      for (var pass = 0; pass < extents.length && eps < delta.abs(); pass++) {
+        final grow = delta > 0;
+
+        final weights = List.filled(extents.length, 0.0);
+        var weightTotal = 0.0;
+        for (final (i, extent) in extents.indexed) {
+          if (flexOnly && widget.children[i] is! FlexResizableRegion) {
+            continue;
+          }
+
+          final (minExt, maxExt) = bounds[i];
+          if (grow ? extent < maxExt : extent > minExt) {
+            weights[i] = grow ? max(extent, eps) : max(extent - minExt, eps);
+            weightTotal += weights[i];
+          }
+        }
+
+        if (weightTotal == 0) {
+          break;
+        }
+
+        var moved = 0.0;
+        for (final (i, extent) in extents.indexed) {
+          if (weights[i] == 0) {
+            continue;
+          }
+
+          final (minExt, maxExt) = bounds[i];
+          final resized = clampDouble(extent + delta * weights[i] / weightTotal, minExt, maxExt);
+          moved += resized - extent;
+          extents[i] = resized;
+        }
+        delta -= moved;
+        if (moved.abs() <= eps) {
+          break;
+        }
+      }
+    }
+
+    // Turn the final extents into regions. The last region ends exactly at `total` so they add up perfectly.
+    final regions = <FResizableRegionData>[];
+    var offset = 0.0;
+    for (var index = 0; index < extents.length; index++) {
+      final maxOffset = index == extents.length - 1 ? total : offset + extents[index];
+      regions.add(
+        FResizableRegionData(
+          index: index,
+          extent: (min: bounds[index].$1, max: bounds[index].$2, total: total),
+          offset: (min: offset, max: maxOffset),
+        ),
+      );
+      offset = maxOffset;
+    }
+
+    _controller.regions
+      ..clear()
+      ..addAll(regions);
+  }
+
+  /// Lays out the regions from their declared configuration, discarding any current extents.
+  ///
+  /// Fixed regions take their declared extent and flex regions their share of the remaining space. Called on the first
+  /// layout and whenever the configuration changes, where there is nothing to preserve.
+  void _reset(double constraint) {
+    final (total, totalMinExtent, remaining, totalFlex) = _constraints(constraint);
+
+    final regions = <FResizableRegionData>[];
+    var offset = 0.0;
+    for (final (index, region) in widget.children.indexed) {
+      switch (region) {
+        case FixedResizableRegion(:final extent, :final minExtent):
+          final minExt = max(minExtent ?? 0, _hitRegionExtent);
+          final maxExt = total - totalMinExtent + minExt;
+          regions.add(
+            FResizableRegionData(
+              index: index,
+              extent: (min: minExt, max: maxExt, total: total),
+              offset: (min: offset, max: offset += extent),
+            ),
+          );
+
+        case FlexResizableRegion(:final flex, :final minFlex):
+          final minExt = minFlex == null ? _hitRegionExtent : max(remaining * minFlex / totalFlex, _hitRegionExtent);
+          final maxExt = total - totalMinExtent + minExt;
+          regions.add(
+            FResizableRegionData(
+              index: index,
+              extent: (min: minExt, max: maxExt, total: total),
+              offset: (min: offset, max: offset += remaining * flex / totalFlex),
+            ),
+          );
+      }
+    }
+
+    _controller.regions
+      ..clear()
+      ..addAll(regions);
+  }
+
+  /// Measures the layout for the current children at the given [constraint].
+  (double total, double totalMinExtent, double remaining, double totalFlex) _constraints(double constraint) {
     var totalFlex = 0.0;
     var totalFixed = 0.0;
     var totalMinExtent = 0.0;
@@ -288,44 +455,13 @@ class _FResizableState extends State<FResizable> {
     }
 
     final remaining = total - totalFixed;
-    final regions = <FResizableRegionData>[];
-    var offset = 0.0;
-
     for (final child in widget.children) {
       if (child case FlexResizableRegion(:final minFlex)) {
         totalMinExtent += minFlex == null ? _hitRegionExtent : max(remaining * minFlex / totalFlex, _hitRegionExtent);
       }
     }
 
-    for (final (index, region) in widget.children.indexed) {
-      switch (region) {
-        case FixedResizableRegion(:final extent, :final minExtent):
-          final minExt = max(minExtent ?? 0, _hitRegionExtent);
-          final maxExt = total - totalMinExtent + minExt;
-          regions.add(
-            FResizableRegionData(
-              index: index,
-              extent: (min: minExt, max: maxExt, total: total),
-              offset: (min: offset, max: offset += extent),
-            ),
-          );
-
-        case FlexResizableRegion(:final flex, :final minFlex):
-          final minExt = minFlex == null ? _hitRegionExtent : max(remaining * minFlex / totalFlex, _hitRegionExtent);
-          final maxExt = total - totalMinExtent + minExt;
-          regions.add(
-            FResizableRegionData(
-              index: index,
-              extent: (min: minExt, max: maxExt, total: total),
-              offset: (min: offset, max: offset += remaining * flex / totalFlex),
-            ),
-          );
-      }
-    }
-
-    _controller.regions
-      ..clear()
-      ..addAll(regions);
+    return (total, totalMinExtent, remaining, totalFlex);
   }
 }
 

--- a/forui/lib/src/widgets/resizable/resizable_controller.dart
+++ b/forui/lib/src/widgets/resizable/resizable_controller.dart
@@ -92,7 +92,7 @@ final class _ResizableController extends FResizableController {
       regions[expanded.index] = expanded;
 
       assert(
-        regions.sum((r) => r.extent.current, initial: 0.0) == regions[0].extent.total,
+        regions.sum((r) => r.extent.current, initial: 0.0).around(regions[0].extent.total),
         'Current total extent: ${regions.sum((r) => r.extent.current, initial: 0.0)} != initial total extent: '
         '${regions[0].extent.total}. This is likely a bug in Forui. Please file a bug report: '
         'https://github.com/duobaseio/forui/issues/new?template=bug_report.md',

--- a/forui/test/src/widgets/resizable/resizable_test.dart
+++ b/forui/test/src/widgets/resizable/resizable_test.dart
@@ -312,4 +312,159 @@ void main() {
       expect(firstHeight, greaterThanOrEqualTo(50));
     });
   });
+
+  group('resize', () {
+    Widget stub(BuildContext context, FResizableRegionData data, Widget? child) => const Align(child: Text('R'));
+
+    Finder divider(Axis axis) => find.byType(axis == Axis.vertical ? VerticalDivider : HorizontalDivider);
+    Offset drag(Axis axis, double delta) => axis == Axis.vertical ? Offset(0, delta) : Offset(delta, 0);
+    double main(Size size, Axis axis) => axis == Axis.vertical ? size.height : size.width;
+
+    Widget build(
+      Axis axis,
+      double extent,
+      List<FResizableRegion> children, {
+      TextDirection textDirection = TextDirection.ltr,
+    }) => TestScaffold.app(
+      platform: .macOS,
+      textDirection: textDirection,
+      child: Center(
+        child: SizedBox(
+          width: axis == Axis.vertical ? 50 : extent,
+          height: axis == Axis.vertical ? extent : 50,
+          child: FResizable(crossAxisExtent: 50, axis: axis, children: children),
+        ),
+      ),
+    );
+
+    for (final axis in [Axis.vertical, Axis.horizontal]) {
+      testWidgets('$axis flex scales proportionally without a prior drag', (tester) async {
+        await tester.pumpWidget(build(axis, 100, [.flex(builder: stub), .flex(builder: stub)]));
+        expect(main(tester.getSize(find.byType(FlexResizableRegion).first), axis), 50);
+        expect(main(tester.getSize(find.byType(FlexResizableRegion).last), axis), 50);
+
+        await tester.pumpWidget(build(axis, 200, [.flex(builder: stub), .flex(builder: stub)]));
+        expect(main(tester.getSize(find.byType(FlexResizableRegion).first), axis), 100);
+        expect(main(tester.getSize(find.byType(FlexResizableRegion).last), axis), 100);
+
+        await tester.pumpWidget(build(axis, 60, [.flex(builder: stub), .flex(builder: stub)]));
+        expect(main(tester.getSize(find.byType(FlexResizableRegion).first), axis), 30);
+        expect(main(tester.getSize(find.byType(FlexResizableRegion).last), axis), 30);
+      });
+
+      testWidgets('$axis flex preserves the drag proportions across a resize', (tester) async {
+        await tester.pumpWidget(build(axis, 100, [.flex(builder: stub), .flex(builder: stub)]));
+        await tester.timedDrag(divider(axis), drag(axis, 100), const Duration(seconds: 1));
+        await tester.pumpAndSettle();
+        expect(main(tester.getSize(find.byType(FlexResizableRegion).first), axis), 90);
+        expect(main(tester.getSize(find.byType(FlexResizableRegion).last), axis), 10);
+
+        await tester.pumpWidget(build(axis, 200, [.flex(builder: stub), .flex(builder: stub)]));
+        expect(main(tester.getSize(find.byType(FlexResizableRegion).first), axis), 180);
+        expect(main(tester.getSize(find.byType(FlexResizableRegion).last), axis), 20);
+      });
+    }
+
+    testWidgets('rtl horizontal flex preserves the drag proportions across a resize', (tester) async {
+      List<FResizableRegion> children() => [.flex(builder: stub), .flex(builder: stub)];
+      await tester.pumpWidget(build(Axis.horizontal, 100, children(), textDirection: .rtl));
+      await tester.timedDrag(find.byType(HorizontalDivider), const Offset(100, 0), const Duration(seconds: 1));
+      await tester.pumpAndSettle();
+      final first = tester.getSize(find.byType(FlexResizableRegion).first).width;
+      final last = tester.getSize(find.byType(FlexResizableRegion).last).width;
+
+      await tester.pumpWidget(build(Axis.horizontal, 200, children(), textDirection: .rtl));
+      expect(tester.getSize(find.byType(FlexResizableRegion).first).width, first * 2);
+      expect(tester.getSize(find.byType(FlexResizableRegion).last).width, last * 2);
+    });
+
+    testWidgets('mixed fixed + flex keeps the fixed pixel size and lets flex absorb the resize', (tester) async {
+      List<FResizableRegion> children() => [.fixed(extent: 40, minExtent: 20, builder: stub), .flex(builder: stub)];
+      await tester.pumpWidget(build(Axis.vertical, 100, children()));
+      await tester.timedDrag(find.byType(VerticalDivider), const Offset(0, -100), const Duration(seconds: 1));
+      await tester.pumpAndSettle();
+      expect(tester.getSize(find.byType(FixedResizableRegion).first).height, 20);
+      expect(tester.getSize(find.byType(FlexResizableRegion).first).height, 80);
+
+      await tester.pumpWidget(build(Axis.vertical, 150, children()));
+      expect(tester.getSize(find.byType(FixedResizableRegion).first).height, 20);
+      expect(tester.getSize(find.byType(FlexResizableRegion).first).height, 130);
+    });
+
+    testWidgets('mixed fixed + flex fresh build keeps the fixed region at its declared extent', (tester) async {
+      List<FResizableRegion> children() => [.fixed(extent: 40, minExtent: 20, builder: stub), .flex(builder: stub)];
+      await tester.pumpWidget(build(Axis.vertical, 100, children()));
+      expect(tester.getSize(find.byType(FixedResizableRegion).first).height, 40);
+      expect(tester.getSize(find.byType(FlexResizableRegion).first).height, 60);
+
+      await tester.pumpWidget(build(Axis.vertical, 150, children()));
+      expect(tester.getSize(find.byType(FixedResizableRegion).first).height, 40);
+      expect(tester.getSize(find.byType(FlexResizableRegion).first).height, 110);
+    });
+
+    testWidgets('all-fixed preserves the drag when the constraint changes', (tester) async {
+      List<FResizableRegion> children() => [
+        .fixed(extent: 30, minExtent: 20, builder: stub),
+        .fixed(extent: 70, minExtent: 20, builder: stub),
+      ];
+      await tester.pumpWidget(build(Axis.vertical, 100, children()));
+      await tester.timedDrag(find.byType(VerticalDivider), const Offset(0, 100), const Duration(seconds: 1));
+      await tester.pumpAndSettle();
+      expect(tester.getSize(find.byType(FixedResizableRegion).first).height, 80);
+      expect(tester.getSize(find.byType(FixedResizableRegion).last).height, 20);
+
+      await tester.pumpWidget(build(Axis.vertical, 150, children()));
+      expect(tester.getSize(find.byType(FixedResizableRegion).first).height, 80);
+      expect(tester.getSize(find.byType(FixedResizableRegion).last).height, 20);
+    });
+
+    testWidgets('shrinking past the flex minimum pins flex and shrinks fixed, preserving the total', (tester) async {
+      List<FResizableRegion> children() => [.fixed(extent: 40, minExtent: 20, builder: stub), .flex(builder: stub)];
+      await tester.pumpWidget(build(Axis.vertical, 100, children()));
+      await tester.timedDrag(find.byType(VerticalDivider), const Offset(0, 100), const Duration(seconds: 1));
+      await tester.pumpAndSettle();
+      expect(tester.getSize(find.byType(FixedResizableRegion).first).height, 90);
+      expect(tester.getSize(find.byType(FlexResizableRegion).first).height, 10);
+
+      await tester.pumpWidget(build(Axis.vertical, 70, children()));
+      final fixed = tester.getSize(find.byType(FixedResizableRegion).first).height;
+      final flex = tester.getSize(find.byType(FlexResizableRegion).first).height;
+      expect(flex, 10);
+      expect(fixed, 60);
+      expect(fixed + flex, 70);
+    });
+
+    testWidgets('a same-size parent rebuild preserves the drag', (tester) async {
+      await tester.pumpWidget(build(Axis.vertical, 100, [.flex(builder: stub), .flex(builder: stub)]));
+      await tester.timedDrag(find.byType(VerticalDivider), const Offset(0, 100), const Duration(seconds: 1));
+      await tester.pumpAndSettle();
+      expect(tester.getSize(find.byType(FlexResizableRegion).first).height, 90);
+
+      await tester.pumpWidget(
+        build(Axis.vertical, 100, [
+          .flex(builder: (_, _, _) => const Align(child: Text('X'))),
+          .flex(builder: (_, _, _) => const Align(child: Text('Y'))),
+        ]),
+      );
+      expect(tester.getSize(find.byType(FlexResizableRegion).first).height, 90);
+      expect(tester.getSize(find.byType(FlexResizableRegion).last).height, 10);
+    });
+
+    testWidgets('a structural change rebuilds from the new configuration', (tester) async {
+      await tester.pumpWidget(build(Axis.vertical, 100, [.flex(builder: stub), .flex(builder: stub)]));
+      await tester.timedDrag(find.byType(VerticalDivider), const Offset(0, 100), const Duration(seconds: 1));
+      await tester.pumpAndSettle();
+      expect(tester.getSize(find.byType(FlexResizableRegion).first).height, 90);
+
+      await tester.pumpWidget(build(Axis.vertical, 100, [.flex(builder: stub), .flex(flex: 2, builder: stub)]));
+      expect(tester.getSize(find.byType(FlexResizableRegion).first).height, closeTo(100 / 3, 0.01));
+      expect(tester.getSize(find.byType(FlexResizableRegion).last).height, closeTo(200 / 3, 0.01));
+
+      await tester.pumpWidget(
+        build(Axis.vertical, 90, [.flex(builder: stub), .flex(builder: stub), .flex(builder: stub)]),
+      );
+      expect(find.byType(FlexResizableRegion), findsNWidgets(3));
+      expect(tester.getSize(find.byType(FlexResizableRegion).at(1)).height, 30);
+    });
+  });
 }

--- a/forui_cli/bin/forui_cli.dart
+++ b/forui_cli/bin/forui_cli.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
+
 import 'package:forui_cli/src/commands/init/command.dart';
 import 'package:forui_cli/src/commands/snippet/command.dart';
 import 'package:forui_cli/src/commands/style/command.dart';

--- a/forui_cli/lib/src/commands/init/command.dart
+++ b/forui_cli/lib/src/commands/init/command.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'package:yaml/yaml.dart';
+
 import 'package:forui_cli/src/codec.dart';
 import 'package:forui_cli/src/commands/snippet/snippet.dart';
 import 'package:forui_cli/src/components/autocomplete.dart';
@@ -12,7 +14,6 @@ import 'package:forui_cli/src/terminal/command.dart';
 import 'package:forui_cli/src/terminal/primitives.dart';
 import 'package:forui_cli/src/terminal/terminal.dart';
 import 'package:forui_cli/src/terminal/theme.dart';
-import 'package:yaml/yaml.dart';
 
 const _placeholderImport = "import 'theme.dart';";
 

--- a/forui_cli/lib/src/components/confirm.dart
+++ b/forui_cli/lib/src/components/confirm.dart
@@ -8,12 +8,7 @@ import 'package:forui_cli/src/terminal/theme.dart';
 /// confirms the current choice. Returns [Cancelled] on Esc / Ctrl+C.
 ///
 /// Ported from [clack](https://github.com/bombshell-dev/clack). AI-generated; use at your own risk.
-bool confirm({
-  required String message,
-  bool initial = true,
-  String active = 'Yes',
-  String inactive = 'No',
-}) {
+bool confirm({required String message, bool initial = true, String active = 'Yes', String inactive = 'No'}) {
   if (!terminal.interactive) {
     return initial;
   }

--- a/forui_cli/lib/src/components/select.dart
+++ b/forui_cli/lib/src/components/select.dart
@@ -8,12 +8,8 @@ import 'package:forui_cli/src/terminal/theme.dart';
 /// See [groupedSelect] for [initial], [maxItems], and the return value.
 ///
 /// Ported from [clack](https://github.com/bombshell-dev/clack). AI-generated; use at your own risk.
-Result<T> select<T>({
-  required String message,
-  required List<SelectOption<T>> options,
-  T? initial,
-  int maxItems = 8,
-}) => groupedSelect(message: message, options: {'': options}, initial: initial, maxItems: maxItems);
+Result<T> select<T>({required String message, required List<SelectOption<T>> options, T? initial, int maxItems = 8}) =>
+    groupedSelect(message: message, options: {'': options}, initial: initial, maxItems: maxItems);
 
 /// Prompts the user to pick one option from grouped [options], using arrow-key navigation.
 ///

--- a/forui_cli/lib/src/configuration.dart
+++ b/forui_cli/lib/src/configuration.dart
@@ -1,8 +1,9 @@
 import 'dart:io';
 
 import 'package:dart_style/dart_style.dart';
-import 'package:forui_cli/src/terminal/terminal.dart';
 import 'package:yaml/yaml.dart';
+
+import 'package:forui_cli/src/terminal/terminal.dart';
 
 const defaults =
     '''

--- a/forui_cli/lib/src/preset/theme.dart
+++ b/forui_cli/lib/src/preset/theme.dart
@@ -70,12 +70,7 @@ part of '$themeFileName';
 /// Icon tokens for the generated theme.''';
 
 /// Generates the theme files for [preset] under [output], installing any required fonts and icon packages.
-Future<void> create(
-  Configuration configuration,
-  Preset preset, {
-  required bool force,
-  required String output,
-}) async {
+Future<void> create(Configuration configuration, Preset preset, {required bool force, required String output}) async {
   final separator = Platform.pathSeparator;
   final themePath =
       '${configuration.root.path}$separator${output.endsWith('.dart') ? output : '$output${separator}theme.dart'}';

--- a/forui_cli/lib/src/preset/typography.dart
+++ b/forui_cli/lib/src/preset/typography.dart
@@ -1,13 +1,14 @@
 import 'dart:io';
 
+import 'package:yaml/yaml.dart';
+import 'package:yaml_edit/yaml_edit.dart';
+
 import 'package:forui_cli/src/codec.dart';
 import 'package:forui_cli/src/commands/theme/theme.dart';
 import 'package:forui_cli/src/components/log.dart';
 import 'package:forui_cli/src/components/spinner.dart';
 import 'package:forui_cli/src/configuration.dart';
 import 'package:forui_cli/src/terminal/terminal.dart';
-import 'package:yaml/yaml.dart';
-import 'package:yaml_edit/yaml_edit.dart';
 
 /// Generates the typography section, swapping in [preset]'s display and body fonts where they differ from the default.
 String generateTypography(Preset preset) {

--- a/forui_cli/lib/src/terminal/command.dart
+++ b/forui_cli/lib/src/terminal/command.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
+
 import 'package:forui_cli/src/terminal/text.dart';
 import 'package:forui_cli/src/terminal/theme.dart';
 

--- a/forui_cli/test/src/codec_test.dart
+++ b/forui_cli/test/src/codec_test.dart
@@ -1,5 +1,6 @@
-import 'package:forui_cli/forui_cli.dart';
 import 'package:test/test.dart';
+
+import 'package:forui_cli/forui_cli.dart';
 
 void main() {
   group('codec', () {

--- a/forui_cli/tool/main.dart
+++ b/forui_cli/tool/main.dart
@@ -12,7 +12,7 @@ import 'generate_styles.dart';
 import 'generate_theme.dart';
 
 final library = p.join(Directory.current.parent.path, 'forui', 'lib');
-final _base =  p.join(Directory.current.parent.path, 'forui_cli', 'lib', 'src');
+final _base = p.join(Directory.current.parent.path, 'forui_cli', 'lib', 'src');
 final _snippet = p.join(_base, 'commands', 'snippet', 'snippet.dart');
 final _icons = p.join(_base, 'preset', 'icon_mapping.dart');
 final _style = p.join(_base, 'commands', 'style', 'style.dart');


### PR DESCRIPTION
**Describe the changes**

Fixes #1072.

- `FResizable` rebuilt its regions from the declared children on **every** layout pass, so divider drags were discarded whenever the main-axis constraint changed (e.g. a desktop window resize), snapping regions back to their initial sizes. Regression from flex support (#1042), which tied region computation to the live constraint.
- Split the per-layout work into two modes:
  - `_reset` — rebuilds from the declared config on the first layout or a configuration change.
  - `_scale` — preserves the current (possibly dragged) sizes and rescales them to the new total on a constraint-only change.
- Resize semantics: fixed regions keep their pixel size; flex regions absorb the change, spilling onto fixed regions only once flex runs out of room.
- A `_dirty` flag (set on first layout, axis/children/hit-extent changes) selects the mode; `didUpdateWidget` compares children by layout config, ignoring `builder`/`child`/`key` so ordinary rebuilds don't reset drags.
- Relax the non-cascade controller's sum assertion to `.around` for float drift after rescaling.
- Add resize regression tests (drag-then-resize preservation across flex/fixed/mixed, both axes + RTL) and an `FResizable` demo to the example sandbox.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)