### PR TITLE
Add onDisabledPress to FTappable and FButton

### DIFF
--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 
 ### `FButton`
+* Add `FButton.onDisabledPress`.
 * Add `FButton.semanticsTooltip`.
 
 
@@ -106,6 +107,7 @@ rebuilt.
 
 
 ### `FTappable`
+* Add `FTappable.onDisabledPress`.
 * Add `FTappable.semanticsTooltip`.
 
 * Fix pressed effect applying to ancestor tappables when a nested tappable is pressed.

--- a/forui/lib/src/foundation/tappable/tappable.dart
+++ b/forui/lib/src/foundation/tappable/tappable.dart
@@ -149,6 +149,14 @@ class FTappable extends StatefulWidget {
   /// {@endtemplate}
   final VoidCallback? onPress;
 
+  /// {@template forui.foundation.FTappable.onDisabledPress}
+  /// A callback for when the widget is pressed while disabled. Setting it does not enable the widget.
+  ///
+  /// The widget remains styled and announced as disabled but can receive focus and be activated. Useful for showing
+  /// feedback, such as a validation error, when a user presses a disabled widget.
+  /// {@endtemplate}
+  final VoidCallback? onDisabledPress;
+
   /// {@template forui.foundation.FTappable.onLongPressDown}
   /// A callback for when a primary pointer that might cause a long press has contacted the widget.
   ///
@@ -339,6 +347,7 @@ class FTappable extends StatefulWidget {
     GestureTapMoveCallback? onPressMove,
     GestureTapUpCallback? onPressUp,
     VoidCallback? onPress,
+    VoidCallback? onDisabledPress,
     GestureLongPressDownCallback? onLongPressDown,
     GestureLongPressCancelCallback? onLongPressCancel,
     GestureLongPressStartCallback? onLongPressStart,
@@ -392,6 +401,7 @@ class FTappable extends StatefulWidget {
     this.onPressMove,
     this.onPressUp,
     this.onPress,
+    this.onDisabledPress,
     this.onLongPressDown,
     this.onLongPressCancel,
     this.onLongPressStart,
@@ -416,7 +426,9 @@ class FTappable extends StatefulWidget {
     this.child,
     Map<ShortcutActivator, Intent>? shortcuts,
     super.key,
-  }) : shortcuts = shortcuts ?? (onPress == null ? const {} : const {SingleActivator(.enter): ActivateIntent()}),
+  }) : shortcuts =
+           shortcuts ??
+           (onPress == null && onDisabledPress == null ? const {} : const {SingleActivator(.enter): ActivateIntent()}),
        assert(builder != defaultBuilder || child != null, 'Either builder or child must be provided');
 
   @override
