### PR TITLE
Add Carbon Ads to the docs site

### DIFF
--- a/docs/app/docs/[[...slug]]/page.tsx
+++ b/docs/app/docs/[[...slug]]/page.tsx
@@ -7,6 +7,7 @@ import { createRelativeLink } from 'fumadocs-ui/mdx';
 import { Separator } from '@/components/ui/separator';
 import LinkBadge from '@/components/ui/link-badge/link-badge';
 import LinkBadgeGroup from '@/components/ui/link-badge/link-badge-group';
+import { Ads } from '@/components/ads';
 
 export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
   const params = await props.params;
@@ -16,7 +17,11 @@ export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
   const MDX = page.data.body;
 
   return (
-    <DocsPage toc={page.data.toc} full={page.data.full} tableOfContent={{ style: 'clerk' }}>
+    <DocsPage
+      toc={page.data.toc}
+      full={page.data.full}
+      tableOfContent={{ style: 'clerk', footer: <Ads className="mt-auto shrink-0 pt-4 pb-2" /> }}
+    >
       <div className="space-y-0.5">
         <DocsTitle className="">{page.data.title}</DocsTitle>
         <DocsDescription className="text-base mb-0">{page.data.description}</DocsDescription>

--- a/docs/components/ads.tsx
+++ b/docs/components/ads.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+
+const src = '//cdn.carbonads.com/carbon.js?serve=CWBDE277&placement=foruidev&format=responsive';
+const dev = process.env.NODE_ENV === 'development';
+
+export function Ads({ className }: { className?: string }) {
+  const slot = useRef<HTMLDivElement>(null);
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const current = slot.current;
+    if (!current || dev) return;
+
+    const script = document.createElement('script');
+    script.async = true;
+    script.id = '_carbonads_js';
+    script.src = src;
+    current.append(script);
+
+    return () => current.replaceChildren();
+  }, [pathname]);
+
+  return (
+    <div ref={slot} className={className} style={{ minHeight: 155 }}>
+      {dev && (
+        <div className="grid min-h-[155px] place-items-center rounded-md border text-xs text-muted-foreground">
+          Advertisement
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
**Describe the changes**

Adds Carbon Ads to the documentation site.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests. <!-- N/A, docs site only -->
- [ ] I have included the relevant samples. <!-- N/A -->
- [ ] I have updated the documentation accordingly. <!-- N/A -->
- [ ] I have added the required flutters_hook for widget controllers. <!-- N/A -->
- [ ] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary. <!-- N/A, no changes to forui/ -->
