### PR TITLE
Fix `FPortal` & `FPointPortal` rendering behind the soft keyboard

### DIFF
--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -17,6 +17,11 @@
   `FDateSelectionControl.liftedMulti(...)` or `FDateSelectionControl.liftedRange(...)` instead.
 
 
+### `FPortal` & `FPointPortal`
+* Fix portal (and dependents like `FPopover`, `FSelect`, and `FAutocomplete`) rendering behind the soft keyboard when
+  shown inside a scrollable within a Material `Scaffold`.
+
+
 ### `FResizable`
 * Fix `FResizable` resetting regions to their initial sizes when the main-axis constraint changes (e.g. window resize).
 

--- a/forui/lib/src/foundation/overlay/point_portal.dart
+++ b/forui/lib/src/foundation/overlay/point_portal.dart
@@ -176,7 +176,7 @@ class _State extends State<FPointPortal> with WidgetsBindingObserver {
     // resizeToAvoidBottomInset removes the bottom inset via MediaQuery.removeViewInsets) is not notified when the
     // keyboard opens, as the absorbed MediaQuery no longer changes. Rebuild on metrics changes so
     // MediaQuery.viewInsetsOf is re-read and the portal stays clear of the keyboard.
-    if (_controller.isShowing) {
+    if ((widget.useViewInsets || widget.useViewPadding) && _controller.isShowing) {
       setState(() {});
     }
   }

--- a/forui/lib/src/foundation/overlay/point_portal.dart
+++ b/forui/lib/src/foundation/overlay/point_portal.dart
@@ -152,7 +152,7 @@ class FPointPortal extends StatefulWidget {
   }
 }
 
