### PR TITLE
Fix dangling listener leaks in FAutocomplete and select search field

### DIFF
--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.24.3
+
+### `FAutocomplete`
+* Fix crash when an external focus node is reused by another widget after `FAutocomplete` is disposed.
+* Fix `FAutocomplete` not responding to focus changes after its focus node is swapped.
+
+
+### `FSelect` & `FMultiSelect`
+* Fix crash when the search field's external controller is modified after the popover closes.
+
+
 ## 0.24.2
 
 ### `FHeader`

--- a/forui/lib/src/widgets/autocomplete/autocomplete.dart
+++ b/forui/lib/src/widgets/autocomplete/autocomplete.dart
@@ -1217,10 +1217,12 @@ class _State<T> extends State<FAutocomplete<T>> with TickerProviderStateMixin {
     super.didUpdateWidget(old);
     // DO NOT REORDER
     if (widget.focusNode != old.focusNode) {
+      _fieldFocus.removeListener(_focus);
       if (old.focusNode == null) {
         _fieldFocus.dispose();
       }
       _fieldFocus = widget.focusNode ?? .new(debugLabel: 'FAutocomplete field');
+      _fieldFocus.addListener(_focus);
     }
 
     final (controller, updated) = widget.control.update(old.control, _controller, _update);
@@ -1237,6 +1239,7 @@ class _State<T> extends State<FAutocomplete<T>> with TickerProviderStateMixin {
   void dispose() {
     _popoverFocus.dispose();
 
+    _fieldFocus.removeListener(_focus);
     if (widget.focusNode == null) {
       _fieldFocus.dispose();
     }

--- a/forui/lib/src/widgets/select/content/search_content.dart
+++ b/forui/lib/src/widgets/select/content/search_content.dart
@@ -86,7 +86,6 @@ class _SearchContentState<T> extends State<SearchContent<T>> {
   void initState() {
     super.initState();
     _controller = widget.properties.control.create(_update);
-    _controller.addListener(_update);
 
     _previous = _controller.text;
     _data = widget.filter(_controller.text);

--- a/forui/pubspec.yaml
+++ b/forui/pubspec.yaml
@@ -2,7 +2,7 @@ name: forui
 description: >-
   Beautifully designed, minimalistic Flutter widgets for desktop & touch devices. Designs are heavily
   inspired by shadcn/ui and are fully customizable.
-version: 0.24.2
+version: 0.24.3
 homepage: https://forui.dev/
 documentation: https://forui.dev/docs
 repository: https://github.com/duobaseio/forui/tree/main/forui

--- a/forui/test/src/widgets/autocomplete/autocomplete_test.dart
+++ b/forui/test/src/widgets/autocomplete/autocomplete_test.dart
@@ -414,7 +414,11 @@ void main() {
       focus.unfocus();
       await tester.pumpAndSettle();
 
-      await tester.pumpWidget(TestScaffold.app(child: FTextField(key: key, focusNode: focus)));
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FTextField(key: key, focusNode: focus),
+        ),
+      );
 
       await tester.tap(find.byKey(key));
       await tester.pumpAndSettle();

--- a/forui/test/src/widgets/autocomplete/autocomplete_test.dart
+++ b/forui/test/src/widgets/autocomplete/autocomplete_test.dart
@@ -396,6 +396,54 @@ void main() {
       expect(autocompleteFocus.hasFocus, false);
       expect(buttonFocus.hasFocus, true);
     });
+
+    testWidgets('external focus node reused after autocomplete is disposed', (tester) async {
+      final focus = autoDispose(FocusNode());
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FAutocomplete.text(key: key, focusNode: focus, items: fruits),
+        ),
+      );
+
+      await tester.tap(find.byKey(key));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byKey(key), 'h');
+      await tester.pumpAndSettle();
+
+      focus.unfocus();
+      await tester.pumpAndSettle();
+
+      await tester.pumpWidget(TestScaffold.app(child: FTextField(key: key, focusNode: focus)));
+
+      await tester.tap(find.byKey(key));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), null);
+    });
+
+    testWidgets('swapping external focus nodes attaches listener to new node', (tester) async {
+      final first = autoDispose(FocusNode());
+      final second = autoDispose(FocusNode());
+
+      Widget build(FocusNode focus) => TestScaffold.app(
+        child: FAutocomplete.text(
+          key: key,
+          popoverControl: .managed(controller: popoverController),
+          focusNode: focus,
+          items: fruits,
+        ),
+      );
+
+      await tester.pumpWidget(build(first));
+      await tester.pumpWidget(build(second));
+
+      second.requestFocus();
+      await tester.pumpAndSettle();
+
+      expect(second.hasFocus, true);
+      expect(popoverController.status.isForwardOrCompleted, true);
+    });
   });
 
   group('right arrow completion', () {

--- a/forui/test/src/widgets/select/content/search_content_test.dart
+++ b/forui/test/src/widgets/select/content/search_content_test.dart
@@ -146,6 +146,32 @@ void main() {
 
         expect(changedValue?.text, 'test');
       });
+
+      testWidgets('external controller mutated after popover closes', (tester) async {
+        final textController = autoDispose(TextEditingController());
+
+        await tester.pumpWidget(
+          TestScaffold.app(
+            child: FSelect<String>.search(
+              key: key,
+              searchFieldProperties: FSelectSearchFieldProperties(control: .managed(controller: textController)),
+              filter: (query) => fruits,
+              items: {for (final fruit in fruits) fruit: fruit},
+            ),
+          ),
+        );
+
+        await tester.tap(find.byKey(key));
+        await tester.pumpAndSettle();
+
+        await tester.tapAt(.zero);
+        await tester.pumpAndSettle();
+
+        textController.text = 'Ba';
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), null);
+      });
     });
   });
 }


### PR DESCRIPTION
**Describe the changes**
- Fixes #1109.
- Fix `FAutocomplete` never removing its focus listener from an external `focusNode` in `dispose()`, crashing with `A FAutocompleteController was used after being disposed.` when the node is reused by another widget (e.g. swapping `FAutocomplete` for an `FTextField` sharing the same node).
- Fix `FAutocomplete` not moving its focus listener to the new node when `focusNode` is swapped in `didUpdateWidget`, so the popover stopped reacting to focus changes.
- Fix `SearchContent` (used by `FSelect.search` / `FMultiSelect.search`) registering its text listener twice; `control.create` already attaches it. The generated dispose only removes one registration, leaving a dangling listener on an external search controller after the popover closes and crashing with `setState() called after dispose()` on the next mutation.
- Add regression tests for all three paths and 0.24.3 changelog entries.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)