### PR TITLE
Fix `forui init --force` emitting files at the overwritten config's paths

### DIFF
--- a/forui_cli/CHANGELOG.md
+++ b/forui_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.26.0
+* Fix `forui init --force` writing files to the overwritten `forui.yaml`'s output paths.
+
+
 ## 0.25.0
 Add support for Forui `0.25.0`.
 

--- a/forui_cli/lib/src/commands/init/command.dart
+++ b/forui_cli/lib/src/commands/init/command.dart
@@ -167,9 +167,9 @@ class InitCommand extends ForuiCommand {
     }
 
     // preset is non-null here: the wizard fills it when interactive, and a non-interactive run defaults it above.
-    _configuration(force: force);
+    final configuration = _configuration(force: force);
     await create(configuration, preset!, force: force, output: configuration.theme);
-    _main(template: template ?? 'basic', force: force);
+    _main(configuration, template: template ?? 'basic', force: force);
 
     if (terminal.interactive) {
       terminal.outro(
@@ -185,7 +185,7 @@ class InitCommand extends ForuiCommand {
     }
   }
 
-  void _configuration({required bool force}) {
+  Configuration _configuration({required bool force}) {
     final yaml = File('${configuration.root.path}/forui.yaml');
     final yml = File('${configuration.root.path}/forui.yml');
     final file = yaml.existsSync() ? yaml : (yml.existsSync() ? yml : yaml);
@@ -205,9 +205,13 @@ class InitCommand extends ForuiCommand {
 
     file.writeAsStringSync(defaults);
     _created(file);
+
+    // [configuration] was parsed before this command ran, so it still holds the overwritten file's paths. Re-read it
+    // to keep the rest of the run in step with what this file now declares.
+    return Configuration.parse();
   }
 
-  void _main({required String template, required bool force}) {
+  void _main(Configuration configuration, {required String template, required bool force}) {
     final file = File('${configuration.root.path}/lib/main.dart');
 
     if (!force && file.existsSync()) {


### PR DESCRIPTION
**Describe the changes**

* `Configuration` is parsed once at startup (`bin/forui_cli.dart`), before any command runs. `init --force` overwrote
  `forui.yaml` with the defaults mid-run but could not update the already-parsed object, so the rest of the run kept
  resolving `theme-output` and `fonts-output` from the superseded file.
* Concretely, given a config declaring `theme-output: lib/design/theme.dart`, `forui init --force` wrote the theme to
  `lib/design/theme.dart` and imported it from `main.dart`, while `forui.yaml` on disk now claimed
  `lib/theme/theme.dart`. Every later command re-parsed the yaml and looked in the wrong place.
* `_configuration` now returns `Configuration.parse()` after writing, and `run()` threads that into `create()` and
  `_main`. The local shadows the field, so nothing downstream can reach the stale one.
* The `--force` gate is unchanged: an existing `forui.yaml` without `--force` still errors when non-interactive and
  still prompts when interactive. `--force` keeps the same meaning it has in `theme create`, `style create`, and
  `snippet create`.
* Surfaced while looking at #1148, but unrelated to it. `--no-input` assuming the default answer of "No" is intended
  behavior and is untouched here.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I have included the relevant unit/golden tests. `forui_cli` has no test coverage for commands (`test/src/codec_test.dart` is the only test file), so there is nothing to extend here.
- [ ] I have included the relevant samples.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)