### PR TITLE
Prepare to release 0.24.1

### DIFF
--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.24.1 (next)
+## 0.24.1
 
 ### `FTooltip`
 * Add `FTooltipStyle.constraints`.

--- a/forui/pubspec.yaml
+++ b/forui/pubspec.yaml
@@ -2,7 +2,7 @@ name: forui
 description: >-
   Beautifully designed, minimalistic Flutter widgets for desktop & touch devices. Designs are heavily
   inspired by shadcn/ui and are fully customizable.
-version: 0.24.0
+version: 0.24.1
 homepage: https://forui.dev/
 documentation: https://forui.dev/docs
 repository: https://github.com/duobaseio/forui/tree/main/forui


### PR DESCRIPTION
**Describe the changes**

Prepares the `0.24.1` patch release. Ships the `FTooltip` wrapping fix from #1107.

- Finalize the `## 0.24.1` changelog heading (drop the `(next)` marker).
- Bump `forui` from `0.24.0` to `0.24.1`.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