-class _State extends State<FPointPortal> {
+class _State extends State<FPointPortal> with WidgetsBindingObserver {
   final _notifier = FChangeNotifier();
   final _link = ChildLayerLink();
   late OverlayPortalController _controller;
@@ -161,12 +161,24 @@ class _State extends State<FPointPortal> {
   void initState() {
     super.initState();
     _controller = widget.control.create();
+    WidgetsBinding.instance.addObserver(this);
   }
 
   @override
   void didUpdateWidget(covariant FPointPortal old) {
     super.didUpdateWidget(old);
     _controller = widget.control.update(old.control, _controller).$1;
+  }
+
+  @override
+  void didChangeMetrics() {
+    // A portal shown under an ancestor that absorbs the view insets (e.g. a Material Scaffold with
+    // resizeToAvoidBottomInset removes the bottom inset via MediaQuery.removeViewInsets) is not notified when the
+    // keyboard opens, as the absorbed MediaQuery no longer changes. Rebuild on metrics changes so
+    // MediaQuery.viewInsetsOf is re-read and the portal stays clear of the keyboard.
+    if (_controller.isShowing) {
+      setState(() {});
+    }
   }
 
   @override
@@ -183,9 +195,6 @@ class _State extends State<FPointPortal> {
             ? .fromViewPadding(view.viewPadding, view.devicePixelRatio)
             : .zero;
 
-        // We don't derive the insets from the view as it does not notify dependencies of changes. This led to
-        // incomplete insets being applied when a keyboard is sliding up from the bottom of the screen WHILE the portal
-        // is being built.
         final insets = widget.useViewInsets ? MediaQuery.viewInsetsOf(context) : EdgeInsets.zero;
 
         Widget portal = CompositedPointPortal(
@@ -235,6 +244,7 @@ class _State extends State<FPointPortal> {
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _notifier.dispose();
     super.dispose();
   }

--- a/forui/lib/src/foundation/overlay/portal.dart
+++ b/forui/lib/src/foundation/overlay/portal.dart
@@ -79,8 +79,8 @@ class FPortal extends StatefulWidget {
   /// Whether to avoid the platform view's insets (the soft keyboard).
   ///
   /// ## Note
-  /// Values are read directly from the [View] rather than [MediaQuery] to ensure unconsumed inset values are used,
-  /// even when a parent widget (e.g. Material `Scaffold`) has already consumed the [MediaQuery] values.
+  /// The inset is read from [MediaQuery], and the portal rebuilds on view metric changes so it still avoids the keyboard
+  /// even when a parent widget (e.g. Material `Scaffold`) has consumed the [MediaQuery] inset.
   /// {@endtemplate}
   ///
   /// Defaults to true.
@@ -152,7 +152,7 @@ class FPortal extends StatefulWidget {
   }
 }
 
-class _State extends State<FPortal> {
+class _State extends State<FPortal> with WidgetsBindingObserver {
   final _notifier = FChangeNotifier();
   final _link = ChildLayerLink();
   late OverlayPortalController _controller;
@@ -161,12 +161,24 @@ class _State extends State<FPortal> {
   void initState() {
     super.initState();
     _controller = widget.control.create();
+    WidgetsBinding.instance.addObserver(this);
   }
 
   @override
   void didUpdateWidget(covariant FPortal old) {
     super.didUpdateWidget(old);
     _controller = widget.control.update(old.control, _controller).$1;
+  }
+
+  @override
+  void didChangeMetrics() {
+    // A portal shown under an ancestor that absorbs the view insets (e.g. a Material Scaffold with
+    // resizeToAvoidBottomInset removes the bottom inset via MediaQuery.removeViewInsets) is not notified when the
+    // keyboard opens, as the absorbed MediaQuery no longer changes. Rebuild on metrics changes so
+    // MediaQuery.viewInsetsOf is re-read and the portal stays clear of the keyboard.
+    if (_controller.isShowing) {
+      setState(() {});
+    }
   }
 
   @override
@@ -185,9 +197,6 @@ class _State extends State<FPortal> {
             ? .fromViewPadding(view.viewPadding, view.devicePixelRatio)
             : .zero;
 
-        // We don't derive the insets from the view as it does not notify dependencies of changes. This led to
-        // incomplete insets being applied when a keyboard is sliding up from the bottom of the screen WHILE the portal
-        // is being built.
         final insets = widget.useViewInsets ? MediaQuery.viewInsetsOf(context) : EdgeInsets.zero;
 
         Widget portal = CompositedPortal(
@@ -237,6 +246,7 @@ class _State extends State<FPortal> {
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _notifier.dispose();
     super.dispose();
   }

--- a/forui/lib/src/foundation/overlay/portal.dart
+++ b/forui/lib/src/foundation/overlay/portal.dart
@@ -176,7 +176,7 @@ class _State extends State<FPortal> with WidgetsBindingObserver {
     // resizeToAvoidBottomInset removes the bottom inset via MediaQuery.removeViewInsets) is not notified when the
     // keyboard opens, as the absorbed MediaQuery no longer changes. Rebuild on metrics changes so
     // MediaQuery.viewInsetsOf is re-read and the portal stays clear of the keyboard.
-    if (_controller.isShowing) {
+    if ((widget.useViewInsets || widget.useViewPadding) && _controller.isShowing) {
       setState(() {});
     }
   }

--- a/forui/test/src/foundation/overlay/point_portal_test.dart
+++ b/forui/test/src/foundation/overlay/point_portal_test.dart
@@ -40,4 +40,53 @@ void main() {
 
     expect(taps, 1);
   });
+
+  testWidgets('avoids a keyboard that opens while shown inside a scrollable Scaffold', (tester) async {
+    // 400x600 screen; the keyboard occupies the bottom 300 (its top edge sits at y = 300).
+    tester.view.physicalSize = const Size(400, 600);
+    tester.view.devicePixelRatio = 1.0;
+    tester.view.viewInsets = FakeViewPadding.zero; // keyboard closed
+    addTearDown(tester.view.reset);
+
+    final controller = OverlayPortalController();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: FLocalizations.localizationsDelegates,
+        supportedLocales: FLocalizations.supportedLocales,
+        home: FTheme(
+          data: FTheme.neutral.light.touch,
+          child: Scaffold(
+            body: ListView(
+              children: [
+                const SizedBox(height: 250), // places the child above the keyboard
+                FPointPortal(
+                  control: .managed(controller: controller),
+                  point: const Offset(100, 20), // bottom-center of the child
+                  anchor: .topCenter,
+                  portalBuilder: (context, _) => const ColoredBox(
+                    key: ValueKey('portal'),
+                    color: Colors.red,
+                    child: SizedBox(height: 150, width: 200),
+                  ),
+                  child: const ColoredBox(color: Colors.yellow, child: SizedBox(height: 20, width: 200)),
+                ),
+                const SizedBox(height: 600), // makes the list scrollable
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    controller.show();
+    await tester.pumpAndSettle();
+
+    // The keyboard slides up after the portal is already shown.
+    tester.view.viewInsets = const FakeViewPadding(bottom: 300);
+    await tester.pumpAndSettle();
+
+    // The portal flips above the point instead of rendering behind the keyboard.
+    expect(tester.getRect(find.byKey(const ValueKey('portal'))).bottom, lessThanOrEqualTo(300));
+  });
 }

--- a/forui/test/src/foundation/overlay/portal_test.dart
+++ b/forui/test/src/foundation/overlay/portal_test.dart
@@ -41,4 +41,51 @@ void main() {
 
     expect(taps, 1);
   });
+
+  testWidgets('avoids a keyboard that opens while shown inside a scrollable Scaffold', (tester) async {
+    // 400x600 screen; the keyboard occupies the bottom 300 (its top edge sits at y = 300).
+    tester.view.physicalSize = const Size(400, 600);
+    tester.view.devicePixelRatio = 1.0;
+    tester.view.viewInsets = FakeViewPadding.zero; // keyboard closed
+    addTearDown(tester.view.reset);
+
+    final controller = OverlayPortalController();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: FLocalizations.localizationsDelegates,
+        supportedLocales: FLocalizations.supportedLocales,
+        home: FTheme(
+          data: FTheme.neutral.light.touch,
+          child: Scaffold(
+            body: ListView(
+              children: [
+                const SizedBox(height: 250), // places the child above the keyboard
+                FPortal(
+                  control: .managed(controller: controller),
+                  portalBuilder: (context, _) => const ColoredBox(
+                    key: ValueKey('portal'),
+                    color: Colors.red,
+                    child: SizedBox(height: 150, width: 200),
+                  ),
+                  child: const ColoredBox(color: Colors.yellow, child: SizedBox.square(dimension: 20)),
+                ),
+                const SizedBox(height: 600), // makes the list scrollable
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    controller.show();
+    await tester.pumpAndSettle();
+
+    // The keyboard slides up after the portal is already shown.
+    tester.view.viewInsets = const FakeViewPadding(bottom: 300);
+    await tester.pumpAndSettle();
+
+    // The portal flips above its child instead of rendering behind the keyboard.
+    expect(tester.getRect(find.byKey(const ValueKey('portal'))).bottom, lessThanOrEqualTo(300));
+  });
 }


### PR DESCRIPTION
**Describe the changes**

Fixes #1053.

- A portal shown inside a scrollable within a Material `Scaffold` (with the default `resizeToAvoidBottomInset: true`) was not rebuilt when the keyboard opened, so `FPopover`/`FSelect`/`FAutocomplete` dropdowns could render behind the keyboard with their lower items unreachable.
- Root cause: the Scaffold resizes its body and removes the bottom view inset from the body's `MediaQuery`. Combined with a scrollable's layout-time build and `OverlayPortal`'s deferred overlay child, the overlay child stops receiving `MediaQuery` change notifications, so it keeps the stale (keyboard-closed) inset. `MediaQuery.viewInsetsOf` still reports the correct value on rebuild; only the notification is lost.
- Fix: `FPortal` and `FPointPortal` now observe `WidgetsBindingObserver.didChangeMetrics` and rebuild while shown, so `MediaQuery.viewInsetsOf` is re-read as the keyboard slides in and out. The inset value source is unchanged.
- Corrected the `useViewInsets` dartdoc, which claimed the inset was read from `View` (it is read from `MediaQuery`).
- Added regression tests for both `FPortal` and `FPointPortal` that reproduce the issue (a portal shown in a `ListView` inside a `Scaffold`, then the keyboard opens) and fail without the fix.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)