### PR TITLE
Fix persistent focus outline after pointer click with web semantics (#1079)

### DIFF
--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -17,6 +17,10 @@
   `FDateSelectionControl.liftedMulti(...)` or `FDateSelectionControl.liftedRange(...)` instead.
 
 
+### `FFocusHighlight`
+* Add `FFocusHighlight` to gate descendant focus decorations on `FocusManager.highlightMode`.
+
+
 ### `FPortal` & `FPointPortal`
 * Fix portal (and dependents like `FPopover`, `FSelect`, and `FAutocomplete`) rendering behind the soft keyboard when
   shown inside a scrollable within a Material `Scaffold`.
@@ -42,6 +46,9 @@
 * Add italic support to the bundled `Inter` font.
 
 * Change the bundled `Inter` font to a variable font.
+
+* Fix focus outlines and highlights persisting after a pointer click when Flutter web semantics are enabled. Focus
+  decorations now follow `FocusManager.highlightMode`.
 
 
 ## 0.23.0

--- a/forui/example/lib/sandbox.dart
+++ b/forui/example/lib/sandbox.dart
@@ -1,6 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+
 import 'package:forui/forui.dart';
 
+/// Repro for https://github.com/duobaseio/forui/issues/1079.
+///
+/// Run on the web (`flutter run -d chrome`) for the true repro. With semantics enabled, a mouse click routes through the
+/// accessibility tree as a `SemanticsAction.focus`, which Flutter treats as a touch interaction ([FocusHighlightMode] ->
+/// `touch`). Focus decorations should therefore NOT appear on a pointer click, only after keyboard (Tab) focus flips the
+/// mode back to `traditional`.
+///
+/// Watch the live highlight mode readout as you click vs. Tab. The Material button is there as a reference; it already
+/// gates its focus highlight on the mode.
 class Sandbox extends StatefulWidget {
   const Sandbox({super.key});
 
@@ -9,102 +20,88 @@ class Sandbox extends StatefulWidget {
 }
 
 class _SandboxState extends State<Sandbox> {
+  SemanticsHandle? _semantics;
+  FocusHighlightMode _mode = FocusManager.instance.highlightMode;
+
   @override
-  void dispose() {
-    super.dispose();
+  void initState() {
+    super.initState();
+    _semantics = SemanticsBinding.instance.ensureSemantics();
+    FocusManager.instance.addHighlightModeListener(_onModeChange);
   }
 
   @override
-  Widget build(BuildContext context) => SingleChildScrollView(
-    padding: const EdgeInsets.all(20),
-    child: Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        spacing: 20,
-        children: [
-          FSelect<String>(
-            hint: 'Select a fruit',
-            label: const Text('Fruit'),
-            description: const Text('Select a fruit'),
-            items: const {
-              'Apple': 'Apple',
-              'Banana': 'Banana',
-              'Blueberry': 'Blueberry',
-              'Grapes': 'Grapes',
-              'Lemon': 'Lemon',
-              'Mango': 'Mango',
-              'Kiwi': 'Kiwi',
-              'Orange': 'Orange',
-              'Pear': 'Pear',
-              'Strawberry': 'Strawberry',
-            },
-          ),
-          FMultiSelect<String>(
-            hint: const Text('Select fruits'),
-            label: const Text('Fruits'),
-            description: const Text('Select your favorite fruits'),
-            items: const {
-              'Apple': 'Apple',
-              'Banana': 'Banana',
-              'Blueberry': 'Blueberry',
-              'Grapes': 'Grapes',
-              'Lemon': 'Lemon',
-              'Mango': 'Mango',
-              'Kiwi': 'Kiwi',
-              'Orange': 'Orange',
-              'Pear': 'Pear',
-              'Strawberry': 'Strawberry',
-            },
-          ),
-          // Drag the dividers, then resize the window: the fixed sidebar keeps its pixel width and the flex
-          // regions scale to fill the rest, without resetting to their initial sizes.
-          DecoratedBox(
-            decoration: BoxDecoration(
-              border: Border.all(color: context.theme.colors.border),
-              borderRadius: BorderRadius.circular(8),
-            ),
-            child: FResizable(
-              axis: .horizontal,
-              crossAxisExtent: 200,
-              children: [
-                .fixed(
-                  extent: 160,
-                  minExtent: 100,
-                  builder: (context, data, _) => _Region(label: 'Sidebar (fixed)', data: data),
-                ),
-                .flex(
-                  builder: (context, data, _) => _Region(label: 'Content (flex 1)', data: data),
-                ),
-                .flex(
-                  flex: 2,
-                  builder: (context, data, _) => _Region(label: 'Preview (flex 2)', data: data),
-                ),
-              ],
-            ),
-          ),
-        ],
-      ),
-    ),
-  );
-}
+  void dispose() {
+    FocusManager.instance.removeHighlightModeListener(_onModeChange);
+    _semantics?.dispose();
+    super.dispose();
+  }
 
-class _Region extends StatelessWidget {
-  final String label;
-  final FResizableRegionData data;
+  void _onModeChange(FocusHighlightMode mode) => setState(() => _mode = mode);
 
-  const _Region({required this.label, required this.data});
+  void _toggleSemantics() => setState(() {
+    if (_semantics case final handle?) {
+      handle.dispose();
+      _semantics = null;
+    } else {
+      _semantics = SemanticsBinding.instance.ensureSemantics();
+    }
+  });
 
   @override
   Widget build(BuildContext context) {
     final FThemeData(:colors, :typography) = context.theme;
-    return Align(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(label, style: typography.body.sm.copyWith(color: colors.foreground)),
-          const SizedBox(height: 4),
-          Text('${data.extent.current.round()} px', style: typography.body.xs.copyWith(color: colors.mutedForeground)),
-        ],
+    final enabled = _semantics != null;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(20),
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 360),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            spacing: 16,
+            children: [
+              Text('Issue #1079', style: typography.body.lg.copyWith(color: colors.foreground)),
+              Text(
+                'Click a button with the mouse, then press Tab. With semantics on (web), the click should NOT leave a '
+                'focus outline; Tab should.',
+                textAlign: TextAlign.center,
+                style: typography.body.sm.copyWith(color: colors.mutedForeground),
+              ),
+              DecoratedBox(
+                decoration: BoxDecoration(
+                  border: Border.all(color: colors.border),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    spacing: 2,
+                    children: [
+                      Text('semantics: ${enabled ? 'on' : 'off'}', style: typography.body.sm),
+                      Text('highlight mode: ${_mode.name}', style: typography.body.sm),
+                    ],
+                  ),
+                ),
+              ),
+              FButton(
+                variant: .outline,
+                onPress: _toggleSemantics,
+                child: Text(enabled ? 'Disable semantics' : 'Enable semantics'),
+              ),
+              const FDivider(),
+              FButton(onPress: () {}, child: const Text('FButton primary')),
+              FButton(variant: .outline, onPress: () {}, child: const Text('FButton outline')),
+              FButton(variant: .secondary, onPress: () {}, child: const Text('FButton secondary')),
+              FButton(variant: .destructive, onPress: () {}, child: const Text('FButton destructive')),
+              const FTextField(hint: 'FTextField (keeps its focus border)'),
+              const SizedBox(height: 4),
+              ElevatedButton(onPressed: () {}, child: const Text('Material ElevatedButton')),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/forui/lib/foundation.dart
+++ b/forui/lib/foundation.dart
@@ -4,7 +4,7 @@ library forui.foundation;
 export 'src/foundation/barrier.dart';
 export 'src/foundation/collapsible.dart';
 export 'src/foundation/doc_templates.dart' hide Control, Focus, FormFieldKey, Scroll, Semantics, TappableGroup;
-export 'src/foundation/focused_outline.dart';
+export 'src/foundation/focused_outline.dart' hide FocusHighlightScope;
 export 'src/foundation/form_field_properties.dart';
 export 'src/foundation/notifiers.dart' hide InternalFMultiValueControl;
 export 'src/foundation/rendering.dart' hide Alignments, DefaultData, RenderBoxes;

--- a/forui/lib/src/foundation/focused_outline.dart
+++ b/forui/lib/src/foundation/focused_outline.dart
@@ -11,6 +11,65 @@ import 'package:forui/forui.dart';
 
 part 'focused_outline.design.dart';
 
+@internal
+class FocusHighlightScope extends StatefulWidget {
+  final Widget child;
+
+  const FocusHighlightScope({required this.child, super.key});
+
+  @override
+  State<FocusHighlightScope> createState() => _FocusHighlightScopeState();
+}
+
+class _FocusHighlightScopeState extends State<FocusHighlightScope> {
+  late bool _highlight;
+
+  @override
+  void initState() {
+    super.initState();
+    _highlight = FocusManager.instance.highlightMode == .traditional;
+    FocusManager.instance.addHighlightModeListener(_onChange);
+  }
+
+  @override
+  void dispose() {
+    FocusManager.instance.removeHighlightModeListener(_onChange);
+    super.dispose();
+  }
+
+  void _onChange(FocusHighlightMode mode) {
+    final highlight = FocusManager.instance.highlightMode == .traditional;
+    if (mounted && _highlight != highlight) {
+      setState(() => _highlight = highlight);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => FFocusHighlight(highlight: _highlight, child: widget.child);
+}
+
+/// Provides the current [FocusHighlightMode] down the widget tree.
+class FFocusHighlight extends InheritedWidget {
+  /// Returns whether a highlight should be applied to focused descendants.
+  @useResult
+  static bool of(BuildContext context) => context.dependOnInheritedWidgetOfExactType<FFocusHighlight>()!.highlight;
+
+  /// True if a highlight should be applied to focused descendants.
+  final bool highlight;
+
+  /// Creates a [FFocusHighlight].
+  const FFocusHighlight({required this.highlight, required super.child, super.key});
+
+  @override
+  bool updateShouldNotify(FFocusHighlight old) => highlight != old.highlight;
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(FlagProperty('highlight', value: highlight, ifTrue: 'highlight'));
+  }
+}
+
 /// An outline around a focused widget that does not affect its layout.
 ///
 /// See:

--- a/forui/lib/src/foundation/tappable/tappable.dart
+++ b/forui/lib/src/foundation/tappable/tappable.dart
@@ -470,6 +470,7 @@ class _FTappableState<T extends FTappable> extends State<T> {
   late FTappableStyle _style;
   late FocusNode _focus;
   late Set<FTappableVariant> _current;
+  late bool _highlight;
   FTappableVariant? _platform;
   int _monotonic = 0;
   int _buttons = 0;
@@ -491,6 +492,20 @@ class _FTappableState<T extends FTappable> extends State<T> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     _style = widget.style(context.theme.tappableStyle);
+    _highlight = FFocusHighlight.of(context);
+    if (_highlight) {
+      if (_focus.hasFocus) {
+        _current.add(FTappableVariant.focused);
+      }
+      if (_focus.hasPrimaryFocus) {
+        _current.add(FTappableVariant.primaryFocused);
+      }
+    } else {
+      _current
+        ..remove(FTappableVariant.focused)
+        ..remove(FTappableVariant.primaryFocused);
+    }
+
     // This cast is always fine since extension types are erased at runtime.
     if (context.platformVariant case final FTappableVariant platform when _platform != platform) {
       _current
@@ -613,8 +628,10 @@ class _FTappableState<T extends FTappable> extends State<T> {
             canRequestFocus: !widget._disabled,
             onFocusChange: (focused) {
               setState(() {
-                _update(.focused, focused);
-                _update(.primaryFocused, _focus.hasPrimaryFocus);
+                if (_highlight) {
+                  _update(.focused, focused);
+                  _update(.primaryFocused, _focus.hasPrimaryFocus);
+                }
               });
               widget.onFocusChange?.call(focused);
             },

--- a/forui/lib/src/theme/theme.dart
+++ b/forui/lib/src/theme/theme.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:forui/src/foundation/focused_outline.dart';
 
 import 'package:meta/meta.dart';
 
 import 'package:forui/forui.dart';
+import 'package:forui/src/foundation/focused_outline.dart';
 
 part 'theme.design.dart';
 

--- a/forui/lib/src/theme/theme.dart
+++ b/forui/lib/src/theme/theme.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:forui/src/foundation/focused_outline.dart';
 
 import 'package:meta/meta.dart';
 
@@ -289,15 +290,17 @@ class FBasicTheme extends StatelessWidget {
   const FBasicTheme({required this.data, required this.child, this.textDirection, this.platform, super.key});
 
   @override
-  Widget build(BuildContext context) => FAdaptiveScope(
-    platform: platform,
-    child: _InheritedTheme(
-      data: data,
-      child: Directionality(
-        textDirection: textDirection ?? Directionality.maybeOf(context) ?? .ltr,
-        child: DefaultTextStyle(
-          style: data.typography.body.sm.copyWith(color: data.colors.foreground),
-          child: child,
+  Widget build(BuildContext context) => FocusHighlightScope(
+    child: FAdaptiveScope(
+      platform: platform,
+      child: _InheritedTheme(
+        data: data,
+        child: Directionality(
+          textDirection: textDirection ?? Directionality.maybeOf(context) ?? .ltr,
+          child: DefaultTextStyle(
+            style: data.typography.body.sm.copyWith(color: data.colors.foreground),
+            child: child,
+          ),
         ),
       ),
     ),

--- a/forui/lib/src/widgets/picker/picker_wheel.dart
+++ b/forui/lib/src/widgets/picker/picker_wheel.dart
@@ -142,7 +142,7 @@ abstract class _State<T extends FPickerWheel> extends State<T> {
         child: Stack(
           alignment: .center,
           children: [
-            if (_focused)
+            if (_focused && FFocusHighlight.of(context))
               Container(
                 height: extent,
                 decoration: ShapeDecoration(

--- a/forui/lib/src/widgets/select/content/content.dart
+++ b/forui/lib/src/widgets/select/content/content.dart
@@ -231,7 +231,9 @@ class _ContentState<T> extends State<Content<T>> {
       );
     }
 
-    return content;
+    // Force the highlight on so items stay highlighted regardless of the global highlight mode. Focus is the
+    // active-descendant highlight rather than a keyboard-traversal affordance.
+    return FFocusHighlight(highlight: true, child: content);
   }
 
   Future<void> _ensureVisible(BuildContext context) async {

--- a/forui/lib/src/widgets/select_menu_tile.dart
+++ b/forui/lib/src/widgets/select_menu_tile.dart
@@ -681,7 +681,7 @@ class _FSelectMenuTileState<T> extends State<FSelectMenuTile<T>> with TickerProv
           final variants = <FFormFieldVariant>{
             if (!widget.enabled) .disabled,
             if (state.errorText != null) .error,
-            if (_focused) .focused,
+            if (_focused && FFocusHighlight.of(context)) .focused,
           };
           final error = state.errorText == null ? null : widget.errorBuilder(context, state.errorText!);
 

--- a/forui/lib/src/widgets/switch.dart
+++ b/forui/lib/src/widgets/switch.dart
@@ -142,7 +142,7 @@ class _FSwitchState extends State<FSwitch> {
     final formVariants = <FFormFieldVariant>{
       if (!widget.enabled) .disabled,
       if (widget.error != null) .error,
-      if (_focused) .focused,
+      if (_focused && FFocusHighlight.of(context)) .focused,
     };
     final variants = <FVariant>{if (widget.value) FSwitchVariant.selected, ...formVariants};
     final (layout, labelStyle) = widget.leadingLabel

--- a/forui/test/src/foundation/tappable/tappable_group_test.dart
+++ b/forui/test/src/foundation/tappable/tappable_group_test.dart
@@ -258,6 +258,9 @@ void main() {
     });
 
     testWidgets('focus still works', (tester) async {
+      FocusManager.instance.highlightStrategy = .alwaysTraditional;
+      addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
       final focusNode = autoDispose(FocusNode());
       await tester.pumpWidget(
         TestScaffold(

--- a/forui/test/src/foundation/tappable/tappable_test.dart
+++ b/forui/test/src/foundation/tappable/tappable_test.dart
@@ -77,6 +77,9 @@ void main() {
 
   group('FTappable', () {
     testWidgets('focused when enabled', (tester) async {
+      FocusManager.instance.highlightStrategy = .alwaysTraditional;
+      addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
       await tester.pumpWidget(
         TestScaffold(
           child: FTappable(focusNode: focusNode, builder: (_, states, _) => Text('$states'), onPress: () {}),
@@ -356,6 +359,9 @@ void main() {
 
   group('FTappable.static', () {
     testWidgets('focused when enabled', (tester) async {
+      FocusManager.instance.highlightStrategy = .alwaysTraditional;
+      addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
       await tester.pumpWidget(
         TestScaffold(
           child: FTappable.static(focusNode: focusNode, builder: (_, states, _) => Text('$states'), onPress: () {}),
@@ -827,6 +833,9 @@ void main() {
   });
 
   testWidgets('returns focused state on primary focus', (tester) async {
+    FocusManager.instance.highlightStrategy = .alwaysTraditional;
+    addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
     final focus = autoDispose(FocusNode());
 
     var focused = false;
@@ -850,6 +859,9 @@ void main() {
   });
 
   testWidgets('return focused state on non-primary focus', (tester) async {
+    FocusManager.instance.highlightStrategy = .alwaysTraditional;
+    addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
     final focus = autoDispose(FocusNode());
 
     var focused = false;

--- a/forui/test/src/widgets/accordion/accordion_golden_test.dart
+++ b/forui/test/src/widgets/accordion/accordion_golden_test.dart
@@ -63,6 +63,9 @@ void main() {
     });
 
     testWidgets('focused', (tester) async {
+      FocusManager.instance.highlightStrategy = .alwaysTraditional;
+      addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
       await tester.pumpWidget(
         TestScaffold(
           theme: theme.data,

--- a/forui/test/src/widgets/bottom_navigation_bar/bottom_navigation_bar_golden_test.dart
+++ b/forui/test/src/widgets/bottom_navigation_bar/bottom_navigation_bar_golden_test.dart
@@ -111,6 +111,9 @@ void main() {
     });
 
     testWidgets('focused - ${theme.name}', (tester) async {
+      FocusManager.instance.highlightStrategy = .alwaysTraditional;
+      addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
       await tester.pumpWidget(
         TestScaffold(
           theme: theme.data,

--- a/forui/test/src/widgets/breadcrumb/breadcrumb_golden_test.dart
+++ b/forui/test/src/widgets/breadcrumb/breadcrumb_golden_test.dart
@@ -64,6 +64,9 @@ void main() {
     });
 
     testWidgets('${theme.name} with focused breadcrumb', (tester) async {
+      FocusManager.instance.highlightStrategy = .alwaysTraditional;
+      addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
       await tester.pumpWidget(
         TestScaffold(
           theme: theme.data,

--- a/forui/test/src/widgets/button/button_golden_test.dart
+++ b/forui/test/src/widgets/button/button_golden_test.dart
@@ -144,6 +144,9 @@ void main() {
       });
 
       testWidgets('${theme.name} focused', (tester) async {
+        FocusManager.instance.highlightStrategy = .alwaysTraditional;
+        addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
         await tester.pumpWidget(
           TestScaffold(
             theme: theme.data,

--- a/forui/test/src/widgets/calendar/day/day_picker_golden_test.dart
+++ b/forui/test/src/widgets/calendar/day/day_picker_golden_test.dart
@@ -124,6 +124,9 @@ void main() {
         ('focus-middle', 15, _range(10, 19)),
       ]) {
         testWidgets(name, (tester) async {
+          FocusManager.instance.highlightStrategy = .alwaysTraditional;
+          addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
           final controller = _controller();
           await tester.pumpWidget(_harness(controller, theme: theme.data, selected: selected));
           await tester.pumpAndSettle();

--- a/forui/test/src/widgets/calendar/month/month_picker_golden_test.dart
+++ b/forui/test/src/widgets/calendar/month/month_picker_golden_test.dart
@@ -67,6 +67,9 @@ void main() {
 
     group('${theme.name} focus', () {
       testWidgets('focus-plain', (tester) async {
+        FocusManager.instance.highlightStrategy = .alwaysTraditional;
+        addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
         final controller = _controller();
         await tester.pumpWidget(_harness(controller, theme: theme.data));
         await tester.pumpAndSettle();

--- a/forui/test/src/widgets/calendar/year/year_picker_golden_test.dart
+++ b/forui/test/src/widgets/calendar/year/year_picker_golden_test.dart
@@ -67,6 +67,9 @@ void main() {
 
     group('${theme.name} focus', () {
       testWidgets('focus-plain', (tester) async {
+        FocusManager.instance.highlightStrategy = .alwaysTraditional;
+        addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
         final controller = _controller();
         await tester.pumpWidget(_harness(controller, theme: theme.data));
         await tester.pumpAndSettle();

--- a/forui/test/src/widgets/checkbox_golden_test.dart
+++ b/forui/test/src/widgets/checkbox_golden_test.dart
@@ -27,6 +27,9 @@ void main() {
 
   for (final theme in TestScaffold.themes) {
     testWidgets('${theme.name} focused', (tester) async {
+      FocusManager.instance.highlightStrategy = .alwaysTraditional;
+      addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
       await tester.pumpWidget(TestScaffold(theme: theme.data, child: const FCheckbox(autofocus: true)));
 
       await expectLater(find.byType(TestScaffold), matchesGoldenFile('check-box/${theme.name}/focused.png'));

--- a/forui/test/src/widgets/checkbox_test.dart
+++ b/forui/test/src/widgets/checkbox_test.dart
@@ -7,6 +7,9 @@ import '../test_scaffold.dart';
 
 void main() {
   testWidgets('forwards focus to label', (tester) async {
+    FocusManager.instance.highlightStrategy = .alwaysTraditional;
+    addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
     final focus = autoDispose(FocusNode());
     bool focused() => tester
         .widget<FLabel>(find.ancestor(of: find.text('Label'), matching: find.byType(FLabel)))

--- a/forui/test/src/widgets/header/nested_header_golden_test.dart
+++ b/forui/test/src/widgets/header/nested_header_golden_test.dart
@@ -153,6 +153,9 @@ void main() {
     });
 
     testWidgets('${theme.name} with focused FNestedHeader actions', (tester) async {
+      FocusManager.instance.highlightStrategy = .alwaysTraditional;
+      addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
       await tester.pumpWidget(
         TestScaffold.app(
           theme: theme.data,

--- a/forui/test/src/widgets/header/root_header_golden_test.dart
+++ b/forui/test/src/widgets/header/root_header_golden_test.dart
@@ -139,6 +139,9 @@ void main() {
     });
 
     testWidgets('${theme.name} with focused FRootHeader actions', (tester) async {
+      FocusManager.instance.highlightStrategy = .alwaysTraditional;
+      addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
       await tester.pumpWidget(
         TestScaffold(
           theme: theme.data,

--- a/forui/test/src/widgets/item/item_golden_test.dart
+++ b/forui/test/src/widgets/item/item_golden_test.dart
@@ -156,6 +156,9 @@ void main() {
     });
 
     testWidgets('RTL', (tester) async {
+      FocusManager.instance.highlightStrategy = .alwaysTraditional;
+      addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
       await tester.pumpWidget(
         TestScaffold(
           theme: theme.data,
@@ -176,6 +179,9 @@ void main() {
     });
 
     testWidgets('focused', (tester) async {
+      FocusManager.instance.highlightStrategy = .alwaysTraditional;
+      addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
       await tester.pumpWidget(
         TestScaffold(
           theme: theme.data,

--- a/forui/test/src/widgets/item/item_group_golden_test.dart
+++ b/forui/test/src/widgets/item/item_group_golden_test.dart
@@ -261,6 +261,9 @@ void main() {
         });
 
         testWidgets('focused on non-first bottom viewport - ${theme.name} - $divider', (tester) async {
+          FocusManager.instance.highlightStrategy = .alwaysTraditional;
+          addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
           final focusNode = autoDispose(FocusNode());
 
           await tester.pumpWidget(
@@ -384,6 +387,9 @@ void main() {
           });
 
           testWidgets('focused - ${theme.name} - $divider - $position', (tester) async {
+            FocusManager.instance.highlightStrategy = .alwaysTraditional;
+            addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
             await tester.pumpWidget(
               TestScaffold(
                 theme: theme.data,

--- a/forui/test/src/widgets/item/item_group_merge_golden_test.dart
+++ b/forui/test/src/widgets/item/item_group_merge_golden_test.dart
@@ -273,6 +273,9 @@ void main() {
       });
 
       testWidgets('focused on non-first bottom viewport - ${theme.name} - $divider', (tester) async {
+        FocusManager.instance.highlightStrategy = .alwaysTraditional;
+        addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
         final focusNode = autoDispose(FocusNode());
 
         await tester.pumpWidget(

--- a/forui/test/src/widgets/line_calendar/line_calendar_golden_test.dart
+++ b/forui/test/src/widgets/line_calendar/line_calendar_golden_test.dart
@@ -81,6 +81,9 @@ void main() {
   group('states', () {
     for (final theme in TestScaffold.themes) {
       testWidgets('${theme.name} - default', (tester) async {
+        FocusManager.instance.highlightStrategy = .alwaysTraditional;
+        addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
         await tester.pumpWidget(
           TestScaffold(
             theme: theme.data,
@@ -113,6 +116,9 @@ void main() {
       });
 
       testWidgets('${theme.name} - disabled focused', (tester) async {
+        FocusManager.instance.highlightStrategy = .alwaysTraditional;
+        addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
         await tester.pumpWidget(
           TestScaffold(
             theme: theme.data,
@@ -155,6 +161,9 @@ void main() {
       });
 
       testWidgets('${theme.name} - disabled selected focused', (tester) async {
+        FocusManager.instance.highlightStrategy = .alwaysTraditional;
+        addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
         await tester.pumpWidget(
           TestScaffold(
             theme: theme.data,
@@ -215,6 +224,9 @@ void main() {
       });
 
       testWidgets('${theme.name} - selected focused', (tester) async {
+        FocusManager.instance.highlightStrategy = .alwaysTraditional;
+        addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
         await tester.pumpWidget(
           TestScaffold(
             theme: theme.data,

--- a/forui/test/src/widgets/picker/picker_golden_test.dart
+++ b/forui/test/src/widgets/picker/picker_golden_test.dart
@@ -156,6 +156,9 @@ void main() {
     });
 
     testWidgets('${theme.name} focused', (tester) async {
+      FocusManager.instance.highlightStrategy = .alwaysTraditional;
+      addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
       await tester.pumpWidget(
         TestScaffold(
           theme: theme.data,

--- a/forui/test/src/widgets/radio_golden_test.dart
+++ b/forui/test/src/widgets/radio_golden_test.dart
@@ -27,6 +27,9 @@ void main() {
 
   for (final theme in TestScaffold.themes) {
     testWidgets('${theme.name} focused', (tester) async {
+      FocusManager.instance.highlightStrategy = .alwaysTraditional;
+      addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
       await tester.pumpWidget(TestScaffold(theme: theme.data, child: const FRadio(autofocus: true)));
 
       await expectLater(find.byType(TestScaffold), matchesGoldenFile('radio/${theme.name}/focused.png'));

--- a/forui/test/src/widgets/radio_test.dart
+++ b/forui/test/src/widgets/radio_test.dart
@@ -7,6 +7,9 @@ import '../test_scaffold.dart';
 
 void main() {
   testWidgets('forwards focus to label', (tester) async {
+    FocusManager.instance.highlightStrategy = .alwaysTraditional;
+    addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
     final focus = autoDispose(FocusNode());
     bool focused() => tester
         .widget<FLabel>(find.ancestor(of: find.text('Label'), matching: find.byType(FLabel)))

--- a/forui/test/src/widgets/select/multi/tag_golden_test.dart
+++ b/forui/test/src/widgets/select/multi/tag_golden_test.dart
@@ -58,6 +58,9 @@ void main() {
     });
 
     testWidgets('focused', (tester) async {
+      FocusManager.instance.highlightStrategy = .alwaysTraditional;
+      addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
       final focus = autoDispose(FocusNode());
 
       await tester.pumpWidget(

--- a/forui/test/src/widgets/switch_test.dart
+++ b/forui/test/src/widgets/switch_test.dart
@@ -7,6 +7,9 @@ import '../test_scaffold.dart';
 
 void main() {
   testWidgets('forwards focus to label', (tester) async {
+    FocusManager.instance.highlightStrategy = .alwaysTraditional;
+    addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
     final focus = autoDispose(FocusNode());
     bool focused() => tester
         .widget<FLabel>(find.ancestor(of: find.text('Label'), matching: find.byType(FLabel)))

--- a/forui/test/src/widgets/tile/tile_golden_test.dart
+++ b/forui/test/src/widgets/tile/tile_golden_test.dart
@@ -152,6 +152,9 @@ void main() {
     });
 
     testWidgets('RTL', (tester) async {
+      FocusManager.instance.highlightStrategy = .alwaysTraditional;
+      addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
       await tester.pumpWidget(
         TestScaffold(
           theme: theme.data,
@@ -172,6 +175,9 @@ void main() {
     });
 
     testWidgets('focused', (tester) async {
+      FocusManager.instance.highlightStrategy = .alwaysTraditional;
+      addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
       await tester.pumpWidget(
         TestScaffold(
           theme: theme.data,

--- a/forui/test/src/widgets/tile/tile_group_golden_test.dart
+++ b/forui/test/src/widgets/tile/tile_group_golden_test.dart
@@ -265,6 +265,9 @@ void main() {
         });
 
         testWidgets('focused on non-first bottom viewport - ${theme.name} - $divider', (tester) async {
+          FocusManager.instance.highlightStrategy = .alwaysTraditional;
+          addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
           final focusNode = autoDispose(FocusNode());
 
           await tester.pumpWidget(
@@ -393,6 +396,9 @@ void main() {
           });
 
           testWidgets('focused - ${theme.name} - $divider - $position', (tester) async {
+            FocusManager.instance.highlightStrategy = .alwaysTraditional;
+            addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
             await tester.pumpWidget(
               TestScaffold(
                 theme: theme.data,

--- a/forui/test/src/widgets/tile/tile_group_merge_golden_test.dart
+++ b/forui/test/src/widgets/tile/tile_group_merge_golden_test.dart
@@ -282,6 +282,9 @@ void main() {
       });
 
       testWidgets('focused on non-first bottom viewport - ${theme.name} - $divider', (tester) async {
+        FocusManager.instance.highlightStrategy = .alwaysTraditional;
+        addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);
+
         final focusNode = autoDispose(FocusNode());
 
         await tester.pumpWidget(


### PR DESCRIPTION
**Describe the changes**

Fixes #1079.

- Focus decorations previously fired on raw focus. On Flutter web with semantics enabled, a pointer click routes through the accessibility tree as a `SemanticsAction.focus`, moving focus and leaving a persistent, theme-colored focus outline — unlike Material or `:focus-visible`.
- Gate focus decorations on `FocusManager.highlightMode` instead:
  - Add `FFocusHighlight` (foundation): an `InheritedWidget` carrying the current highlight visibility, driven by `FocusHighlightScope` (listens to `FocusManager`) and mounted by `FBasicTheme`.
  - `FTappable` only applies `.focused`/`.primaryFocused` when the highlight is on; `onFocusChange` still fires on raw focus.
  - Gate the self-managed form widgets (`FSwitch`, `FSelect` menu tile, `FPicker` wheel) the same way; force the highlight on for `FSelect` dropdown items (active-descendant highlight, not keyboard traversal).
- Focus goldens and behavioral tests force `FocusHighlightStrategy.alwaysTraditional` per test (with an `addTearDown` reset), since `flutter test` defaults to the Android/touch platform where the highlight is off by default.
- Add a #1079 repro to `example/lib/sandbox.dart` (runtime web-semantics toggle, live highlight-mode readout).

**Checklist**
- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [x] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)