@@ -448,6 +460,7 @@ class FTappable extends StatefulWidget {
       ..add(ObjectFlagProperty.has('onPressMove', onPressMove))
       ..add(ObjectFlagProperty.has('onPressUp', onPressUp))
       ..add(ObjectFlagProperty.has('onPress', onPress))
+      ..add(ObjectFlagProperty.has('onDisabledPress', onDisabledPress))
       ..add(ObjectFlagProperty.has('onLongPressDown', onLongPressDown))
       ..add(ObjectFlagProperty.has('onLongPressCancel', onLongPressCancel))
       ..add(ObjectFlagProperty.has('onLongPressStart', onLongPressStart))
@@ -475,6 +488,8 @@ class FTappable extends StatefulWidget {
   bool _animate(int buttons) =>
       (buttons & kPrimaryButton != 0 && _hasPrimaryCallback) ||
       (buttons & kSecondaryButton != 0 && _hasSecondaryCallback);
+
+  VoidCallback? get _onPress => _disabled ? onDisabledPress : onPress;
 
   bool get _disabled => !_hasPrimaryCallback && !_hasSecondaryCallback;
 
@@ -588,7 +603,7 @@ class _FTappableState<T extends FTappable> extends State<T> {
         ..onPressCancel = widget.onPressCancel
         ..onPressMove = widget.onPressMove
         ..onPressUp = widget.onPressUp
-        ..onPress = widget.onPress
+        ..onPress = widget._onPress
         ..onLongPressDown = widget.onLongPressDown
         ..onLongPressCancel = widget.onLongPressCancel
         ..onLongPressStart = widget.onLongPressStart
@@ -630,7 +645,7 @@ class _FTappableState<T extends FTappable> extends State<T> {
           onPressCancel: widget.onPressCancel,
           onPressMove: widget.onPressMove,
           onPressUp: widget.onPressUp,
-          onPress: widget.onPress,
+          onPress: widget._onPress,
           onLongPressDown: widget.onLongPressDown,
           onLongPressCancel: widget.onLongPressCancel,
           onLongPressStart: widget.onLongPressStart,
@@ -658,8 +673,8 @@ class _FTappableState<T extends FTappable> extends State<T> {
         actions:
             widget.actions ??
             {
-              if (widget.onPress != null)
-                ActivateIntent: CallbackAction<ActivateIntent>(onInvoke: (_) => widget.onPress!.call()),
+              if (widget._onPress != null)
+                ActivateIntent: CallbackAction<ActivateIntent>(onInvoke: (_) => widget._onPress!.call()),
             },
         child: Semantics(
           enabled: !widget._disabled,
@@ -676,7 +691,7 @@ class _FTappableState<T extends FTappable> extends State<T> {
           child: Focus(
             autofocus: widget.autofocus,
             focusNode: _focus,
-            canRequestFocus: !widget._disabled,
+            canRequestFocus: !widget._disabled || widget.onDisabledPress != null,
             onFocusChange: (focused) {
               setState(() {
                 if (_highlight) {
@@ -711,7 +726,7 @@ class _FTappableState<T extends FTappable> extends State<T> {
                         }
 
                         _unclaim();
-                        if (!widget._disabled) {
+                        if (!widget._disabled || widget.onDisabledPress != null) {
                           _claims[event.pointer] = this;
                         }
                         _pointer = event.pointer;
@@ -765,7 +780,7 @@ class _FTappableState<T extends FTappable> extends State<T> {
                   onTapCancel: _entries == null ? widget.onPressCancel : null,
                   onTapMove: _entries == null ? widget.onPressMove : null,
                   onTapUp: _entries == null ? widget.onPressUp : null,
-                  onTap: _entries == null ? widget.onPress : null,
+                  onTap: _entries == null ? widget._onPress : null,
                   onLongPressDown: _entries == null ? widget.onLongPressDown : null,
                   onLongPressCancel: _entries == null ? widget.onLongPressCancel : null,
                   onLongPressStart: _entries == null ? widget.onLongPressStart : null,
@@ -882,6 +897,7 @@ class AnimatedTappable extends FTappable {
     super.onPressMove,
     super.onPressUp,
     super.onPress,
+    super.onDisabledPress,
     super.onLongPressDown,
     super.onLongPressCancel,
     super.onLongPressStart,

--- a/forui/lib/src/widgets/button/button.dart
+++ b/forui/lib/src/widgets/button/button.dart
@@ -27,7 +27,7 @@ part 'button.design.dart';
 /// A button.
 ///
 /// [FButton] typically contains icons and/or a label. If the [onPress] and [onLongPress] callbacks are null, then this
-/// button will be disabled, and it will not react to touch.
+/// button will be disabled. A disabled button only reacts to touch when [onDisabledPress] is given.
 ///
 /// {@macro forui.foundation.doc_templates.overlay}
 ///
@@ -107,6 +107,9 @@ class FButton extends StatelessWidget {
   /// {@macro forui.foundation.FTappable.onPress}
   final VoidCallback? onPress;
 
+  /// {@macro forui.foundation.FTappable.onDisabledPress}
+  final VoidCallback? onDisabledPress;
+
   /// {@macro forui.foundation.FTappable.onLongPress}
   final VoidCallback? onLongPress;
 
@@ -177,6 +180,7 @@ class FButton extends StatelessWidget {
     this.variant = .primary,
     this.size = .md,
     this.style = const .context(),
+    this.onDisabledPress,
     this.onLongPress,
     this.onDoubleTap,
     this.onSecondaryPress,
@@ -228,6 +232,7 @@ class FButton extends StatelessWidget {
     this.variant = .outline,
     this.size = .md,
     this.style = const .context(),
+    this.onDisabledPress,
     this.onLongPress,
     this.onDoubleTap,
     this.onSecondaryPress,
@@ -255,6 +260,7 @@ class FButton extends StatelessWidget {
     this.variant = .primary,
     this.size = .md,
     this.style = const .context(),
+    this.onDisabledPress,
     this.onLongPress,
     this.onDoubleTap,
     this.onSecondaryPress,
@@ -287,6 +293,7 @@ class FButton extends StatelessWidget {
       onHoverChange: onHoverChange,
       onVariantChange: onVariantChange,
       onPress: onPress,
+      onDisabledPress: onDisabledPress,
       onLongPress: onLongPress,
       onDoubleTap: onDoubleTap,
       onSecondaryPress: onSecondaryPress,
@@ -310,6 +317,7 @@ class FButton extends StatelessWidget {
       ..add(DiagnosticsProperty('size', size))
       ..add(DiagnosticsProperty('style', style))
       ..add(ObjectFlagProperty.has('onPress', onPress))
+      ..add(ObjectFlagProperty.has('onDisabledPress', onDisabledPress))
       ..add(ObjectFlagProperty.has('onLongPress', onLongPress))
       ..add(ObjectFlagProperty.has('onDoubleTap', onDoubleTap))
       ..add(ObjectFlagProperty.has('onSecondaryPress', onSecondaryPress))

--- a/forui/test/src/foundation/tappable/tappable_test.dart
+++ b/forui/test/src/foundation/tappable/tappable_test.dart
@@ -1299,11 +1299,7 @@ void main() {
     });
 
     testWidgets('disabled without onDisabledPress has no tap action', (tester) async {
-      await tester.pumpWidget(
-        TestScaffold.app(
-          child: const FTappable.static(child: Text('tappable')),
-        ),
-      );
+      await tester.pumpWidget(TestScaffold.app(child: const FTappable.static(child: Text('tappable'))));
 
       expect(
         tester.getSemantics(find.text('tappable')),

--- a/forui/test/src/foundation/tappable/tappable_test.dart
+++ b/forui/test/src/foundation/tappable/tappable_test.dart
@@ -628,6 +628,84 @@ void main() {
     });
   });
 
+  group('onDisabledPress', () {
+    testWidgets('fires when disabled tappable is tapped', (tester) async {
+      final calls = <String>[];
+      await tester.pumpWidget(
+        TestScaffold(
+          child: FTappable(
+            builder: (_, states, _) => Text('$states'),
+            onDisabledPress: () => calls.add('onDisabledPress'),
+          ),
+        ),
+      );
+      expect(find.text(set(false).toString()), findsOneWidget);
+
+      await tester.tap(find.byType(AnimatedTappable));
+      await tester.pumpAndSettle();
+
+      expect(calls, ['onDisabledPress']);
+    });
+
+    testWidgets('does not fire when enabled', (tester) async {
+      final calls = <String>[];
+      await tester.pumpWidget(
+        TestScaffold(
+          child: FTappable(
+            builder: (_, states, _) => Text('$states'),
+            onPress: () => calls.add('onPress'),
+            onDisabledPress: () => calls.add('onDisabledPress'),
+          ),
+        ),
+      );
+      expect(find.text(set(true).toString()), findsOneWidget);
+
+      await tester.tap(find.byType(AnimatedTappable));
+      await tester.pumpAndSettle();
+
+      expect(calls, ['onPress']);
+    });
+
+    testWidgets('focusable and activatable via keyboard when disabled', (tester) async {
+      final calls = <String>[];
+      await tester.pumpWidget(
+        TestScaffold(
+          child: FTappable(
+            focusNode: focusNode,
+            builder: (_, states, _) => Text('$states'),
+            onDisabledPress: () => calls.add('onDisabledPress'),
+          ),
+        ),
+      );
+      expect(find.text(set(false).toString()), findsOneWidget);
+
+      focusNode.requestFocus();
+      await tester.pumpAndSettle();
+      expect(focusNode.hasFocus, true);
+
+      await tester.sendKeyEvent(.enter);
+      await tester.pumpAndSettle();
+
+      expect(calls, ['onDisabledPress']);
+    });
+
+    testWidgets('no bounce when pressed', (tester) async {
+      final key = GlobalKey<AnimatedTappableState>();
+      await tester.pumpWidget(
+        TestScaffold(
+          child: FTappable(key: key, builder: (_, states, _) => Text('$states'), onDisabledPress: () {}),
+        ),
+      );
+
+      final gesture = await tester.press(find.byType(AnimatedTappable));
+      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+      expect(key.currentState?.bounce.value, 1.0);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+  });
+
   group('in FTappableGroup', () {
     Widget tappables(List<String> calls) => TestScaffold(
       child: FTappableGroup(
@@ -817,6 +895,25 @@ void main() {
       );
     });
 
+    testWidgets('disabled tappable with onDisabledPress fires on tap', (tester) async {
+      final calls = <String>[];
+      await tester.pumpWidget(
+        TestScaffold(
+          child: FTappableGroup(
+            child: FTappable(
+              builder: (_, _, _) => const SizedBox(width: 50, height: 50, child: Text('A')),
+              onDisabledPress: () => calls.add('onDisabledPress'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('A'));
+      await tester.pumpAndSettle();
+
+      expect(calls, ['onDisabledPress']);
+    });
+
     testWidgets('entry unmounted mid-gesture does not crash on cancel', (tester) async {
       late StateSetter setState;
       var show = true;
@@ -928,6 +1025,37 @@ void main() {
 
       await gesture.up();
       await tester.pumpAndSettle();
+    });
+
+    testWidgets('pressing disabled inner with onDisabledPress does not press outer', (tester) async {
+      final calls = <String>[];
+      final outerSeen = <FTappableVariant>{};
+      await tester.pumpWidget(
+        TestScaffold(
+          child: FTappable(
+            onPress: () => calls.add('outer'),
+            onVariantChange: (_, current) => outerSeen.addAll(current),
+            builder: (_, _, child) => ColoredBox(
+              color: const Color(0x00000000),
+              child: Padding(padding: const EdgeInsets.all(30), child: child),
+            ),
+            child: FTappable(
+              onDisabledPress: () => calls.add('inner.onDisabledPress'),
+              child: const SizedBox(width: 60, height: 60, child: Text('inner')),
+            ),
+          ),
+        ),
+      );
+
+      final gesture = await tester.startGesture(tester.getCenter(find.text('inner')));
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(outerSeen.contains(FTappableVariant.pressed), false);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(calls, ['inner.onDisabledPress']);
     });
 
     testWidgets('pressing disabled inner presses outer', (tester) async {
@@ -1155,6 +1283,32 @@ void main() {
       );
 
       expect(tester.getSemantics(find.text('tappable')), isSemantics(hasSelectedState: true, isSelected: true));
+    });
+
+    testWidgets('disabled with onDisabledPress announced as disabled with tap action', (tester) async {
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FTappable.static(onDisabledPress: () {}, child: const Text('tappable')),
+        ),
+      );
+
+      expect(
+        tester.getSemantics(find.text('tappable')),
+        isSemantics(isButton: true, hasEnabledState: true, isEnabled: false, hasTapAction: true, isFocusable: true),
+      );
+    });
+
+    testWidgets('disabled without onDisabledPress has no tap action', (tester) async {
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: const FTappable.static(child: Text('tappable')),
+        ),
+      );
+
+      expect(
+        tester.getSemantics(find.text('tappable')),
+        isSemantics(hasEnabledState: true, isEnabled: false, hasTapAction: false),
+      );
     });
   });
 }

--- a/forui/test/src/widgets/button/button_test.dart
+++ b/forui/test/src/widgets/button/button_test.dart
@@ -44,6 +44,64 @@ void main() {
     expect(hovered, false);
   });
 
+  group('onDisabledPress', () {
+    testWidgets('fires when disabled button is tapped', (tester) async {
+      final calls = <String>[];
+      await tester.pumpWidget(
+        TestScaffold(
+          child: FButton(
+            onPress: null,
+            onDisabledPress: () => calls.add('onDisabledPress'),
+            child: const Text('Button'),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Button'));
+      await tester.pumpAndSettle();
+
+      expect(calls, ['onDisabledPress']);
+    });
+
+    testWidgets('does not fire when enabled', (tester) async {
+      final calls = <String>[];
+      await tester.pumpWidget(
+        TestScaffold(
+          child: FButton(
+            onPress: () => calls.add('onPress'),
+            onDisabledPress: () => calls.add('onDisabledPress'),
+            child: const Text('Button'),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Button'));
+      await tester.pumpAndSettle();
+
+      expect(calls, ['onPress']);
+    });
+
+    testWidgets('keeps disabled variant', (tester) async {
+      Set<FTappableVariant>? variants;
+      await tester.pumpWidget(
+        TestScaffold(
+          child: FButton.raw(
+            onPress: null,
+            onDisabledPress: () {},
+            child: Builder(
+              builder: (context) {
+                variants = FButtonData.of(context).variants;
+                return const Text('Button');
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(variants, contains(FTappableVariant.disabled));
+    });
+  });
+
   group('builders', () {
     testWidgets('FButton prefixBuilder & suffixBuilder receive child widgets', (tester) async {
       Widget? capturedPrefixChild;


### PR DESCRIPTION
**Describe the changes**

Closes #1120.

* Add `FTappable.onDisabledPress`, a callback for when the widget is pressed while disabled. It does not count towards
  enabling the widget, so `.disabled` styling and semantics are preserved.
* A disabled tappable with `onDisabledPress` can receive focus and be activated via Enter, tap, and `FTappableGroup`
  slide-across gestures. It shows no press bounce and claims pointers so ancestor tappables show no pressed effect.
* Announced to assistive technology as disabled with a tap action, mirroring `aria-disabled` on the web.
* Expose `onDisabledPress` on all three `FButton` constructors.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)