### PR TITLE
Fix overlays not restyling when the enclosing theme changes while open

### DIFF
--- a/docs_snippets/lib/snippets/concepts/themes/components/equality.dart
+++ b/docs_snippets/lib/snippets/concepts/themes/components/equality.dart
@@ -1,5 +1,7 @@
 import 'dart:ui';
 
+import 'package:flutter/widgets.dart';
+
 import 'package:forui/forui.dart';
 
 // {@snippet}
@@ -9,7 +11,7 @@ final bad = FDialogRouteStyle(
 );
 
 // Good: a static function is canonical.
-ImageFilter _blur(FThemeData theme, double v) => ImageFilter.blur(sigmaX: v * 5, sigmaY: v * 5);
+ImageFilter _blur(BuildContext context, double v) => ImageFilter.blur(sigmaX: v * 5, sigmaY: v * 5);
 
 const good = FDialogRouteStyle(barrierFilter: _blur);
 // {@endsnippet}

--- a/docs_snippets/lib/usages/overlay/modal_sheet.dart
+++ b/docs_snippets/lib/usages/overlay/modal_sheet.dart
@@ -50,6 +50,7 @@ final route = FModalSheetRoute<void>(
   barrierOnTapHint: null,
   // {@endcategory}
   // {@category "Navigation"}
+  capturedFTheme: null,
   capturedThemes: null,
   settings: null,
   anchorPoint: null,
@@ -57,7 +58,6 @@ final route = FModalSheetRoute<void>(
   // {@endcategory}
   // {@category "Core"}
   style: const FModalSheetStyle(),
-  theme: FTheme.neutral.light.touch,
   side: .btt,
   builder: (context) => const Padding(padding: .all(16), child: Text('Sheet content')),
   // {@endcategory}

--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 0.25.0 (Next)
+## 0.25.0
+
+This update continues with our ongoing effort to improve Forui's accessibility. It also includes several QoL improvements
+and bugfixes.
 
 ### `FAutocomplete`
 * Add `FAutocomplete.contentOverlayLocation`.
@@ -30,10 +33,12 @@
 
 ### `FDialog`
 * Add `FDialogRouteStyle.defaultBarrierFilter`.
+* Add `FDialogRoute.capturedScopes`.
 
-* **Breaking** Add `FDialogRoute(theme: ...)`.
-* **Breaking** Change `FDialogRouteStyle.barrierFilter` and `FDialogStyle.backgroundFilter` to accept a `FThemeData`.
+* **Breaking** Change `FDialogRouteStyle.barrierFilter` and `FDialogStyle.backgroundFilter` to accept a `BuildContext`.
 * **Breaking** Remove `FDialogRouteStyle.inherit(colors: ...)`. Use `FDialogRouteStyle.inherit()` instead.
+
+* Fix `showFDialog` not restyling the dialog and barrier when the theme changes while open.
 
 
 ### `FHeaderAction`
@@ -56,6 +61,10 @@ rebuilt.
 * Add `FItem.semanticsTooltip` and `FTile.semanticsTooltip`.
 
 
+### `FModalBarrier` & `FAnimatedModalBarrier`
+* **Breaking** Change `FAnimatedModalBarrier.filter` to accept a `BuildContext`.
+
+
 ### `FOverlay`
 * Add `FOverlay.overlayLocation`.
 
@@ -74,7 +83,7 @@ rebuilt.
 * Add `FPopover.overlayLocation`.
 * Add `FPopover.traversalGrouped`.
 
-* **Breaking** Change `FPopoverStyle.barrierFilter` and `FPopoverStyle.backgroundFilter` to accept a `FThemeData`.
+* **Breaking** Change `FPopoverStyle.barrierFilter` and `FPopoverStyle.backgroundFilter` to accept a `BuildContext`.
 
 * Fix `FPopover` content not being traversed immediately after its child.
 
@@ -100,10 +109,12 @@ rebuilt.
 
 ### `FSheet`
 * Add `FModalSheetStyle.defaultBarrierFilter`.
+* Add `FModalSheetRoute.capturedScopes`.
 
-* **Breaking** Add `FModalSheetRoute(theme: ...)`.
-* **Breaking** Change `FModalSheetStyle.barrierFilter` to accept a `FThemeData`.
+* **Breaking** Change `FModalSheetStyle.barrierFilter` to accept a `BuildContext`.
 * **Breaking** Remove `FModalSheetStyle.inherit(colors: ...)`. Use `FModalSheetStyle.inherit()` instead.
+
+* Fix `showFSheet` content not restyling when the theme changes while open.
 
 
 ### `FTappable`
@@ -113,8 +124,16 @@ rebuilt.
 * Fix pressed effect applying to ancestor tappables when a nested tappable is pressed.
 
 
+### `FTheme`
+* Add `FTheme.capture` and `FCapturedTheme`.
+
+
 ### `FTimeField`
 * Add `FTimeFieldPickerProperties.overlayLocation`.
+
+
+### `FToast` & `FToaster`
+* Fix toasts not restyling when the theme changes while shown.
 
 
 ### `FTooltip`

--- a/forui/lib/foundation.dart
+++ b/forui/lib/foundation.dart
@@ -1,7 +1,7 @@
 /// Low-level utilities and services.
 library forui.foundation;
 
-export 'src/foundation/accessibility.dart';
+export 'src/foundation/accessibility.dart' hide AccessibilityScopeElement;
 export 'src/foundation/barrier.dart';
 export 'src/foundation/collapsible.dart';
 export 'src/foundation/doc_templates.dart' hide Control, Focus, FormFieldKey, Scroll, Semantics, TappableGroup;

--- a/forui/lib/src/foundation/accessibility.dart
+++ b/forui/lib/src/foundation/accessibility.dart
@@ -77,7 +77,7 @@ class FAccessibilityScope extends StatefulWidget {
   ///
   /// It is recommended to use the terser [FAccessibilityContext.accessibleNavigation] getter instead.
   @useResult
-  static bool accessibleNavigationOf(BuildContext context) => InheritedModel.inheritFrom<_Accessibility>(
+  static bool accessibleNavigationOf(BuildContext context) => InheritedModel.inheritFrom<_AccessibilityScope>(
     context,
     aspect: _Aspect.accessibleNavigation,
   )!.data.accessibleNavigation;
@@ -87,14 +87,14 @@ class FAccessibilityScope extends StatefulWidget {
   /// It is recommended to use the terser [FAccessibilityContext.motion] getter instead.
   @useResult
   static FAccessibilityMotion motionOf(BuildContext context) =>
-      InheritedModel.inheritFrom<_Accessibility>(context, aspect: _Aspect.motion)!.data.motion;
+      InheritedModel.inheritFrom<_AccessibilityScope>(context, aspect: _Aspect.motion)!.data.motion;
 
   /// Returns [FAccessibility.focusHighlight] of the nearest [FAccessibilityScope] in the given [context].
   ///
   /// It is recommended to use the terser [FAccessibilityContext.focusHighlight] getter instead.
   @useResult
   static bool focusHighlightOf(BuildContext context) =>
-      InheritedModel.inheritFrom<_Accessibility>(context, aspect: _Aspect.focusHighlight)!.data.focusHighlight;
+      InheritedModel.inheritFrom<_AccessibilityScope>(context, aspect: _Aspect.focusHighlight)!.data.focusHighlight;
 
   /// The features to expose. When null, the platform features are observed instead.
   final FAccessibility? data;
@@ -158,7 +158,7 @@ class _State extends State<FAccessibilityScope> with WidgetsBindingObserver {
   }
 
   @override
-  Widget build(BuildContext context) => _Accessibility(data: widget.data ?? _current, child: widget.child);
+  Widget build(BuildContext context) => _AccessibilityScope(data: widget.data ?? _current, child: widget.child);
 }
 
 /// Provides convenient access to the nearest [FAccessibility].
@@ -173,16 +173,19 @@ extension type FAccessibilityContext(BuildContext context) {
   bool get focusHighlight => FAccessibilityScope.focusHighlightOf(context);
 }
 
-class _Accessibility extends InheritedModel<_Aspect> {
+class _AccessibilityScope extends InheritedModel<_Aspect> {
   final FAccessibility data;
 
-  const _Accessibility({required this.data, required super.child});
+  const _AccessibilityScope({required this.data, required super.child});
 
   @override
-  bool updateShouldNotify(_Accessibility old) => data != old.data;
+  InheritedModelElement<_Aspect> createElement() => AccessibilityScopeElement(this);
 
   @override
-  bool updateShouldNotifyDependent(_Accessibility old, Set<_Aspect> dependencies) =>
+  bool updateShouldNotify(_AccessibilityScope old) => data != old.data;
+
+  @override
+  bool updateShouldNotifyDependent(_AccessibilityScope old, Set<_Aspect> dependencies) =>
       dependencies.contains(_Aspect.accessibleNavigation) &&
           data.accessibleNavigation != old.data.accessibleNavigation ||
       dependencies.contains(_Aspect.motion) && data.motion != old.data.motion ||
@@ -192,5 +195,33 @@ class _Accessibility extends InheritedModel<_Aspect> {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty('data', data));
+  }
+}
+
+@internal
+class AccessibilityScopeElement extends InheritedModelElement<_Aspect> {
+  static ValueListenable<FAccessibility>? of(BuildContext context) =>
+      (context.getElementForInheritedWidgetOfExactType<_AccessibilityScope>() as AccessibilityScopeElement?)?.notifier;
+
+  final ValueNotifier<FAccessibility> notifier;
+
+  AccessibilityScopeElement(_AccessibilityScope super.widget) : notifier = ValueNotifier(widget.data);
+
+  @override
+  void update(covariant _AccessibilityScope current) { // ignore: library_private_types_in_public_api
+    notifier.value = current.data;
+    super.update(current);
+  }
+
+  @override
+  void unmount() {
+    notifier.dispose();
+    super.unmount();
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty('notifier', notifier));
   }
 }

--- a/forui/lib/src/foundation/accessibility.dart
+++ b/forui/lib/src/foundation/accessibility.dart
@@ -208,8 +208,8 @@ class AccessibilityScopeElement extends InheritedModelElement<_Aspect> {
   AccessibilityScopeElement(_AccessibilityScope super.widget) : notifier = ValueNotifier(widget.data);
 
   @override
+  // ignore: library_private_types_in_public_api
   void update(covariant _AccessibilityScope current) {
-    // ignore: library_private_types_in_public_api
     notifier.value = current.data;
     super.update(current);
   }

--- a/forui/lib/src/foundation/accessibility.dart
+++ b/forui/lib/src/foundation/accessibility.dart
@@ -208,7 +208,8 @@ class AccessibilityScopeElement extends InheritedModelElement<_Aspect> {
   AccessibilityScopeElement(_AccessibilityScope super.widget) : notifier = ValueNotifier(widget.data);
 
   @override
-  void update(covariant _AccessibilityScope current) { // ignore: library_private_types_in_public_api
+  void update(covariant _AccessibilityScope current) {
+    // ignore: library_private_types_in_public_api
     notifier.value = current.data;
     super.update(current);
   }

--- a/forui/lib/src/foundation/barrier.dart
+++ b/forui/lib/src/foundation/barrier.dart
@@ -23,12 +23,6 @@ import 'package:forui/forui.dart';
 /// * support for [ImageFilter]s instead of just solid colors.
 /// * uses [FModalBarrier] instead of [ModalBarrier].
 class FAnimatedModalBarrier extends AnimatedWidget {
-  /// The theme passed to [filter].
-  ///
-  /// A barrier is mounted in an [Overlay], outside the [FTheme] that created it, so the theme cannot be read from the
-  /// [BuildContext].
-  final FThemeData theme;
-
   /// {@macro forui.foundation.FModalBarrier.cutout}
   final RenderBox? cutout;
 
@@ -36,7 +30,7 @@ class FAnimatedModalBarrier extends AnimatedWidget {
   final void Function(Path path, Rect bounds) cutoutBuilder;
 
   /// If non-null, applies the given [ImageFilter] to the barrier.
-  final ImageFilter Function(FThemeData theme, double value)? filter;
+  final ImageFilter Function(BuildContext context, double value)? filter;
 
   /// {@macro forui.foundation.FModalBarrier.onDismiss}
   final VoidCallback? onDismiss;
@@ -63,7 +57,6 @@ class FAnimatedModalBarrier extends AnimatedWidget {
 
   /// Creates a [FAnimatedModalBarrier] that blocks user interaction.
   const FAnimatedModalBarrier({
-    required this.theme,
     required this.filter,
     required this.onDismiss,
     required Animation<double> animation,
@@ -80,7 +73,9 @@ class FAnimatedModalBarrier extends AnimatedWidget {
   Widget build(BuildContext context) => FModalBarrier(
     cutout: cutout,
     cutoutBuilder: cutoutBuilder,
-    filter: filter == null ? null : filter!(theme, context.accessibility.motion == .disabled ? 1.0 : animation.value),
+    filter: filter == null
+        ? null
+        : filter!(context, context.accessibility.motion == .disabled ? 1.0 : animation.value),
     onDismiss: onDismiss,
     semanticsLabel: semanticsLabel,
     barrierSemanticsDismissible: barrierSemanticsDismissible,
@@ -98,7 +93,6 @@ class FAnimatedModalBarrier extends AnimatedWidget {
       ..add(DiagnosticsProperty('cutout', cutout))
       ..add(ObjectFlagProperty.has('cutoutBuilder', cutoutBuilder))
       ..add(DiagnosticsProperty('filter', filter))
-      ..add(DiagnosticsProperty('theme', theme))
       ..add(ObjectFlagProperty.has('onDismiss', onDismiss))
       ..add(StringProperty('semanticsLabel', semanticsLabel))
       ..add(

--- a/forui/lib/src/foundation/barrier.dart
+++ b/forui/lib/src/foundation/barrier.dart
@@ -73,9 +73,7 @@ class FAnimatedModalBarrier extends AnimatedWidget {
   Widget build(BuildContext context) => FModalBarrier(
     cutout: cutout,
     cutoutBuilder: cutoutBuilder,
-    filter: filter == null
-        ? null
-        : filter!(context, context.accessibility.motion == .disabled ? 1.0 : animation.value),
+    filter: filter == null ? null : filter!(context, context.accessibility.motion == .disabled ? 1.0 : animation.value),
     onDismiss: onDismiss,
     semanticsLabel: semanticsLabel,
     barrierSemanticsDismissible: barrierSemanticsDismissible,

--- a/forui/lib/src/theme/adaptive_scope.dart
+++ b/forui/lib/src/theme/adaptive_scope.dart
@@ -43,11 +43,42 @@ class FAdaptiveScope extends InheritedWidget {
   FAdaptiveScope({required super.child, FPlatformVariant? platform, super.key}) : platform = platform ?? _platform;
 
   @override
+  InheritedElement createElement() => AdaptiveScopeElement(this);
+
+  @override
   bool updateShouldNotify(FAdaptiveScope old) => platform != old.platform;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty('platform', platform));
+  }
+}
+
+@internal
+class AdaptiveScopeElement extends InheritedElement {
+  static ValueListenable<FPlatformVariant>? of(BuildContext context) =>
+      (context.getElementForInheritedWidgetOfExactType<FAdaptiveScope>() as AdaptiveScopeElement?)?.notifier;
+
+  final ValueNotifier<FPlatformVariant> notifier;
+
+  AdaptiveScopeElement(FAdaptiveScope super.widget) : notifier = ValueNotifier(widget.platform);
+
+  @override
+  void update(covariant FAdaptiveScope current) {
+    notifier.value = current.platform;
+    super.update(current);
+  }
+
+  @override
+  void unmount() {
+    notifier.dispose();
+    super.unmount();
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty('notifier', notifier));
   }
 }

--- a/forui/lib/src/theme/captured_theme.dart
+++ b/forui/lib/src/theme/captured_theme.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+import 'package:forui/forui.dart';
+
+/// Similar to [InheritedTheme.capture], [FCapturedTheme] captures [FTheme]'s fields from one [BuildContext] to
+/// another. This is typically used when a navigator pushes a new route.
+///
+/// See:
+/// * [FTheme.capture].
+class FCapturedTheme {
+  /// The captured theme data, or null if no theme was captured.
+  final ValueListenable<FThemeData>? theme;
+
+  /// The captured accessibility features, or null if no accessibility scope was captured.
+  final ValueListenable<FAccessibility>? accessibility;
+
+  /// The captured platform variant, or null if no adaptive scope was captured.
+  final ValueListenable<FPlatformVariant>? platform;
+
+  /// Creates a [FCapturedTheme].
+  const FCapturedTheme({this.theme, this.accessibility, this.platform});
+
+  /// Wraps the given [child] in widgets that re-establish and observe the captured scopes.
+  Widget wrap(Widget child) =>
+      theme == null && accessibility == null && platform == null ? child : _CapturedTheme(captured: this, child: child);
+}
+
+class _CapturedTheme extends StatefulWidget {
+  final FCapturedTheme captured;
+  final Widget child;
+
+  const _CapturedTheme({required this.captured, required this.child});
+
+  @override
+  State<_CapturedTheme> createState() => _CapturedThemeState();
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty('captured', captured));
+  }
+}
+
+class _CapturedThemeState extends State<_CapturedTheme> {
+  bool _deferred = false;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.captured.theme?.addListener(_onChange);
+    widget.captured.accessibility?.addListener(_onChange);
+    widget.captured.platform?.addListener(_onChange);
+  }
+
+  @override
+  void didUpdateWidget(covariant _CapturedTheme old) {
+    super.didUpdateWidget(old);
+    if (!identical(old.captured.theme, widget.captured.theme)) {
+      old.captured.theme?.removeListener(_onChange);
+      widget.captured.theme?.addListener(_onChange);
+    }
+
+    if (!identical(old.captured.accessibility, widget.captured.accessibility)) {
+      old.captured.accessibility?.removeListener(_onChange);
+      widget.captured.accessibility?.addListener(_onChange);
+    }
+
+    if (!identical(old.captured.platform, widget.captured.platform)) {
+      old.captured.platform?.removeListener(_onChange);
+      widget.captured.platform?.addListener(_onChange);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.captured.theme?.removeListener(_onChange);
+    widget.captured.accessibility?.removeListener(_onChange);
+    widget.captured.platform?.removeListener(_onChange);
+    super.dispose();
+  }
+
+  void _onChange() {
+    if (!mounted) {
+      return;
+    }
+
+    // A captured scope usually rebuilds during the framework's build phase while this widget is in an unrelated
+    // subtree, which cannot be marked dirty mid-build. Defer the rebuild to the end of the frame instead, same as
+    // [OverlayEntry.remove] and [LocalHistoryRoute.changedInternalState].
+    if (WidgetsBinding.instance.schedulerPhase == .persistentCallbacks) {
+      if (!_deferred) {
+        _deferred = true;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          _deferred = false;
+          if (mounted) {
+            setState(() {});
+          }
+        });
+      }
+    } else {
+      setState(() {});
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.captured.theme case final theme?) {
+      return FBasicTheme(
+        data: theme.value,
+        accessibility: widget.captured.accessibility?.value,
+        platform: widget.captured.platform?.value,
+        child: widget.child,
+      );
+    }
+
+    var child = widget.child;
+    if (widget.captured.platform case final platform?) {
+      child = FAdaptiveScope(platform: platform.value, child: child);
+    }
+
+    if (widget.captured.accessibility case final accessibility?) {
+      child = FAccessibilityScope(data: accessibility.value, child: child);
+    }
+
+    return child;
+  }
+}

--- a/forui/lib/src/theme/delta/delta.dart
+++ b/forui/lib/src/theme/delta/delta.dart
@@ -26,7 +26,7 @@ extension Sentinels on Never {
   static const imageFilter = _ImageFilterSentinel();
 
   /// A sentinel value for image filter function fields.
-  static ImageFilter imageFilterFunction(FThemeData theme, double animation) => throw UnimplementedError();
+  static ImageFilter imageFilterFunction(BuildContext context, double animation) => throw UnimplementedError();
 
   /// A sentinel value for border radius fields.
   static const borderRadius = _BorderRadiusSentinel();

--- a/forui/lib/src/theme/theme.dart
+++ b/forui/lib/src/theme/theme.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 
 import 'package:forui/forui.dart';
+import 'package:forui/src/foundation/accessibility.dart';
+import 'package:forui/src/theme/adaptive_scope.dart';
 
 part 'theme.design.dart';
 
@@ -136,6 +138,20 @@ class FTheme extends StatelessWidget {
   static FThemeData of(BuildContext context) {
     final theme = context.dependOnInheritedWidgetOfExactType<_InheritedTheme>();
     return theme?.data ?? FTheme.neutral.light.touch;
+  }
+
+  /// Captures the [FTheme], [FAccessibilityScope] and [FAdaptiveScope] visible from [from] to [to].
+  @useResult
+  static FCapturedTheme capture({required BuildContext from, required BuildContext to}) {
+    final theme = InheritedThemeElement.of(from);
+    final accessibility = AccessibilityScopeElement.of(from);
+    final platform = AdaptiveScopeElement.of(from);
+
+    return FCapturedTheme(
+      theme: identical(theme, InheritedThemeElement.of(to)) ? null : theme,
+      accessibility: identical(accessibility, AccessibilityScopeElement.of(to)) ? null : accessibility,
+      platform: identical(platform, AdaptiveScopeElement.of(to)) ? null : platform,
+    );
   }
 
   /// The [Neutral](https://ui.shadcn.com/docs/theming#neutral) theme.
@@ -349,6 +365,9 @@ class _InheritedTheme extends InheritedTheme {
   const _InheritedTheme({required this.data, required super.child});
 
   @override
+  InheritedElement createElement() => InheritedThemeElement(this);
+
+  @override
   Widget wrap(BuildContext context, Widget child) => _InheritedTheme(data: data, child: child);
 
   @override
@@ -358,6 +377,35 @@ class _InheritedTheme extends InheritedTheme {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty('data', data));
+  }
+}
+
+@internal
+class InheritedThemeElement extends InheritedElement {
+  static ValueListenable<FThemeData>? of(BuildContext context) =>
+      (context.getElementForInheritedWidgetOfExactType<_InheritedTheme>() as InheritedThemeElement?)?.notifier;
+
+  final ValueNotifier<FThemeData> notifier;
+
+  InheritedThemeElement(_InheritedTheme super.widget) : notifier = ValueNotifier(widget.data);
+
+  @override
+  // ignore: library_private_types_in_public_api
+  void update(covariant _InheritedTheme current) {
+    notifier.value = current.data;
+    super.update(current);
+  }
+
+  @override
+  void unmount() {
+    notifier.dispose();
+    super.unmount();
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty('notifier', notifier));
   }
 }
 

--- a/forui/lib/src/widgets/context_menu.dart
+++ b/forui/lib/src/widgets/context_menu.dart
@@ -436,7 +436,6 @@ class _State extends State<FContextMenu> with TickerProviderStateMixin {
                   cutoutBuilder: widget.cutoutBuilder,
                   animation: _controller.fade,
                   filter: style.barrierFilter!,
-                  theme: context.theme,
                   semanticsLabel: widget.barrierSemanticsLabel ?? localizations.barrierLabel,
                   barrierSemanticsDismissible: widget.barrierSemanticsDismissible,
                   semanticsOnTapHint: localizations.barrierOnTapHint(localizations.contextMenuSemanticsLabel),
@@ -511,8 +510,8 @@ class _State extends State<FContextMenu> with TickerProviderStateMixin {
                     clipper: InnerPathClipper(decoration: style.decoration, direction: direction),
                     child: AnimatedBuilder(
                       animation: _controller.fade,
-                      builder: (_, _) =>
-                          BackdropFilter(filter: filter(context.theme, _controller.fade.value), child: Container()),
+                      builder: (context, _) =>
+                          BackdropFilter(filter: filter(context, _controller.fade.value), child: Container()),
                     ),
                   ),
                 ),

--- a/forui/lib/src/widgets/dialog.dart
+++ b/forui/lib/src/widgets/dialog.dart
@@ -20,8 +20,7 @@ part 'dialog.design.dart';
 
 /// Shows a dialog.
 ///
-/// [context] is used to look up the [Navigator] and [FDialogStyle] for the dialog. It is only used when the method is
-/// called. Its corresponding widget can be safely removed from the tree before the sheet is closed.
+/// [context] is used to look up the [Navigator] and [FDialogStyle] for the dialog.
 ///
 /// [useRootNavigator] ensures that the root navigator displays the sheet when `true`. This is useful in the case that a
 /// modal sheet needs to be displayed above all other content but the caller is inside another [Navigator].
@@ -79,14 +78,13 @@ Future<T?> showFDialog<T>({
   final navigator = Navigator.of(context, rootNavigator: useRootNavigator);
   final localizations = FLocalizations.of(context) ?? FDefaultLocalizations();
   final dialogRouteStyle = routeStyle(context.theme.dialogRouteStyle);
-  final dialogStyle = style(context.theme.dialogStyle);
 
   return navigator.push(
     FDialogRoute<T>(
       style: dialogRouteStyle,
-      theme: context.theme,
-      builder: (context, animation) => builder(context, dialogStyle, animation),
+      builder: (context, animation) => builder(context, style(context.theme.dialogStyle), animation),
       capturedThemes: InheritedTheme.capture(from: context, to: navigator.context),
+      capturedFTheme: FTheme.capture(from: context, to: navigator.context),
       barrierDismissible: barrierDismissible,
       barrierLabel: barrierLabel ?? localizations.barrierLabel,
       barrierOnTapHint: localizations.barrierOnTapHint(localizations.dialogSemanticsLabel),
@@ -104,11 +102,8 @@ class FDialogRoute<T> extends RawDialogRoute<T> {
   /// The dialog route's style.
   final FDialogRouteStyle style;
 
-  /// The theme passed to [FDialogRouteStyle.barrierFilter].
-  ///
-  /// A barrier is mounted in an [Overlay], outside the [FTheme] that created it, so the theme cannot be read from the
-  /// [BuildContext].
-  final FThemeData theme;
+  /// The captured [FTheme].
+  final FCapturedTheme? capturedFTheme;
 
   @override
   final bool barrierDismissible;
@@ -123,11 +118,11 @@ class FDialogRoute<T> extends RawDialogRoute<T> {
   /// Creates a [FDialogRoute].
   FDialogRoute({
     required this.style,
-    required this.theme,
     required Widget Function(BuildContext context, Animation<double> animation) builder,
     this.barrierDismissible = true,
     this.barrierLabel,
     this.barrierOnTapHint,
+    this.capturedFTheme,
     CapturedThemes? capturedThemes,
     bool useSafeArea = true,
     super.settings,
@@ -137,8 +132,9 @@ class FDialogRoute<T> extends RawDialogRoute<T> {
     super.directionalTraversalEdgeBehavior,
   }) : super(
          pageBuilder: (context, animation, secondaryAnimation) {
-           final child = Builder(builder: (context) => builder(context, animation));
-           Widget dialog = capturedThemes?.wrap(child) ?? child;
+           Widget dialog = Builder(builder: (context) => builder(context, animation));
+           dialog = capturedFTheme?.wrap(dialog) ?? dialog;
+           dialog = capturedThemes?.wrap(dialog) ?? dialog;
            if (useSafeArea) {
              dialog = SafeArea(child: dialog);
            }
@@ -148,12 +144,12 @@ class FDialogRoute<T> extends RawDialogRoute<T> {
 
   @override
   Widget buildModalBarrier() {
+    final Widget barrier;
     if (style.barrierFilter != null && !offstage) {
-      return Builder(
+      barrier = Builder(
         builder: (context) => FAnimatedModalBarrier(
           animation: animation!.drive(CurveTween(curve: barrierCurve)),
           filter: style.barrierFilter,
-          theme: theme,
           onDismiss: barrierDismissible ? () => Navigator.pop(context) : null,
           semanticsLabel: barrierLabel,
           // changedInternalState is called if barrierLabel updates
@@ -162,7 +158,7 @@ class FDialogRoute<T> extends RawDialogRoute<T> {
         ),
       );
     } else {
-      return Builder(
+      barrier = Builder(
         builder: (context) => FModalBarrier(
           filter: null,
           onDismiss: barrierDismissible ? () => Navigator.pop(context) : null,
@@ -173,6 +169,8 @@ class FDialogRoute<T> extends RawDialogRoute<T> {
         ),
       );
     }
+
+    return capturedFTheme?.wrap(barrier) ?? barrier;
   }
 
   @override
@@ -198,19 +196,19 @@ class FDialogRoute<T> extends RawDialogRoute<T> {
 
 /// [FDialogRoute]'s style.
 class FDialogRouteStyle with Diagnosticable, _$FDialogRouteStyleFunctions {
+  /// The default [barrierFilter]. Blurs and tints the content behind the barrier.
+  static ImageFilter defaultBarrierFilter(BuildContext context, double animation) => ImageFilter.compose(
+    outer: ImageFilter.blur(sigmaX: animation * 5, sigmaY: animation * 5),
+    inner: ColorFilter.mode(FColors.lerpColor(Colors.transparent, context.theme.colors.barrier, animation)!, .srcOver),
+  );
+
   /// {@macro forui.widgets.FPopoverStyle.barrierFilter}
   @override
-  final ImageFilter Function(FThemeData theme, double animation)? barrierFilter;
+  final ImageFilter Function(BuildContext context, double animation)? barrierFilter;
 
   /// Motion-related properties.
   @override
   final FDialogRouteMotion motion;
-
-  /// The default [barrierFilter]. Blurs and tints the content behind the barrier.
-  static ImageFilter defaultBarrierFilter(FThemeData theme, double animation) => ImageFilter.compose(
-    outer: ImageFilter.blur(sigmaX: animation * 5, sigmaY: animation * 5),
-    inner: ColorFilter.mode(FColors.lerpColor(Colors.transparent, theme.colors.barrier, animation)!, .srcOver),
-  );
 
   /// Creates a [FDialogRouteStyle].
   const FDialogRouteStyle({this.barrierFilter, this.motion = const FDialogRouteMotion()});
@@ -458,11 +456,11 @@ class _FDialogState extends State<FDialog> {
             child: ClipPath(
               clipper: InnerPathClipper(decoration: style.decoration, direction: direction),
               child: _fade == null
-                  ? BackdropFilter(filter: filter(context.theme, 1), child: Container())
+                  ? BackdropFilter(filter: filter(context, 1), child: Container())
                   : AnimatedBuilder(
                       animation: _fade!,
-                      builder: (_, _) =>
-                          BackdropFilter(filter: filter(context.theme, _fade!.value), child: Container()),
+                      builder: (context, _) =>
+                          BackdropFilter(filter: filter(context, _fade!.value), child: Container()),
                     ),
             ),
           ),
@@ -511,7 +509,7 @@ class FDialogStyle with Diagnosticable, _$FDialogStyleFunctions {
   ///
   /// This requires [FDialog.animation] to be non-null.
   @override
-  final ImageFilter Function(FThemeData theme, double animation)? backgroundFilter;
+  final ImageFilter Function(BuildContext context, double animation)? backgroundFilter;
 
   /// The decoration.
   @override

--- a/forui/lib/src/widgets/popover/popover.dart
+++ b/forui/lib/src/widgets/popover/popover.dart
@@ -472,7 +472,6 @@ class _State extends State<FPopover> with TickerProviderStateMixin {
                     cutoutBuilder: widget.cutoutBuilder,
                     animation: _controller.fade,
                     filter: style.barrierFilter!,
-                    theme: context.theme,
                     semanticsLabel: widget.barrierSemanticsLabel ?? localizations.barrierLabel,
                     barrierSemanticsDismissible: widget.barrierSemanticsDismissible,
                     semanticsOnTapHint: localizations.barrierOnTapHint(localizations.popoverSemanticsLabel),
@@ -527,8 +526,8 @@ class _State extends State<FPopover> with TickerProviderStateMixin {
                       clipper: InnerPathClipper(decoration: style.decoration, direction: direction),
                       child: AnimatedBuilder(
                         animation: _controller.fade,
-                        builder: (_, _) =>
-                            BackdropFilter(filter: filter(context.theme, _controller.fade.value), child: Container()),
+                        builder: (context, _) =>
+                            BackdropFilter(filter: filter(context, _controller.fade.value), child: Container()),
                       ),
                     ),
                   ),
@@ -565,8 +564,8 @@ class FPopoverStyle with Diagnosticable, _$FPopoverStyleFunctions {
   final Decoration decoration;
 
   /// {@template forui.widgets.FPopoverStyle.barrierFilter}
-  /// An optional callback that takes the current animation transition value (0.0 to 1.0) and returns an [ImageFilter]
-  /// that is used as the barrier. Defaults to null.
+  /// An optional callback that takes a [BuildContext] and the current animation transition value (0.0 to 1.0), and
+  /// returns an [ImageFilter] that is used as the barrier. Defaults to null.
   ///
   /// Prefer a static function over a closure literal. A closure literal is never equal to another, which causes widgets
   /// to flicker when the same theme is recreated.
@@ -574,23 +573,26 @@ class FPopoverStyle with Diagnosticable, _$FPopoverStyleFunctions {
   /// ## Examples
   /// ```dart
   /// // Blurred
-  /// (animation) => ImageFilter.blur(sigmaX: animation * 5, sigmaY: animation * 5);
+  /// (context, animation) => ImageFilter.blur(sigmaX: animation * 5, sigmaY: animation * 5);
   ///
   /// // Solid color
-  /// (animation) => ColorFilter.mode(Colors.white.withValues(alpha: animation), BlendMode.srcOver);
+  /// (context, animation) => ColorFilter.mode(Colors.white.withValues(alpha: animation), BlendMode.srcOver);
   ///
   /// // Tinted
-  /// (animation) => ColorFilter.mode(Colors.white.withValues(alpha: animation * 0.5), BlendMode.srcOver);
+  /// (context, animation) => ColorFilter.mode(
+  ///   context.theme.colors.barrier.withValues(alpha: animation * 0.5),
+  ///   BlendMode.srcOver,
+  /// );
   ///
   /// // Blurred & tinted
-  /// (animation) => ImageFilter.compose(
+  /// (context, animation) => ImageFilter.compose(
   ///   outer: ImageFilter.blur(sigmaX: animation * 5, sigmaY: animation * 5),
   ///   inner: ColorFilter.mode(Colors.white.withValues(alpha: animation * 0.5), BlendMode.srcOver),
   /// );
   /// ```
   /// {@endtemplate}
   @override
-  final ImageFilter Function(FThemeData theme, double animation)? barrierFilter;
+  final ImageFilter Function(BuildContext context, double animation)? barrierFilter;
 
   /// {@template forui.widgets.FPopoverStyle.backgroundFilter}
   /// An optional callback that takes the current animation transition value (0.0 to 1.0) and returns an [ImageFilter]
@@ -604,23 +606,23 @@ class FPopoverStyle with Diagnosticable, _$FPopoverStyleFunctions {
   /// ## Examples
   /// ```dart
   /// // Blurred
-  /// (animation) => ImageFilter.blur(sigmaX: animation * 5, sigmaY: animation * 5);
+  /// (context, animation) => ImageFilter.blur(sigmaX: animation * 5, sigmaY: animation * 5);
   ///
   /// // Solid color
-  /// (animation) => ColorFilter.mode(Colors.white.withValues(alpha: animation), BlendMode.srcOver);
+  /// (context, animation) => ColorFilter.mode(Colors.white.withValues(alpha: animation), BlendMode.srcOver);
   ///
   /// // Tinted
-  /// (animation) => ColorFilter.mode(Colors.white.withValues(alpha: animation * 0.5), BlendMode.srcOver);
+  /// (context, animation) => ColorFilter.mode(Colors.white.withValues(alpha: animation * 0.5), BlendMode.srcOver);
   ///
   /// // Blurred & tinted
-  /// (animation) => ImageFilter.compose(
+  /// (context, animation) => ImageFilter.compose(
   ///   outer: ImageFilter.blur(sigmaX: animation * 5, sigmaY: animation * 5),
   ///   inner: ColorFilter.mode(Colors.white.withValues(alpha: animation * 0.5), BlendMode.srcOver),
   /// );
   /// ```
   /// {@endtemplate}
   @override
-  final ImageFilter Function(FThemeData theme, double animation)? backgroundFilter;
+  final ImageFilter Function(BuildContext context, double animation)? backgroundFilter;
 
   /// The additional padding between the edges of the view and the edges of the popover.
   ///

--- a/forui/lib/src/widgets/sheet/modal_sheet.dart
+++ b/forui/lib/src/widgets/sheet/modal_sheet.dart
@@ -18,8 +18,7 @@ part 'modal_sheet.design.dart';
 /// A modal sheet is an alternative to a menu or a dialog and prevents the user from interacting with the rest of the
 /// app.
 ///
-/// [context] is used to look up the [Navigator] and [FSheetStyle] for the sheet. It is only used when the method is
-/// called. Its corresponding widget can be safely removed from the tree before the sheet is closed.
+/// [context] is used to look up the [Navigator] and [FSheetStyle] for the sheet.
 ///
 /// [useRootNavigator] ensures that the root navigator displays the sheet when `true`. This is useful in the case that a
 /// modal sheet needs to be displayed above all other content but the caller is inside another [Navigator].
@@ -94,10 +93,10 @@ Future<T?> showFSheet<T>({
   return navigator.push(
     FModalSheetRoute<T>(
       style: style(context.theme.modalSheetStyle),
-      theme: context.theme,
       side: side,
       builder: builder,
       mainAxisMaxRatio: mainAxisMaxRatio,
+      capturedFTheme: FTheme.capture(from: context, to: navigator.context),
       capturedThemes: InheritedTheme.capture(from: context, to: navigator.context),
       barrierOnTapHint: localizations.barrierOnTapHint(localizations.sheetSemanticsLabel),
       barrierLabel: barrierLabel ?? localizations.barrierLabel,
@@ -135,14 +134,11 @@ class FModalSheetRoute<T> extends PopupRoute<T> {
   /// The style.
   final FModalSheetStyle style;
 
-  /// The theme passed to [FModalSheetStyle.barrierFilter].
-  ///
-  /// A barrier is mounted in an [Overlay], outside the [FTheme] that created it, so the theme cannot be read from the
-  /// [BuildContext].
-  final FThemeData theme;
-
   /// The side.
   final FLayout side;
+
+  /// The captured [FTheme].
+  final FCapturedTheme? capturedFTheme;
 
   /// Stores a list of captured [InheritedTheme]s that are wrapped around the sheet.
   ///
@@ -227,10 +223,10 @@ class FModalSheetRoute<T> extends PopupRoute<T> {
   /// Creates a [FModalSheetRoute].
   FModalSheetRoute({
     required this.style,
-    required this.theme,
     required this.side,
     required this.builder,
     this.mainAxisMaxRatio = 9 / 16,
+    this.capturedFTheme,
     this.capturedThemes,
     this.barrierOnTapHint,
     this.barrierLabel,
@@ -285,17 +281,19 @@ class FModalSheetRoute<T> extends PopupRoute<T> {
       },
     );
 
-    return capturedThemes?.wrap(sheet) ?? sheet;
+    // The scopes are nested inside the captured themes so that their live values shadow the snapshots.
+    final wrapped = capturedFTheme?.wrap(sheet) ?? sheet;
+    return capturedThemes?.wrap(wrapped) ?? wrapped;
   }
 
   @override
   Widget buildModalBarrier() {
+    final Widget barrier;
     if (style.barrierFilter != null && !offstage) {
-      return Builder(
+      barrier = Builder(
         builder: (context) => FAnimatedModalBarrier(
           animation: animation!.drive(CurveTween(curve: barrierCurve)),
           filter: style.barrierFilter,
-          theme: theme,
           onDismiss: barrierDismissible ? () => Navigator.pop(context) : null,
           semanticsLabel: barrierLabel,
           // changedInternalState is called if barrierLabel updates
@@ -305,7 +303,7 @@ class FModalSheetRoute<T> extends PopupRoute<T> {
         ),
       );
     } else {
-      return Builder(
+      barrier = Builder(
         builder: (context) => FModalBarrier(
           filter: null,
           onDismiss: barrierDismissible ? () => Navigator.pop(context) : null,
@@ -317,6 +315,8 @@ class FModalSheetRoute<T> extends PopupRoute<T> {
         ),
       );
     }
+
+    return capturedFTheme?.wrap(barrier) ?? barrier;
   }
 
   @override
@@ -355,12 +355,12 @@ class FModalSheetRoute<T> extends PopupRoute<T> {
 /// A modal sheet's style.
 class FModalSheetStyle extends FSheetStyle with Diagnosticable, _$FModalSheetStyleFunctions {
   /// The default [barrierFilter]. Tints the content behind the barrier.
-  static ImageFilter defaultBarrierFilter(FThemeData theme, double animation) =>
-      ColorFilter.mode(FColors.lerpColor(Colors.transparent, theme.colors.barrier, animation)!, .srcOver);
+  static ImageFilter defaultBarrierFilter(BuildContext context, double animation) =>
+      ColorFilter.mode(FColors.lerpColor(Colors.transparent, context.theme.colors.barrier, animation)!, .srcOver);
 
   /// {@macro forui.widgets.FPopoverStyle.barrierFilter}
   @override
-  final ImageFilter Function(FThemeData theme, double animation)? barrierFilter;
+  final ImageFilter Function(BuildContext context, double animation)? barrierFilter;
 
   /// The motion-related properties for a modal sheet.
   @override

--- a/forui/lib/src/widgets/toast/animated_toast.dart
+++ b/forui/lib/src/widgets/toast/animated_toast.dart
@@ -210,11 +210,13 @@ class _AnimatedToastState extends State<AnimatedToast> with TickerProviderStateM
         ..duration = widget.style.motion.reentranceDuration
         ..reverseDuration = widget.style.motion.exitDuration;
 
+      _curvedEntranceDismiss.dispose();
       _curvedEntranceDismiss = CurvedAnimation(
         parent: _entranceDismissController,
         curve: widget.style.motion.entranceCurve,
         reverseCurve: widget.style.motion.dismissCurve,
       );
+      _transition.dispose();
       _transition = CurvedAnimation(
         parent: _transitionController,
         curve: widget.style.motion.reentranceCurve,

--- a/forui/lib/src/widgets/toast/toaster.dart
+++ b/forui/lib/src/widgets/toast/toaster.dart
@@ -338,14 +338,7 @@ class FToasterState extends State<FToaster> {
           if (resolved.x < 0) .left else if (resolved.x > 0) .right,
         ];
 
-    final entry = ToasterEntry(
-      style(toasterStyle.toastStyles.resolve({variant, context.platformVariant})),
-      resolved,
-      directions,
-      dismissThreshold,
-      duration,
-      builder,
-    );
+    final entry = ToasterEntry(style, variant, resolved, directions, dismissThreshold, duration, builder);
     entry.onDismiss = () {
       entry.dismissing.value = true;
       _remove(entry);
@@ -432,7 +425,8 @@ mixin FToasterEntry {
 @internal
 class ToasterEntry with FToasterEntry {
   final GlobalKey key = GlobalKey();
-  final FToastStyle style;
+  final FToastStyleDelta style;
+  final FToastVariant variant;
   final Alignment alignment;
   List<AxisDirection> swipeToDismiss;
   final double dismissThreshold;
@@ -441,7 +435,15 @@ class ToasterEntry with FToasterEntry {
   final Widget Function(BuildContext context, FToasterEntry entry) builder;
   VoidCallback? onDismiss;
 
-  ToasterEntry(this.style, this.alignment, this.swipeToDismiss, this.dismissThreshold, this.duration, this.builder);
+  ToasterEntry(
+    this.style,
+    this.variant,
+    this.alignment,
+    this.swipeToDismiss,
+    this.dismissThreshold,
+    this.duration,
+    this.builder,
+  );
 
   @override
   void dismiss() {

--- a/forui/lib/src/widgets/toast/toaster_stack.dart
+++ b/forui/lib/src/widgets/toast/toaster_stack.dart
@@ -141,7 +141,7 @@ class _ToasterStackState extends State<ToasterStack> with SingleTickerProviderSt
           for (final (index, entry) in widget.entries.indexed)
             AnimatedToast(
               key: entry.key,
-              style: entry.style,
+              style: entry.style(widget.style.toastStyles.resolve({entry.variant, context.platformVariant})),
               alignTransform: widget.collapsedAlignTransform,
               index: widget.entries.length - 1 - index,
               length: widget.entries.length,

--- a/forui/lib/theme.dart
+++ b/forui/lib/theme.dart
@@ -2,9 +2,10 @@
 /// choices of Forui widgets.
 library forui.theme;
 
-export 'src/theme/adaptive_scope.dart';
+export 'src/theme/adaptive_scope.dart' hide AdaptiveScopeElement;
 export 'src/theme/border_radius.dart';
 export 'src/theme/breakpoints.dart';
+export 'src/theme/captured_theme.dart';
 export 'src/theme/colors.dart';
 export 'src/theme/delta/decoration.dart';
 export 'src/theme/delta/delta.dart';
@@ -16,7 +17,7 @@ export 'src/theme/haptic_feedback.dart';
 export 'src/theme/icons.dart';
 export 'src/theme/sizes.dart';
 export 'src/theme/style.dart';
-export 'src/theme/theme.dart';
+export 'src/theme/theme.dart' hide InheritedThemeElement;
 export 'src/theme/theme_data.dart';
 export 'src/theme/typography.dart';
 export 'src/theme/variant.dart' hide And, Desktop, Not, Touch, Value, toTextFieldVariants;

--- a/forui/test/src/widgets/dialog/dialog_test.dart
+++ b/forui/test/src/widgets/dialog/dialog_test.dart
@@ -308,8 +308,7 @@ void main() {
                     builder: (context) => FButton(
                       onPress: () => showFDialog(
                         context: context,
-                        builder: (context, style, _) =>
-                            FDialog(style: style, builder: (_, _) => const Text('dialog')),
+                        builder: (context, style, _) => FDialog(style: style, builder: (_, _) => const Text('dialog')),
                       ),
                       child: const Text('button'),
                     ),

--- a/forui/test/src/widgets/dialog/dialog_test.dart
+++ b/forui/test/src/widgets/dialog/dialog_test.dart
@@ -153,6 +153,184 @@ void main() {
         );
       });
     });
+
+    testWidgets('restyles when the enclosing theme changes while open', (tester) async {
+      Widget app(FThemeData theme) => TestScaffold.app(
+        theme: theme,
+        child: Builder(
+          builder: (context) => FButton(
+            onPress: () => showFDialog(
+              context: context,
+              builder: (context, style, _) => FDialog(style: style, builder: (_, _) => const Text('dialog')),
+            ),
+            child: const Text('button'),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(app(FTheme.neutral.light.touch));
+      await tester.tap(find.text('button'));
+      await tester.pumpAndSettle();
+
+      ShapeDecoration decoration() =>
+          tester
+                  .widget<DecoratedBox>(
+                    find.descendant(of: find.byType(FDialog), matching: find.byType(DecoratedBox)).first,
+                  )
+                  .decoration
+              as ShapeDecoration;
+
+      expect(decoration().color, FTheme.neutral.light.touch.colors.card);
+
+      await tester.pumpWidget(app(FTheme.neutral.dark.touch));
+      await tester.pumpAndSettle();
+
+      expect(decoration().color, FTheme.neutral.dark.touch.colors.card);
+    });
+
+    group('captured scopes', () {
+      ShapeDecoration decoration(WidgetTester tester) =>
+          tester
+                  .widget<DecoratedBox>(
+                    find.descendant(of: find.byType(FDialog), matching: find.byType(DecoratedBox)).first,
+                  )
+                  .decoration
+              as ShapeDecoration;
+
+      testWidgets('uses nested theme below the navigator and observes changes', (tester) async {
+        Widget app(FThemeData nested) => TestScaffold.app(
+          child: FTheme(
+            data: nested,
+            child: Builder(
+              builder: (context) => FButton(
+                onPress: () => showFDialog(
+                  context: context,
+                  builder: (context, style, _) => FDialog(style: style, builder: (_, _) => const Text('dialog')),
+                ),
+                child: const Text('button'),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpWidget(app(TestScaffold.greenOverride));
+        await tester.tap(find.text('button'));
+        await tester.pumpAndSettle();
+
+        expect(decoration(tester).color, TestScaffold.greenOverride.colors.card);
+
+        await tester.pumpWidget(app(TestScaffold.blueOverride));
+        await tester.pumpAndSettle();
+
+        expect(decoration(tester).color, TestScaffold.blueOverride.colors.card);
+      });
+
+      testWidgets('observes nested FAccessibilityScope below the navigator', (tester) async {
+        const all = FAccessibility(accessibleNavigation: false, motion: .all, focusHighlight: false);
+        const disabled = FAccessibility(accessibleNavigation: false, motion: .disabled, focusHighlight: false);
+
+        FAccessibilityMotion? seen;
+        Widget app(FAccessibility accessibility) => TestScaffold.app(
+          child: FAccessibilityScope(
+            data: accessibility,
+            child: Builder(
+              builder: (context) => FButton(
+                onPress: () => showFDialog(
+                  context: context,
+                  builder: (context, style, _) => FDialog(
+                    style: style,
+                    builder: (context, _) {
+                      seen = context.accessibility.motion;
+                      return const Text('dialog');
+                    },
+                  ),
+                ),
+                child: const Text('button'),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpWidget(app(all));
+        await tester.tap(find.text('button'));
+        await tester.pumpAndSettle();
+
+        expect(seen, FAccessibilityMotion.all);
+
+        await tester.pumpWidget(app(disabled));
+        await tester.pumpAndSettle();
+
+        expect(seen, FAccessibilityMotion.disabled);
+      });
+
+      testWidgets('observes nested FAdaptiveScope below the navigator', (tester) async {
+        FPlatformVariant? seen;
+        Widget app(FPlatformVariant platform) => TestScaffold.app(
+          child: FAdaptiveScope(
+            platform: platform,
+            child: Builder(
+              builder: (context) => FButton(
+                onPress: () => showFDialog(
+                  context: context,
+                  builder: (context, style, _) => FDialog(
+                    style: style,
+                    builder: (context, _) {
+                      seen = context.platformVariant;
+                      return const Text('dialog');
+                    },
+                  ),
+                ),
+                child: const Text('button'),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpWidget(app(.android));
+        await tester.tap(find.text('button'));
+        await tester.pumpAndSettle();
+
+        expect(seen, FPlatformVariant.android);
+
+        await tester.pumpWidget(app(.iOS));
+        await tester.pumpAndSettle();
+
+        expect(seen, FPlatformVariant.iOS);
+      });
+
+      testWidgets('retains captured scopes after the call-site is removed', (tester) async {
+        Widget app({required bool present}) => TestScaffold.app(
+          child: !present
+              ? const SizedBox()
+              : FTheme(
+                  data: TestScaffold.greenOverride,
+                  child: Builder(
+                    builder: (context) => FButton(
+                      onPress: () => showFDialog(
+                        context: context,
+                        builder: (context, style, _) =>
+                            FDialog(style: style, builder: (_, _) => const Text('dialog')),
+                      ),
+                      child: const Text('button'),
+                    ),
+                  ),
+                ),
+        );
+
+        await tester.pumpWidget(app(present: true));
+        await tester.tap(find.text('button'));
+        await tester.pumpAndSettle();
+
+        expect(decoration(tester).color, TestScaffold.greenOverride.colors.card);
+
+        await tester.pumpWidget(app(present: false));
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), null);
+        expect(find.text('dialog'), findsOneWidget);
+        expect(decoration(tester).color, TestScaffold.greenOverride.colors.card);
+      });
+    });
   });
 }
 

--- a/forui/test/src/widgets/sheet/modal_sheet_test.dart
+++ b/forui/test/src/widgets/sheet/modal_sheet_test.dart
@@ -153,4 +153,70 @@ void main() {
       expect(find.text('sheet'), findsOne);
     });
   }
+
+  group('scope liveness', () {
+    testWidgets('content observes theme changes while open', (tester) async {
+      FThemeData? seen;
+      Widget app(FThemeData theme) => TestScaffold.app(
+        theme: theme,
+        child: Builder(
+          builder: (context) => FButton(
+            onPress: () => showFSheet(
+              context: context,
+              side: .btt,
+              builder: (context) {
+                seen = context.theme;
+                return const Text('sheet');
+              },
+            ),
+            child: const Text('button'),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(app(FTheme.neutral.light.touch));
+      await tester.tap(find.text('button'));
+      await tester.pumpAndSettle();
+
+      expect(seen, FTheme.neutral.light.touch);
+
+      await tester.pumpWidget(app(FTheme.neutral.dark.touch));
+      await tester.pumpAndSettle();
+
+      expect(seen, FTheme.neutral.dark.touch);
+    });
+
+    testWidgets('content observes nested theme below the navigator', (tester) async {
+      FThemeData? seen;
+      Widget app(FThemeData nested) => TestScaffold.app(
+        child: FTheme(
+          data: nested,
+          child: Builder(
+            builder: (context) => FButton(
+              onPress: () => showFSheet(
+                context: context,
+                side: .btt,
+                builder: (context) {
+                  seen = context.theme;
+                  return const Text('sheet');
+                },
+              ),
+              child: const Text('button'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(app(TestScaffold.greenOverride));
+      await tester.tap(find.text('button'));
+      await tester.pumpAndSettle();
+
+      expect(seen, TestScaffold.greenOverride);
+
+      await tester.pumpWidget(app(TestScaffold.blueOverride));
+      await tester.pumpAndSettle();
+
+      expect(seen, TestScaffold.blueOverride);
+    });
+  });
 }

--- a/forui/test/src/widgets/toast/toaster_test.dart
+++ b/forui/test/src/widgets/toast/toaster_test.dart
@@ -5,6 +5,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:forui/forui.dart';
+import 'package:forui/src/widgets/toast/animated_toast.dart';
 import 'package:forui/src/widgets/toast/toaster.dart';
 import '../../test_scaffold.dart';
 
@@ -636,6 +637,42 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('1'), findsNothing);
+    });
+  });
+
+  group('scope liveness', () {
+    testWidgets('toast restyles when the theme changes while shown', (tester) async {
+      Widget app(FThemeData theme) => TestScaffold.app(
+        theme: theme,
+        child: FToaster(
+          child: Builder(
+            builder: (context) => FButton(
+              onPress: () => showFToast(context: context, title: const Text('toast'), duration: null),
+              child: const Text('button'),
+            ),
+          ),
+        ),
+      );
+
+      FToastStyle resolved(FThemeData theme) =>
+          theme.toasterStyle.toastStyles.resolve({FToastVariant.primary, FPlatformVariant.android});
+
+      await tester.pumpWidget(app(FTheme.neutral.light.touch));
+      await tester.tap(find.text('button'));
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.widget<AnimatedToast>(find.byType(AnimatedToast)).style.decoration,
+        resolved(FTheme.neutral.light.touch).decoration,
+      );
+
+      await tester.pumpWidget(app(FTheme.neutral.dark.touch));
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.widget<AnimatedToast>(find.byType(AnimatedToast)).style.decoration,
+        resolved(FTheme.neutral.dark.touch).decoration,
+      );
     });
   });
 }


### PR DESCRIPTION
**Describe the changes**

Closes #1133.

- Fix `showFDialog` resolving the dialog's style at push time; it is now resolved inside the route so an open dialog restyles (and animates) with the enclosing theme.
- Add `FTheme.capture` and `FCapturedTheme`, which capture the `FTheme`, `FAccessibilityScope` and `FAdaptiveScope` visible from a context and re-establish them in a disconnected subtree. Unlike `InheritedTheme.capture`, the captured scopes are observed rather than copied, so overlays opened from under a nested scope below the navigator stay live. If a captured scope is unmounted while the overlay is open, the last observed values are retained.
- Wire the captured scopes into `FDialogRoute` and `FModalSheetRoute` (page content and modal barrier).
- **Breaking** Change `barrierFilter`/`backgroundFilter` on `FDialogRouteStyle`, `FDialogStyle`, `FPopoverStyle`, `FModalSheetStyle` and `FAnimatedModalBarrier.filter` to accept a `BuildContext` instead of a `FThemeData`, so filters read the theme live. The `FThemeData` variants were unreleased, so no data-driven fixes are needed.
- Remove the unreleased `theme` parameters on `FDialogRoute`, `FModalSheetRoute` and `FAnimatedModalBarrier`.
- Fix toasts freezing their style at show time; the per-toast style delta is now resolved during build so shown toasts restyle with the theme and platform variant.
- Fix `AnimatedToast` leaking `CurvedAnimation`s when its style changes (previously unreachable).
- Scope elements publish stable `ValueNotifier` handles (`InheritedThemeElement`, `AccessibilityScopeElement`, `AdaptiveScopeElement`, hidden from the barrels); the capture bridge defers rebuilds to the end of the frame when notified mid-build, mirroring `OverlayEntry.remove` and `LocalHistoryRoute.changedInternalState`.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [x] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)