### PR TITLE
Fix pressed effect applying to ancestor tappables when a nested tappable is pressed

### DIFF
--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -108,6 +108,8 @@ rebuilt.
 ### `FTappable`
 * Add `FTappable.semanticsTooltip`.
 
+* Fix pressed effect applying to ancestor tappables when a nested tappable is pressed.
+
 
 ### `FTimeField`
 * Add `FTimeFieldPickerProperties.overlayLocation`.

--- a/forui/lib/src/foundation/tappable/tappable.dart
+++ b/forui/lib/src/foundation/tappable/tappable.dart
@@ -35,6 +35,9 @@ typedef FTappableVariantChangeCallback = void Function(Set<FTappableVariant> pre
 /// It is typically used to create other high-level widgets, i.e., [FButton]. Unless you are creating a custom widget,
 /// you should use those high-level widgets instead.
 ///
+/// Pressing a tappable nested inside another tappable shows a pressed effect on only the deepest enabled tappable.
+/// Hovering it also hovers its ancestor tappables, mirroring CSS `:hover`.
+///
 /// {@macro forui.foundation.doc_templates.overlay}
 class FTappable extends StatefulWidget {
   /// The default builder that returns the child as-is.
@@ -505,6 +508,9 @@ class FTappable extends StatefulWidget {
 }
 
 class _FTappableState<T extends FTappable> extends State<T> {
+  /// Pointers claimed by the deepest enabled tappable.
+  static final Map<int, _FTappableState<FTappable>> _claims = {};
+
   late FTappableStyle _style;
   late FocusNode _focus;
   late Set<FTappableVariant> _current;
@@ -512,6 +518,7 @@ class _FTappableState<T extends FTappable> extends State<T> {
   FTappableVariant? _platform;
   int _monotonic = 0;
   int _buttons = 0;
+  int? _pointer;
   List<GroupEntry>? _entries;
   GroupEntry? _entry;
 
@@ -603,6 +610,7 @@ class _FTappableState<T extends FTappable> extends State<T> {
 
   @override
   void dispose() {
+    _unclaim();
     _unregister();
     if (widget.focusNode == null) {
       _focus.dispose();
@@ -695,11 +703,26 @@ class _FTappableState<T extends FTappable> extends State<T> {
               // GestureArena and only 1 GestureDetector will win. This is problematic if this tappable is wrapped in
               // another GestureDetector as onTapDown and onTapUp might absorb EVERY gesture, including drags and pans.
               child: Listener(
-                onPointerDown: _entries == null ? (event) => _start(event.buttons) : null,
+                onPointerDown: _entries == null
+                    ? (event) {
+                        // A deeper tappable claimed this pointer first.
+                        if (_claims.containsKey(event.pointer)) {
+                          return;
+                        }
+
+                        _unclaim();
+                        if (!widget._disabled) {
+                          _claims[event.pointer] = this;
+                        }
+                        _pointer = event.pointer;
+
+                        unawaited(_start(event.buttons));
+                      }
+                    : null,
                 onPointerMove: _entries == null
                     ? (event) async {
                         // Check if it's mounted due to a non-deterministic race condition, https://github.com/duobaseio/forui/issues/482.
-                        if (!mounted) {
+                        if (!mounted || event.pointer != _pointer) {
                           return;
                         }
 
@@ -720,7 +743,22 @@ class _FTappableState<T extends FTappable> extends State<T> {
                         await _cancel();
                       }
                     : null,
-                onPointerUp: _entries == null ? (_) => _end() : null,
+                onPointerUp: _entries == null
+                    ? (event) {
+                        if (event.pointer == _pointer) {
+                          _unclaim();
+                          unawaited(_end());
+                        }
+                      }
+                    : null,
+                onPointerCancel: _entries == null
+                    ? (event) {
+                        if (event.pointer == _pointer) {
+                          _unclaim();
+                          unawaited(_cancel());
+                        }
+                      }
+                    : null,
                 child: GestureDetector(
                   behavior: widget.behavior,
                   onTapDown: _entries == null ? widget.onPressDown : null,
@@ -805,6 +843,13 @@ class _FTappableState<T extends FTappable> extends State<T> {
     if (mounted && count == _monotonic && _current.contains(FTappableVariant.pressed)) {
       setState(() => _update(.pressed, false));
     }
+  }
+
+  void _unclaim() {
+    if (_pointer case final pointer? when identical(_claims[pointer], this)) {
+      _claims.remove(pointer);
+    }
+    _pointer = null;
   }
 
   void onPressStart() {}

--- a/forui/test/src/foundation/tappable/tappable_test.dart
+++ b/forui/test/src/foundation/tappable/tappable_test.dart
@@ -861,6 +861,150 @@ void main() {
     });
   });
 
+  group('nested', () {
+    Widget nested({
+      bool static = false,
+      bool inner = true,
+      Key? outerKey,
+      Key? innerKey,
+      List<String>? calls,
+      ValueChanged<Set<FTappableVariant>>? onOuter,
+      ValueChanged<Set<FTappableVariant>>? onInner,
+    }) {
+      final constructor = static ? FTappable.static : FTappable.new;
+      return TestScaffold(
+        child: constructor(
+          key: outerKey,
+          onPress: () => calls?.add('outer'),
+          onVariantChange: onOuter == null ? null : (_, current) => onOuter(current),
+          // The ColoredBox makes the padding gutter hit-testable, like a real widget's background.
+          builder: (_, _, child) => ColoredBox(
+            color: const Color(0x00000000),
+            child: Padding(padding: const EdgeInsets.all(30), child: child),
+          ),
+          child: constructor(
+            key: innerKey,
+            onPress: inner ? () => calls?.add('inner') : null,
+            onVariantChange: onInner == null ? null : (_, current) => onInner(current),
+            child: const SizedBox(width: 60, height: 60, child: Text('inner')),
+          ),
+        ),
+      );
+    }
+
+    for (final static in [false, true]) {
+      testWidgets('pressing inner never presses outer - static: $static', (tester) async {
+        final calls = <String>[];
+        final outerSeen = <FTappableVariant>{};
+        final innerSeen = <FTappableVariant>{};
+        await tester.pumpWidget(
+          nested(static: static, calls: calls, onOuter: outerSeen.addAll, onInner: innerSeen.addAll),
+        );
+
+        final gesture = await tester.startGesture(tester.getCenter(find.text('inner')));
+        await tester.pump(const Duration(milliseconds: 200));
+
+        expect(innerSeen.contains(FTappableVariant.pressed), true);
+        expect(outerSeen.contains(FTappableVariant.pressed), false);
+
+        await gesture.up();
+        await tester.pumpAndSettle();
+
+        expect(outerSeen.contains(FTappableVariant.pressed), false);
+        expect(calls, ['inner']);
+      });
+    }
+
+    testWidgets('pressing inner never bounces outer', (tester) async {
+      final outerKey = GlobalKey<AnimatedTappableState>();
+      final innerKey = GlobalKey<AnimatedTappableState>();
+      await tester.pumpWidget(nested(outerKey: outerKey, innerKey: innerKey));
+
+      final gesture = await tester.startGesture(tester.getCenter(find.text('inner')));
+      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+      expect(innerKey.currentState?.bounce.value, 0.97);
+      expect(outerKey.currentState?.bounce.value, 1);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('pressing disabled inner presses outer', (tester) async {
+      final calls = <String>[];
+      final outerSeen = <FTappableVariant>{};
+      await tester.pumpWidget(nested(inner: false, calls: calls, onOuter: outerSeen.addAll));
+
+      final gesture = await tester.startGesture(tester.getCenter(find.text('inner')));
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(outerSeen.contains(FTappableVariant.pressed), true);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(calls, ['outer']);
+    });
+
+    testWidgets('outer presses normally after pressing inner', (tester) async {
+      var outerLive = <FTappableVariant>{};
+      await tester.pumpWidget(nested(onOuter: (current) => outerLive = current));
+
+      await tester.tap(find.text('inner'));
+      await tester.pumpAndSettle();
+      expect(outerLive.contains(FTappableVariant.pressed), false);
+
+      // 15px outside the inner tappable's top-left corner is within the outer tappable's padding.
+      final gesture = await tester.startGesture(tester.getTopLeft(find.text('inner')) - const Offset(15, 15));
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(outerLive.contains(FTappableVariant.pressed), true);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(outerLive.contains(FTappableVariant.pressed), false);
+    });
+
+    testWidgets("second pointer on inner does not end outer's press", (tester) async {
+      var outerLive = <FTappableVariant>{};
+      await tester.pumpWidget(nested(onOuter: (current) => outerLive = current));
+
+      final outer = await tester.startGesture(tester.getTopLeft(find.text('inner')) - const Offset(15, 15));
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(outerLive.contains(FTappableVariant.pressed), true);
+
+      final inner = await tester.startGesture(tester.getCenter(find.text('inner')));
+      await tester.pump(const Duration(milliseconds: 50));
+      await inner.up();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(outerLive.contains(FTappableVariant.pressed), true);
+
+      await outer.up();
+      await tester.pumpAndSettle();
+
+      expect(outerLive.contains(FTappableVariant.pressed), false);
+    });
+
+    testWidgets('hovering inner also hovers outer', (tester) async {
+      var outerLive = <FTappableVariant>{};
+      var innerLive = <FTappableVariant>{};
+      await tester.pumpWidget(
+        nested(onOuter: (current) => outerLive = current, onInner: (current) => innerLive = current),
+      );
+
+      final gesture = await tester.createPointerGesture();
+      await tester.pump();
+
+      await gesture.moveTo(tester.getCenter(find.text('inner')));
+      await tester.pumpAndSettle();
+
+      expect(innerLive.contains(FTappableVariant.hovered), true);
+      expect(outerLive.contains(FTappableVariant.hovered), true);
+    });
+  });
+
   testWidgets('returns focused state on primary focus', (tester) async {
     FocusManager.instance.highlightStrategy = .alwaysTraditional;
     addTearDown(() => FocusManager.instance.highlightStrategy = .automatic);


### PR DESCRIPTION
**Describe the changes**

Fixes https://github.com/duobaseio/forui/issues/1130.

* `FTappable` drives its pressed effect from a raw `Listener`, and raw pointer events are dispatched to every listener in the hit-test path, ancestors included. Pressing an `FButton` nested in an `FTile`/`FCard` therefore also pressed the tile, even though its `onPress` never fired.
* Raw pointer events are dispatched deepest-first, so the deepest enabled tappable now claims the pointer in a shared per-pointer registry. Ancestors ignore claimed pointers, matching the deepest-first resolution `TappableGroupGestureRecognizer` already performs for grouped tappables.
* Disabled tappables never claim, so pressing a disabled nested tappable still passes through to its ancestor.
* `onPointerMove`/`onPointerUp` now only react to the claimed pointer, and a new `onPointerCancel` handler releases claims. This also fixes a latent multi-touch bug where releasing a second pointer on a descendant ended an ancestor's unrelated press.
* Hover intentionally remains shared with ancestors, mirroring CSS `:hover` (and Material Web/Compose/Flutter Material behavior); this is now documented on `FTappable` and locked in by a test.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [x] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)