### PR TITLE
Add FSwitch spotlight demo

### DIFF
--- a/spotlight/lib/main.dart
+++ b/spotlight/lib/main.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart' hide Autocomplete, Badge, Dialog, TextField, Tooltip;
+import 'package:flutter/material.dart' hide Autocomplete, Badge, Dialog, Switch, TextField, Tooltip;
 
 import 'package:forui/forui.dart';
 import 'package:marionette_flutter/marionette_flutter.dart';
 
-import 'widgets/tabs.dart';
+import 'widgets/switch.dart';
 
 void main() {
   if (kDebugMode) {
@@ -30,7 +30,7 @@ class Application extends StatelessWidget {
         data: theme,
         child: FToaster(child: FTooltipGroup(child: child!)),
       ),
-      home: const FScaffold(child: Tabs()),
+      home: const FScaffold(child: Switch()),
     );
   }
 }

--- a/spotlight/lib/widgets/switch.dart
+++ b/spotlight/lib/widgets/switch.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/widgets.dart';
+import 'package:forui/forui.dart';
+
+class Switch extends StatefulWidget {
+  const Switch({super.key});
+
+  @override
+  State<Switch> createState() => _SwitchState();
+}
+
+class _SwitchState extends State<Switch> {
+  final GlobalKey<FormState> _key = GlobalKey<FormState>();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = context.theme;
+    return Center(
+      child: SizedBox(
+        width: 400,
+        child: Form(
+          key: _key,
+          child: Column(
+            mainAxisAlignment: .center,
+            crossAxisAlignment: .start,
+            children: [
+              Text(
+                'Email Notifications',
+                style: theme.typography.display.xl2.copyWith(
+                  fontWeight: FontWeight.w600,
+                  color: theme.colors.foreground,
+                  height: 1.5,
+                ),
+              ),
+              const SizedBox(height: 15),
+              FCard.raw(
+                child: Padding(
+                  padding: const .fromLTRB(16, 12, 16, 16),
+                  child: Row(
+                    mainAxisAlignment: .spaceBetween,
+                    children: [
+                      Flexible(
+                        child: Column(
+                          crossAxisAlignment: .start,
+                          children: [
+                            Text(
+                              'Marketing Emails',
+                              style: theme.typography.body.md.copyWith(
+                                fontWeight: .w500,
+                                color: theme.colors.foreground,
+                                height: 1.5,
+                              ),
+                            ),
+                            Text(
+                              'Receive emails about new products, features, and more.',
+                              style: theme.typography.body.sm.copyWith(color: theme.colors.mutedForeground),
+                            ),
+                          ],
+                        ),
+                      ),
+                      FormField(
+                        initialValue: false,
+                        onSaved: (value) {
+                          // Save values somewhere.
+                        },
+                        validator: (value) => null, // No validation required.
+                        builder: (state) =>
+                            FSwitch(value: state.value ?? false, onChange: (value) => state.didChange(value)),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 12),
+              FCard.raw(
+                child: Padding(
+                  padding: const .fromLTRB(16, 12, 16, 16),
+                  child: Row(
+                    mainAxisAlignment: .spaceBetween,
+                    children: [
+                      Flexible(
+                        child: Column(
+                          crossAxisAlignment: .start,
+                          children: [
+                            Text(
+                              'Security emails',
+                              style: theme.typography.body.md.copyWith(
+                                fontWeight: .w500,
+                                color: theme.colors.foreground,
+                                height: 1.5,
+                              ),
+                            ),
+                            Text(
+                              'Receive emails about your account security.',
+                              style: theme.typography.body.sm.copyWith(color: theme.colors.mutedForeground),
+                            ),
+                          ],
+                        ),
+                      ),
+                      FormField(
+                        initialValue: true,
+                        onSaved: (value) {
+                          // Save values somewhere.
+                        },
+                        validator: (value) => null, // No validation required.
+                        builder: (state) =>
+                            FSwitch(value: state.value ?? false, onChange: (value) => state.didChange(value)),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 30),
+              FButton(
+                child: const Text('Submit'),
+                onPress: () {
+                  if (!_key.currentState!.validate()) {
+                    // Handle errors here.
+                    return;
+                  }
+
+                  _key.currentState!.save();
+                  // Do something.
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
**Describe the changes**

- Add an `Email Notifications` form demo for `FSwitch` to the `spotlight/` internal playground app (`spotlight/lib/widgets/switch.dart`).
  - Two `FCard.raw` rows (Marketing Emails off, Security emails on) driven by `FormField` + `FSwitch`, with a Submit button that validates and saves the form.
  - Uses the desktop platform theme inherited from `main.dart` via `context.theme`.
- Point `spotlight/lib/main.dart` at the new `Switch` demo (and add `Switch` to the Material `hide` list to avoid the name clash).

**Checklist**
- [x] I have read the CONTRIBUTING.md.
- [ ] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [ ] I have updated the CHANGELOG.md if necessary.

<sub>Spotlight-only change (internal playground app); no library code, tests, or docs affected.</sub>