### PR TITLE
Fix FTappable dropping SemanticsAction.tap when labelled or grouped

### DIFF
--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -13,6 +13,8 @@
 * Add `FTappable(selectable: ...)` to control whether descendant text participates in an enclosing `SelectionArea`.
   Defaults to false.
 
+* Fix labelled (`excludeSemantics`) and grouped (`FTappableGroup`) tappables dropping `SemanticsAction.tap`.
+
 
 ## 0.25.0
 

--- a/forui/lib/src/foundation/tappable/tappable.dart
+++ b/forui/lib/src/foundation/tappable/tappable.dart
@@ -691,6 +691,11 @@ class _FTappableState<T extends FTappable> extends State<T> {
               if (widget._onPress != null)
                 ActivateIntent: CallbackAction<ActivateIntent>(onInvoke: (_) => widget._onPress!.call()),
             },
+        // When excludeSemantics is true, child GestureDetector tap is omitted from
+        // the tree. When grouped (_entries != null), GestureDetector.onTap is
+        // nullified so the group owns pointer gestures. In both cases, forward
+        // onPress via Semantics.onTap so Voice Control / screen readers can activate
+        // the control. Leave onTap null otherwise to avoid double-numbering.
         child: Semantics(
           enabled: !widget._disabled,
           label: widget.semanticsLabel,
@@ -703,6 +708,7 @@ class _FTappableState<T extends FTappable> extends State<T> {
           inMutuallyExclusiveGroup: widget.semanticsInMutuallyExclusiveGroup,
           selected: widget.semanticsChecked == null ? widget.selected : null,
           excludeSemantics: widget.excludeSemantics,
+          onTap: (widget.excludeSemantics || _entries != null) ? widget._onPress : null,
           child: Focus(
             autofocus: widget.autofocus,
             focusNode: _focus,

--- a/forui/test/src/foundation/tappable/tappable_test.dart
+++ b/forui/test/src/foundation/tappable/tappable_test.dart
@@ -1354,5 +1354,52 @@ void main() {
         isSemantics(hasEnabledState: true, isEnabled: false, hasTapAction: false),
       );
     });
+
+    // excludeSemantics drops GestureDetector tap from the tree; Semantics.onTap must
+    // compensate so Voice Control / screen readers can still activate the control.
+    testWidgets('excludeSemantics keeps a single tap action on the labelled node', (tester) async {
+      final semantics = tester.ensureSemantics();
+      var presses = 0;
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FTappable.static(
+            semanticsLabel: 'Save',
+            excludeSemantics: true,
+            onPress: () => presses++,
+            child: const Text('tappable'),
+          ),
+        ),
+      );
+
+      expect(tester.getSemantics(find.text('tappable')), isSemantics(label: 'Save', hasTapAction: true));
+      expect(find.semantics.byAction(SemanticsAction.tap), findsOneWidget);
+
+      tester.semantics.tap(find.semantics.byLabel('Save'));
+      await tester.pump();
+      expect(presses, 1);
+
+      semantics.dispose();
+    });
+
+    testWidgets('without excludeSemantics exposes a single tap action', (tester) async {
+      final semantics = tester.ensureSemantics();
+      var presses = 0;
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FTappable.static(onPress: () => presses++, child: const Text('tappable')),
+        ),
+      );
+
+      expect(tester.getSemantics(find.text('tappable')), isSemantics(hasTapAction: true));
+      expect(find.semantics.byAction(SemanticsAction.tap), findsOneWidget);
+
+      tester.semantics.tap(find.semantics.byAction(SemanticsAction.tap));
+      await tester.pump();
+      expect(presses, 1);
+
+      semantics.dispose();
+    });
   });
 }

--- a/forui/test/src/widgets/button/button_test.dart
+++ b/forui/test/src/widgets/button/button_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/semantics.dart';
 import 'package:flutter/widgets.dart';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -233,5 +234,29 @@ void main() {
         });
       }
     }
+  });
+
+  group('accessibility', () {
+    // FButton sets excludeSemantics when semanticsLabel is non-null, which would
+    // otherwise drop SemanticsAction.tap (#1144).
+    testWidgets('semanticsLabel keeps a single tap action', (tester) async {
+      final semantics = tester.ensureSemantics();
+      var presses = 0;
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FButton(semanticsLabel: 'Save', onPress: () => presses++, child: const Text('Visible')),
+        ),
+      );
+
+      expect(tester.getSemantics(find.text('Visible')), isSemantics(label: 'Save', hasTapAction: true));
+      expect(find.semantics.byAction(SemanticsAction.tap), findsOneWidget);
+
+      tester.semantics.tap(find.semantics.byLabel('Save'));
+      await tester.pump();
+      expect(presses, 1);
+
+      semantics.dispose();
+    });
   });
 }

--- a/forui/test/src/widgets/item/item_test.dart
+++ b/forui/test/src/widgets/item/item_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 
 import 'package:flutter_test/flutter_test.dart';
 
@@ -215,5 +216,31 @@ void main() {
         expect(tester.getSize(find.byKey(const Key('raw-item'))).height, closeTo(height, 0.001));
       });
     }
+  });
+
+  group('accessibility', () {
+    // Default FItemGroup wraps items in FTappableGroup, which nulls GestureDetector
+    // onTap; Semantics.onTap must compensate (#1145).
+    testWidgets('item in FItemGroup keeps a single tap action', (tester) async {
+      final semantics = tester.ensureSemantics();
+      var presses = 0;
+
+      await tester.pumpWidget(
+        TestScaffold.app(
+          child: FItemGroup(
+            children: [FItem(title: const Text('Option one'), onPress: () => presses++)],
+          ),
+        ),
+      );
+
+      expect(tester.getSemantics(find.text('Option one')), isSemantics(label: 'Option one', hasTapAction: true));
+      expect(find.semantics.byAction(SemanticsAction.tap), findsOneWidget);
+
+      tester.semantics.tap(find.semantics.byLabel('Option one'));
+      await tester.pump();
+      expect(presses, 1);
+
+      semantics.dispose();
+    });
   });
 }


### PR DESCRIPTION
**Describe the changes**
- Fix `FTappable` omitting `SemanticsAction.tap` when `excludeSemantics` is true (as `FButton` sets for `semanticsLabel`) or when the tappable is in an `FTappableGroup` / default `FItemGroup` Fixes:
  -  #1144 
  - #1145 
- Forward `onPress` via `Semantics.onTap` only in those cases so Voice Control / screen readers can activate once; leave `onTap` null otherwise to avoid double numbering.
- Add accessibility tests for labelled `FButton`, grouped `FItem`, and `FTappable` with/without `excludeSemantics`.
- Update `CHANGELOG.md`.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.

Made with [Cursor](https://cursor.com)