### PR TITLE
Add open range selection to `FCalendar`

### DIFF
--- a/docs/content/docs/widgets/data/calendar.mdx
+++ b/docs/content/docs/widgets/data/calendar.mdx
@@ -14,6 +14,7 @@ import dateSnippet from '@/snippets/examples/data/calendar/date.json';
 import datesSnippet from '@/snippets/examples/data/calendar/dates.json';
 import unselectableSnippet from '@/snippets/examples/data/calendar/unselectable.json';
 import rangeSnippet from '@/snippets/examples/data/calendar/range.json';
+import openRangeSnippet from '@/snippets/examples/data/calendar/open-range.json';
 import splitGridSnippet from '@/snippets/examples/data/calendar/split-grid.json';
 import wheelSnippet from '@/snippets/examples/data/calendar/wheel.json';
 import fixedWeeksSnippet from '@/snippets/examples/data/calendar/fixed-weeks.json';
@@ -150,7 +151,10 @@ height constant.
     </Tab>
 </Tabs>
 
-#### Range Selection
+#### Range
+
+`.managedRange()` always holds a complete range, unlike `.managedOpenRange()` which leaves one bound open until the
+user selects it.
 
 <Tabs items={['Preview', 'Code']}>
     <Tab value="Preview">
@@ -158,6 +162,20 @@ height constant.
     </Tab>
     <Tab value="Code">
         <CodeSnippet snippet={rangeSnippet} />
+    </Tab>
+</Tabs>
+
+#### Open Range
+
+`.managedOpenRange()` leaves one bound open until the user selects it, unlike `.managedRange()` which always holds a
+complete range.
+
+<Tabs items={['Preview', 'Code']}>
+    <Tab value="Preview">
+        <Widget name='data/calendar' variant='open-range' height={350}/>
+    </Tab>
+    <Tab value="Code">
+        <CodeSnippet snippet={openRangeSnippet} />
     </Tab>
 </Tabs>
 

--- a/docs_snippets/lib/examples/data/calendar.dart
+++ b/docs_snippets/lib/examples/data/calendar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 
 import 'package:auto_route/auto_route.dart';
 import 'package:forui/forui.dart';
+import 'package:intl/intl.dart';
 
 import 'package:docs_snippets/example.dart';
 
@@ -88,16 +89,85 @@ class DatesCalendarPage extends Example {
 }
 
 @RoutePage()
-class RangeCalendarPage extends Example {
+class RangeCalendarPage extends StatefulExample {
   RangeCalendarPage({@queryParam super.theme}) : super(alignment: .topCenter, top: 24);
 
   @override
-  Widget example(BuildContext _) => FCalendar.grid(
-    control: FGridCalendarControl(start: DateTime.utc(2000), today: DateTime.utc(2026, 7, 15), end: DateTime.utc(2030)),
-    // {@highlight}
-    selectionControl: .managedRange(initial: (DateTime.utc(2026, 7, 17), DateTime.utc(2026, 7, 20))),
-    // {@endhighlight}
-  );
+  State<RangeCalendarPage> createState() => _RangeCalendarPageState();
+}
+
+class _RangeCalendarPageState extends StatefulExampleState<RangeCalendarPage> {
+  static final _format = DateFormat.yMMMd(); // Requires package:intl
+  static final _initial = (DateTime.utc(2026, 7, 17), DateTime.utc(2026, 7, 20));
+
+  (DateTime, DateTime)? _range = _initial;
+
+  @override
+  Widget example(BuildContext context) {
+    final FThemeData(:colors, :typography) = context.theme;
+    return Column(
+      mainAxisSize: .min,
+      spacing: 12,
+      children: [
+        Text(switch (_range) {
+          (final start, final end) => '${_format.format(start)} to ${_format.format(end)}',
+          null => 'No dates selected',
+        }, style: typography.body.sm.copyWith(color: colors.mutedForeground)),
+        FCalendar.grid(
+          control: FGridCalendarControl(
+            start: DateTime.utc(2000),
+            today: DateTime.utc(2026, 7, 15),
+            end: DateTime.utc(2030),
+          ),
+          // {@highlight}
+          selectionControl: .managedRange(initial: _initial, onChange: (range) => setState(() => _range = range)),
+          // {@endhighlight}
+        ),
+      ],
+    );
+  }
+}
+
+@RoutePage()
+class OpenRangeCalendarPage extends StatefulExample {
+  OpenRangeCalendarPage({@queryParam super.theme}) : super(alignment: .topCenter, top: 24);
+
+  @override
+  State<OpenRangeCalendarPage> createState() => _OpenRangeCalendarPageState();
+}
+
+class _OpenRangeCalendarPageState extends StatefulExampleState<OpenRangeCalendarPage> {
+  static final _format = DateFormat.yMMMd(); // Requires package:intl
+  static final (DateTime?, DateTime?) _initial = (DateTime.utc(2026, 7, 17), null);
+
+  (DateTime?, DateTime?) _range = _initial;
+
+  @override
+  Widget example(BuildContext context) {
+    final FThemeData(:colors, :typography) = context.theme;
+    return Column(
+      mainAxisSize: .min,
+      spacing: 12,
+      children: [
+        Text(switch (_range) {
+          (final start?, final end?) => '${_format.format(start)} to ${_format.format(end)}',
+          (final start?, null) => 'From ${_format.format(start)}',
+          (null, final end?) => 'Until ${_format.format(end)}',
+          _ => 'No dates selected',
+        }, style: typography.body.sm.copyWith(color: colors.mutedForeground)),
+        FCalendar.grid(
+          control: FGridCalendarControl(
+            start: DateTime.utc(2000),
+            today: DateTime.utc(2026, 7, 15),
+            end: DateTime.utc(2030),
+          ),
+          // {@highlight}
+          selectionControl: .managedOpenRange(initial: _initial, onChange: (range) => setState(() => _range = range)),
+          // {@endhighlight}
+        ),
+      ],
+    );
+  }
 }
 
 @RoutePage()

--- a/docs_snippets/lib/main.dart
+++ b/docs_snippets/lib/main.dart
@@ -75,6 +75,7 @@ class _AppRouter extends RootStackRouter {
     AutoRoute(path: '/data/calendar/fixed-weeks', page: FixedWeeksCalendarRoute.page),
     AutoRoute(path: '/data/calendar/unselectable', page: UnselectableCalendarRoute.page),
     AutoRoute(path: '/data/calendar/range', page: RangeCalendarRoute.page),
+    AutoRoute(path: '/data/calendar/open-range', page: OpenRangeCalendarRoute.page),
     AutoRoute(path: '/data/calendar/split-grid', page: SplitGridCalendarRoute.page),
     AutoRoute(path: '/data/calendar/wheel', page: WheelCalendarRoute.page),
     AutoRoute(path: '/data/calendar/none', page: NoneCalendarRoute.page),

--- a/docs_snippets/lib/usages/data/calendar.dart
+++ b/docs_snippets/lib/usages/data/calendar.dart
@@ -134,6 +134,14 @@ final FDateSelectionControl<(DateTime, DateTime)?> selectionLiftedRange = .lifte
   onChange: (range) {},
 );
 
+// {@category "Selection" "`.liftedOpenRange()`"}
+/// Lifts open range selection to the parent for external state management.
+final FDateSelectionControl<(DateTime?, DateTime?)> selectionLiftedOpenRange = .liftedOpenRange(
+  value: (null, null),
+  onChange: (range) {},
+  startFirst: true,
+);
+
 // {@category "Selection" "`.managedSingle()` with internal controller"}
 /// Single date selection managed internally.
 final FDateSelectionControl<DateTime?> selectionSingleInternal = .managedSingle(
@@ -174,6 +182,22 @@ final FDateSelectionControl<(DateTime, DateTime)?> selectionRangeInternal = .man
 final FDateSelectionControl<(DateTime, DateTime)?> selectionRangeExternal = .managedRange(
   // Don't create a controller inline. Store it in a State instead.
   controller: FDateSelectionController.range(initial: (.utc(2026, 7, 17), .utc(2026, 7, 20))),
+  onChange: (range) {},
+);
+
+// {@category "Selection" "`.managedOpenRange()` with internal controller"}
+/// Open range selection managed internally. A bound stays null until the user selects it.
+final FDateSelectionControl<(DateTime?, DateTime?)> selectionOpenRangeInternal = .managedOpenRange(
+  initial: (null, null),
+  startFirst: true,
+  onChange: (range) {},
+);
+
+// {@category "Selection" "`.managedOpenRange()` with external controller"}
+/// Open range selection with an external controller.
+final FDateSelectionControl<(DateTime?, DateTime?)> selectionOpenRangeExternal = .managedOpenRange(
+  // Don't create a controller inline. Store it in a State instead.
+  controller: FDateSelectionController.openRange(initial: (.utc(2026, 7, 17), null)),
   onChange: (range) {},
 );
 

--- a/forui/CHANGELOG.md
+++ b/forui/CHANGELOG.md
@@ -4,6 +4,11 @@
 * Add `FAutocomplete.clearIconBuilder`.
 
 
+### `FCalendar`
+* Add `FDateSelectionController.openRange(...)`.
+* Add `FDateSelectionControl.managedOpenRange(...)` and `FDateSelectionControl.liftedOpenRange(...)`.
+
+
 ### `FDateField` & `FTimeField`
 * Add `FDateField.clearIconBuilder`.
 * Add `FTimeField.clearIconBuilder`.

--- a/forui/example/lib/sandbox.dart
+++ b/forui/example/lib/sandbox.dart
@@ -1,187 +1,20 @@
-import 'package:flutter/foundation.dart';
-import 'package:flutter/semantics.dart';
 import 'package:flutter/widgets.dart';
 
 import 'package:forui/forui.dart';
 
-/// Repro for accessibility audit finding U3-016: `FPagination`'s previous/next actions stay enabled at the range edges.
-///
-/// Run on any target (`flutter run -d macos` / `-d chrome`) and follow the on-screen steps.
-///
-/// [FPaginationController.previous] and [FPaginationController.next] guard internally, so activating them at the
-/// first/last page is a silent no-op. The buttons were nonetheless always built with a non-null `onPress`, so
-/// `FTappable` reported `enabled: true` and kept a `tap` action.
-///
-/// The readout below dumps the live semantics node for each action, so the state is visible without a screen reader.
-/// Semantics is force-enabled via [SemanticsBinding.ensureSemantics], which is why the readout is populated even with
-/// VoiceOver/TalkBack off.
-///
-/// Before the fix, "Previous" reported this on page 1 of 3, unchanged as you paged:
-///   actions: focus, tap
-///   flags:   isButton, hasEnabledState, isEnabled, isFocusable
-///
-/// The actions are now built inside the `ListenableBuilder` and take a null `onPress` at their edge, so they drop the
-/// `tap` action and `isEnabled`, leave the focus order, and dim. The second pagination has a single page, so both are
-/// inert from the start.
-class Sandbox extends StatefulWidget {
+class Sandbox extends StatelessWidget {
   const Sandbox({super.key});
 
   @override
-  State<Sandbox> createState() => _SandboxState();
-}
-
-class _SandboxState extends State<Sandbox> {
-  final GlobalKey _multiple = GlobalKey();
-  final GlobalKey _single = GlobalKey();
-
-  late SemanticsHandle _semantics;
-  late FPaginationController _controller;
-
-  Map<String, String> _multipleNodes = const {};
-  Map<String, String> _singleNodes = const {};
-
-  @override
-  void initState() {
-    super.initState();
-    _semantics = SemanticsBinding.instance.ensureSemantics();
-    _controller = FPaginationController(pages: 3);
-    _controller.addListener(_schedule);
-    _schedule();
-  }
-
-  @override
-  void dispose() {
-    _controller
-      ..removeListener(_schedule)
-      ..dispose();
-    _semantics.dispose();
-    super.dispose();
-  }
-
-  void _schedule() => WidgetsBinding.instance.addPostFrameCallback((_) {
-    if (!mounted) {
-      return;
-    }
-
-    final multiple = _dump(_multiple);
-    final single = _dump(_single);
-    if (!mapEquals(multiple, _multipleNodes) || !mapEquals(single, _singleNodes)) {
-      setState(() {
-        _multipleNodes = multiple;
-        _singleNodes = single;
-      });
-    }
-  });
-
-  /// Collects the semantics node of every labelled action inside [key]'s subtree, keyed by label.
-  Map<String, String> _dump(GlobalKey key) {
-    if (key.currentContext?.findRenderObject() case final root?) {
-      final nodes = <String, String>{};
-
-      void visit(RenderObject object) {
-        if (object.debugSemantics case final node? when node.label == 'Previous' || node.label == 'Next') {
-          nodes[node.label] = _summarize(node);
-        }
-        object.visitChildren(visit);
-      }
-
-      visit(root);
-      return nodes;
-    }
-
-    return const {};
-  }
-
-  String _summarize(SemanticsNode node) {
-    final description = node.toString();
-    final actions = RegExp(r'actions: \[(.*?)\]').firstMatch(description)?.group(1) ?? 'none';
-    final flags = RegExp(r'flags: \[(.*?)\]').firstMatch(description)?.group(1) ?? 'none';
-    return 'actions: $actions\nflags:   $flags';
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final FThemeData(:colors, :typography) = context.theme;
-
-    return SingleChildScrollView(
-      padding: const EdgeInsets.all(20),
-      child: Center(
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 460),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            spacing: 16,
-            children: [
-              Text(
-                'U3-016: FPagination prev/next stay enabled at the edges',
-                textAlign: TextAlign.center,
-                style: typography.body.lg.copyWith(color: colors.foreground),
-              ),
-              _steps(colors, typography),
-              Text(
-                'Three pages, currently on page ${_controller.value + 1}',
-                style: typography.body.sm.copyWith(color: colors.mutedForeground),
-              ),
-              FPagination(
-                key: _multiple,
-                control: .managed(controller: _controller),
-              ),
-              _readout(colors, typography, _multipleNodes),
-              Text(
-                'One page, so both actions are always inert',
-                style: typography.body.sm.copyWith(color: colors.mutedForeground),
-              ),
-              FPagination(key: _single, control: const .managed(pages: 1)),
-              _readout(colors, typography, _singleNodes),
-            ],
-          ),
+  Widget build(BuildContext context) => FScaffold(
+    child: Center(
+      child: FCalendar.grid(
+        control: FGridCalendarControl(
+          start: DateTime.utc(2000),
+          today: DateTime.utc(2026, 7, 15),
+          end: DateTime.utc(2030),
         ),
-      ),
-    );
-  }
-
-  Widget _steps(FColors colors, FTypography typography) => Column(
-    crossAxisAlignment: CrossAxisAlignment.start,
-    spacing: 2,
-    children: [
-      for (final step in const [
-        '1. On page 1, the left chevron is dimmed and its row below reports no tap action and no isEnabled.',
-        '2. Press Tab. Focus skips the left chevron and lands on page 1.',
-        '3. Click the right chevron to reach page 2. The left chevron un-dims and regains its tap action.',
-        '4. Click through to page 3. "Next" now reports the same thing "Previous" did on page 1.',
-      ])
-        Text(step, style: typography.body.sm.copyWith(color: colors.mutedForeground)),
-      const SizedBox(height: 6),
-      Text(
-        'With a screen reader on, an action at its edge is announced as a disabled button.',
-        style: typography.body.xs.copyWith(color: colors.mutedForeground),
-      ),
-    ],
-  );
-
-  Widget _readout(FColors colors, FTypography typography, Map<String, String> nodes) => DecoratedBox(
-    decoration: BoxDecoration(
-      border: Border.all(color: colors.border),
-      borderRadius: BorderRadius.circular(8),
-    ),
-    child: Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        spacing: 8,
-        children: [
-          if (nodes.isEmpty)
-            Text('(no semantics yet)', style: typography.body.sm.copyWith(color: colors.mutedForeground))
-          else
-            for (final MapEntry(key: label, value: summary) in nodes.entries)
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(label, style: typography.body.sm.copyWith(color: colors.foreground)),
-                  Text(summary, style: typography.body.xs.copyWith(color: colors.mutedForeground)),
-                ],
-              ),
-        ],
+        selectionControl: .managedOpenRange(),
       ),
     ),
   );

--- a/forui/lib/src/widgets/calendar/date_selection_control.dart
+++ b/forui/lib/src/widgets/calendar/date_selection_control.dart
@@ -25,11 +25,35 @@ sealed class FDateSelectionControl<T> with Diagnosticable, _$FDateSelectionContr
   }) => _Multi(controller: controller, initial: initial, onChange: onChange);
 
   /// Creates a [FDateSelectionControl] for range selection.
+  ///
+  /// Both the start and end dates of the range are inclusive. Unlike [managedOpenRange], selecting the first date
+  /// returns a complete range, `(first date, first date)`.
+  ///
+  /// ## Contract
+  /// Throws [AssertionError] if [initial]'s end date is less than its start date.
   static FDateSelectionControl<(DateTime, DateTime)?> managedRange({
     FDateSelectionController<(DateTime, DateTime)?>? controller,
     (DateTime, DateTime)? initial,
     ValueChanged<(DateTime, DateTime)?>? onChange,
   }) => _Range(controller: controller, initial: initial, onChange: onChange);
+
+  /// Creates a [FDateSelectionControl] for range selection with an open bound.
+  ///
+  /// Both the start and end dates of the range are inclusive. Unlike [managedRange], selecting the first date returns
+  /// an open-bound range, `(first date, null)`/`(null, first date)`, depending on [startFirst].
+  ///
+  /// [startFirst] determines whether the first selected date is the range's start or end. Defaults to true.
+  ///
+  /// ## Contract
+  /// Throws [AssertionError] if [controller] is provided and [startFirst] is false.
+  ///
+  /// Throws [AssertionError] if both of [initial]'s bounds are given and the end date is less than the start date.
+  static FDateSelectionControl<(DateTime?, DateTime?)> managedOpenRange({
+    FDateSelectionController<(DateTime?, DateTime?)>? controller,
+    (DateTime?, DateTime?)? initial,
+    ValueChanged<(DateTime?, DateTime?)>? onChange,
+    bool startFirst = true,
+  }) => _OpenRange(controller: controller, initial: initial, onChange: onChange, startFirst: startFirst);
 
   /// Creates a lifted [FDateSelectionControl] for single date selection.
   ///
@@ -53,13 +77,29 @@ sealed class FDateSelectionControl<T> with Diagnosticable, _$FDateSelectionContr
 
   /// Creates a lifted [FDateSelectionControl] for range selection.
   ///
+  /// Both the start and end dates of the range are inclusive. Unlike [liftedOpenRange], selecting the first date
+  /// returns a complete range, `(first date, first date)`.
+  ///
   /// The [value] is the currently selected range.
   /// [onChange] is called with the new selection when a date is selected.
-  /// Both the start and end dates of the range are inclusive.
   static FDateSelectionControl<(DateTime, DateTime)?> liftedRange({
     required (DateTime, DateTime)? value,
     required ValueChanged<(DateTime, DateTime)?> onChange,
   }) => _LiftedRange(value: value, onChange: onChange);
+
+  /// Creates a lifted [FDateSelectionControl] for range selection with an open bound.
+  ///
+  /// Both the start and end dates of the range are inclusive. Unlike [liftedRange], selecting the first date returns
+  /// an open-bound range, `(first date, null)`/`(null, first date)`, depending on [startFirst].
+  ///
+  /// The [value] is the currently selected range.
+  /// [onChange] is called with the new selection when a date is selected.
+  /// [startFirst] determines whether the first selected date is the range's start or end. Defaults to true.
+  static FDateSelectionControl<(DateTime?, DateTime?)> liftedOpenRange({
+    required (DateTime?, DateTime?) value,
+    required ValueChanged<(DateTime?, DateTime?)> onChange,
+    bool startFirst = true,
+  }) => _LiftedOpenRange(value: value, onChange: onChange, startFirst: startFirst);
 
   const FDateSelectionControl._();
 
@@ -137,6 +177,33 @@ class _Range extends FDateSelectionManagedControl<(DateTime, DateTime)?> {
   FDateSelectionController<(DateTime, DateTime)?> createController() => controller ?? .range(initial: initial);
 }
 
+class _OpenRange extends FDateSelectionManagedControl<(DateTime?, DateTime?)> {
+  final bool startFirst;
+
+  const _OpenRange({this.startFirst = true, super.controller, super.initial, super.onChange})
+    : assert(
+        controller == null || startFirst,
+        'Cannot provide both controller and startFirst. Pass startFirst to the controller instead.',
+      );
+
+  @override
+  FDateSelectionController<(DateTime?, DateTime?)> createController() =>
+      controller ?? .openRange(initial: initial ?? (null, null), startFirst: startFirst);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(
+      FlagProperty(
+        'startFirst',
+        value: startFirst,
+        ifTrue: 'selects the start first',
+        ifFalse: 'selects the end first',
+      ),
+    );
+  }
+}
+
 /// A [FDateSelectionLiftedControl] enables a parent to own the selection state and update it via a callback.
 abstract class FDateSelectionLiftedControl<T> extends FDateSelectionControl<T>
     with _$FDateSelectionLiftedControlMixin<T> {
@@ -194,6 +261,33 @@ class _LiftedRange extends FDateSelectionLiftedControl<(DateTime, DateTime)?> {
   @override
   void _updateController(FDateSelectionController<(DateTime, DateTime)?> controller) =>
       (controller as _LiftedRangeController).update(value: value, onChange: onChange);
+}
+
+class _LiftedOpenRange extends FDateSelectionLiftedControl<(DateTime?, DateTime?)> {
+  final bool startFirst;
+
+  const _LiftedOpenRange({required super.value, required super.onChange, required this.startFirst});
+
+  @override
+  FDateSelectionController<(DateTime?, DateTime?)> createController() =>
+      _LiftedOpenRangeController(value: value, onChange: onChange, startFirst: startFirst);
+
+  @override
+  void _updateController(FDateSelectionController<(DateTime?, DateTime?)> controller) =>
+      (controller as _LiftedOpenRangeController).update(value: value, onChange: onChange, startFirst: startFirst);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(
+      FlagProperty(
+        'startFirst',
+        value: startFirst,
+        ifTrue: 'selects the start first',
+        ifFalse: 'selects the end first',
+      ),
+    );
+  }
 }
 
 class _None extends FDateSelectionLiftedControl<Object?> {

--- a/forui/lib/src/widgets/calendar/date_selection_controller.dart
+++ b/forui/lib/src/widgets/calendar/date_selection_controller.dart
@@ -7,14 +7,14 @@ part 'date_selection_control.dart';
 part 'date_selection_controller.control.dart';
 
 DateTime? _selectSingle(DateTime? current, DateTime date, bool toggleable) {
-  date = _truncate(date);
+  date = date._truncate();
   return (toggleable && current == date) ? null : date;
 }
 
-Set<DateTime> _selectMulti(Set<DateTime> current, DateTime date) => {...current}..toggle(_truncate(date));
+Set<DateTime> _selectMulti(Set<DateTime> current, DateTime date) => {...current}..toggle(date._truncate());
 
 (DateTime, DateTime)? _selectRange((DateTime, DateTime)? current, DateTime date) {
-  date = _truncate(date);
+  date = date._truncate();
   return switch (current) {
     null => (date, date),
     (final first, final last) when date == first || date == last => null,
@@ -23,7 +23,17 @@ Set<DateTime> _selectMulti(Set<DateTime> current, DateTime date) => {...current}
   };
 }
 
-DateTime _truncate(DateTime date) => .utc(date.year, date.month, date.day);
+(DateTime?, DateTime?) _selectOpenRange((DateTime?, DateTime?) current, DateTime date, bool startFirst) {
+  date = date._truncate();
+  return switch (current) {
+    (final start?, null) when date.isBefore(start) => (date, null),
+    (final start?, null) => (start, date),
+    (null, final end?) when end.isBefore(date) => (null, date),
+    (null, final end?) => (date, end),
+    _ when startFirst => (date, null),
+    _ => (null, date),
+  };
+}
 
 /// A controller that controls date selection.
 ///
@@ -33,7 +43,8 @@ DateTime _truncate(DateTime date) => .utc(date.year, date.month, date.day);
 /// This class should be extended to customize date selection. By default, the following controllers are provided:
 /// * [FDateSelectionController.single] for selecting a single date.
 /// * [FDateSelectionController.multi] for selecting multiple dates.
-/// * [FDateSelectionController.range] for selecting a single range.
+/// * [FDateSelectionController.range] for selecting a single, always complete range.
+/// * [FDateSelectionController.openRange] for selecting a single, open-bound range.
 abstract class FDateSelectionController<T> extends ValueNotifier<T> {
   /// Creates a [FDateSelectionController] that allows only a single date to be selected, with the given initially
   /// selected date.
@@ -49,12 +60,34 @@ abstract class FDateSelectionController<T> extends ValueNotifier<T> {
 
   /// Creates a [FDateSelectionController] that allows a single range to be selected, with the given initial range.
   ///
-  /// Both the start and end dates of the range are inclusive.
+  /// Both the start and end dates of the range are inclusive. Unlike [openRange], selecting the first date returns a
+  /// complete range, `(first date, first date)`.
   ///
   /// ## Contract
   /// Throws [AssertionError] if the end date is less than start date.
+  ///
+  /// See:
+  /// * [openRange] for partial range selection.
   static FDateSelectionController<(DateTime, DateTime)?> range({(DateTime, DateTime)? initial}) =>
       _RangeController(initial: initial);
+
+  /// Creates a [FDateSelectionController] that allows a range with an open bound to be selected, with the given initial
+  /// range.
+  ///
+  /// Both the start and end dates of the range are inclusive. Unlike [range], selecting the first date returns an
+  /// open-bound range, `(first date, null)`/`(null, first date)`, depending on [startFirst].
+  ///
+  /// [startFirst] determines whether the first selected date is the range's start or end. Defaults to true.
+  ///
+  /// ## Contract
+  /// Throws [AssertionError] if both bounds are given and the end date is less than start date.
+  ///
+  /// See:
+  /// * [range] for an always complete range selection.
+  static FDateSelectionController<(DateTime?, DateTime?)> openRange({
+    (DateTime?, DateTime?) initial = (null, null),
+    bool startFirst = true,
+  }) => _OpenRangeController(initial: initial, startFirst: startFirst);
 
   /// Creates a [FDateSelectionController] with the given initial [value].
   FDateSelectionController(super._value);
@@ -72,23 +105,23 @@ class _LiftedSingleController extends FDateSelectionController<DateTime?> {
   bool _toggleable;
 
   _LiftedSingleController({required DateTime? value, required this._onChange, required this._toggleable})
-    : super(value == null ? null : _truncate(value));
+    : super(value?._truncate());
 
   void update({required DateTime? value, required ValueChanged<DateTime?> onChange, required bool toggleable}) {
     _onChange = onChange;
     _toggleable = toggleable;
-    super.value = value == null ? null : _truncate(value);
+    super.value = value?._truncate();
   }
 
   @override
-  bool contains(DateTime date) => value == _truncate(date);
+  bool contains(DateTime date) => value == date._truncate();
 
   @override
   void select(DateTime date) => _onChange(_selectSingle(value, date, _toggleable));
 
   @override
   set value(DateTime? value) {
-    final next = value == null ? null : _truncate(value);
+    final next = value?._truncate();
     if (super.value != next) {
       _onChange(next);
     }
@@ -99,22 +132,23 @@ class _LiftedSingleController extends FDateSelectionController<DateTime?> {
 class _LiftedMultiController extends FDateSelectionController<Set<DateTime>> {
   ValueChanged<Set<DateTime>> _onChange;
 
-  _LiftedMultiController({required Set<DateTime> value, required this._onChange}) : super(value.map(_truncate).toSet());
+  _LiftedMultiController({required Set<DateTime> value, required this._onChange})
+    : super(value.map((date) => date._truncate()).toSet());
 
   void update({required Set<DateTime> value, required ValueChanged<Set<DateTime>> onChange}) {
     _onChange = onChange;
-    super.value = value.map(_truncate).toSet();
+    super.value = value.map((date) => date._truncate()).toSet();
   }
 
   @override
-  bool contains(DateTime date) => value.contains(_truncate(date));
+  bool contains(DateTime date) => value.contains(date._truncate());
 
   @override
   void select(DateTime date) => _onChange(_selectMulti(value, date));
 
   @override
   set value(Set<DateTime> value) {
-    final next = value.map(_truncate).toSet();
+    final next = value.map((date) => date._truncate()).toSet();
     if (!setEquals(super.value, next)) {
       _onChange(next);
     }
@@ -126,17 +160,17 @@ class _LiftedRangeController extends FDateSelectionController<(DateTime, DateTim
   ValueChanged<(DateTime, DateTime)?> _onChange;
 
   _LiftedRangeController({required (DateTime, DateTime)? value, required this._onChange})
-    : super(value == null ? null : (_truncate(value.$1), _truncate(value.$2)));
+    : super(value == null ? null : (value.$1._truncate(), value.$2._truncate()));
 
   void update({required (DateTime, DateTime)? value, required ValueChanged<(DateTime, DateTime)?> onChange}) {
     _onChange = onChange;
-    super.value = value == null ? null : (_truncate(value.$1), _truncate(value.$2));
+    super.value = value == null ? null : (value.$1._truncate(), value.$2._truncate());
   }
 
   @override
   bool contains(DateTime date) {
     if (value case (final first, final last)) {
-      final current = _truncate(date);
+      final current = date._truncate();
       return !current.isBefore(first) && !current.isAfter(last);
     }
 
@@ -148,7 +182,51 @@ class _LiftedRangeController extends FDateSelectionController<(DateTime, DateTim
 
   @override
   set value((DateTime, DateTime)? value) {
-    final next = value == null ? null : (_truncate(value.$1), _truncate(value.$2));
+    final next = value == null ? null : (value.$1._truncate(), value.$2._truncate());
+    if (super.value != next) {
+      _onChange(next);
+    }
+  }
+}
+
+// The lifted open range controller.
+class _LiftedOpenRangeController extends FDateSelectionController<(DateTime?, DateTime?)> {
+  ValueChanged<(DateTime?, DateTime?)> _onChange;
+  bool _startFirst;
+
+  _LiftedOpenRangeController({
+    required (DateTime?, DateTime?) value,
+    required this._onChange,
+    required this._startFirst,
+  }) : super((value.$1?._truncate(), value.$2?._truncate()));
+
+  void update({
+    required (DateTime?, DateTime?) value,
+    required ValueChanged<(DateTime?, DateTime?)> onChange,
+    required bool startFirst,
+  }) {
+    _onChange = onChange;
+    _startFirst = startFirst;
+    super.value = (value.$1?._truncate(), value.$2?._truncate());
+  }
+
+  @override
+  bool contains(DateTime date) {
+    final current = date._truncate();
+    return switch (value) {
+      (final start?, final end?) => !current.isBefore(start) && !current.isAfter(end),
+      (final start?, _) => current == start,
+      (_, final end?) => current == end,
+      _ => false,
+    };
+  }
+
+  @override
+  void select(DateTime date) => _onChange(_selectOpenRange(value, date, _startFirst));
+
+  @override
+  set value((DateTime?, DateTime?) value) {
+    final next = (value.$1?._truncate(), value.$2?._truncate());
     if (super.value != next) {
       _onChange(next);
     }
@@ -170,11 +248,10 @@ class _NoneController extends FDateSelectionController<Object?> {
 class _SingleController extends FDateSelectionController<DateTime?> {
   final bool toggleable;
 
-  _SingleController({required DateTime? initial, required this.toggleable})
-    : super(initial == null ? null : _truncate(initial));
+  _SingleController({required DateTime? initial, required this.toggleable}) : super(initial?._truncate());
 
   @override
-  bool contains(DateTime date) => value == _truncate(date);
+  bool contains(DateTime date) => value == date._truncate();
 
   @override
   void select(DateTime date) => super.value = _selectSingle(value, date, toggleable);
@@ -184,29 +261,29 @@ class _SingleController extends FDateSelectionController<DateTime?> {
     if (toggleable && super.value == value) {
       super.value = null;
     } else {
-      super.value = value == null ? null : _truncate(value);
+      super.value = value?._truncate();
     }
   }
 }
 
 // The multiple dates controller.
 final class _MultiController extends FDateSelectionController<Set<DateTime>> {
-  _MultiController({Set<DateTime> initial = const {}}) : super(initial.map(_truncate).toSet());
+  _MultiController({Set<DateTime> initial = const {}}) : super(initial.map((date) => date._truncate()).toSet());
 
   @override
-  bool contains(DateTime date) => value.contains(_truncate(date));
+  bool contains(DateTime date) => value.contains(date._truncate());
 
   @override
   void select(DateTime date) => super.value = _selectMulti(value, date);
 
   @override
-  set value(Set<DateTime> value) => super.value = value.map(_truncate).toSet();
+  set value(Set<DateTime> value) => super.value = value.map((date) => date._truncate()).toSet();
 }
 
 // The range controller.
 final class _RangeController extends FDateSelectionController<(DateTime, DateTime)?> {
   _RangeController({(DateTime, DateTime)? initial})
-    : super(initial == null ? null : (_truncate(initial.$1), _truncate(initial.$2))) {
+    : super(initial == null ? null : (initial.$1._truncate(), initial.$2._truncate())) {
     final range = value;
     assert(
       range == null || (range.$1.isBefore(range.$2) || range.$1.isAtSameMomentAs(range.$2)),
@@ -217,7 +294,7 @@ final class _RangeController extends FDateSelectionController<(DateTime, DateTim
   @override
   bool contains(DateTime date) {
     if (value case (final first, final last)) {
-      final current = _truncate(date);
+      final current = date._truncate();
       return !current.isBefore(first) && !current.isAfter(last);
     }
 
@@ -229,5 +306,37 @@ final class _RangeController extends FDateSelectionController<(DateTime, DateTim
 
   @override
   set value((DateTime, DateTime)? value) =>
-      super.value = value == null ? null : (_truncate(value.$1), _truncate(value.$2));
+      super.value = value == null ? null : (value.$1._truncate(), value.$2._truncate());
+}
+
+// The open range controller.
+final class _OpenRangeController extends FDateSelectionController<(DateTime?, DateTime?)> {
+  final bool startFirst;
+
+  _OpenRangeController({required (DateTime?, DateTime?) initial, required this.startFirst})
+    : super((initial.$1?._truncate(), initial.$2?._truncate())) {
+    final (start, end) = value;
+    assert(start == null || end == null || !end.isBefore(start), 'start ($start) must be <= end ($end)');
+  }
+
+  @override
+  bool contains(DateTime date) {
+    final current = date._truncate();
+    return switch (value) {
+      (final start?, final end?) => !current.isBefore(start) && !current.isAfter(end),
+      (final start?, _) => current == start,
+      (_, final end?) => current == end,
+      _ => false,
+    };
+  }
+
+  @override
+  void select(DateTime date) => super.value = _selectOpenRange(value, date, startFirst);
+
+  @override
+  set value((DateTime?, DateTime?) value) => super.value = (value.$1?._truncate(), value.$2?._truncate());
+}
+
+extension on DateTime {
+  DateTime _truncate() => .utc(year, month, day);
 }

--- a/forui/test/src/widgets/calendar/date_selection_controller_test.dart
+++ b/forui/test/src/widgets/calendar/date_selection_controller_test.dart
@@ -178,6 +178,141 @@ void main() {
     }
   });
 
+  group('FDateSelectionController.openRange(...)', () {
+    test('constructor defaults to nothing selected', () {
+      expect(FDateSelectionController.openRange().value, (null, null));
+    });
+
+    test(
+      'constructor converts date time',
+      () => expect(
+        FDateSelectionController.openRange(initial: (DateTime(2024, 11, 30, 12), DateTime(2024, 12, 12, 12))).value,
+        (DateTime.utc(2024, 11, 30), DateTime.utc(2024, 12, 12)),
+      ),
+    );
+
+    test(
+      'constructor converts an open end',
+      () => expect(FDateSelectionController.openRange(initial: (DateTime(2024, 11, 30, 12), null)).value, (
+        DateTime.utc(2024, 11, 30),
+        null,
+      )),
+    );
+
+    test(
+      'constructor converts an open start',
+      () => expect(FDateSelectionController.openRange(initial: (null, DateTime(2024, 12, 12, 12))).value, (
+        null,
+        DateTime.utc(2024, 12, 12),
+      )),
+    );
+
+    test(
+      'constructor allows equal start and end',
+      () => expect(FDateSelectionController.openRange(initial: (DateTime(2024), DateTime(2024))).value, (
+        DateTime.utc(2024),
+        DateTime.utc(2024),
+      )),
+    );
+
+    test(
+      'constructor throws error when end before start',
+      () => expect(
+        () => FDateSelectionController.openRange(initial: (DateTime(2025), DateTime(2024))),
+        throwsAssertionError,
+      ),
+    );
+
+    for (final initial in <(DateTime?, DateTime?)>[(DateTime(2025), null), (null, DateTime(2024))]) {
+      test('constructor does not assert the order of an open bound initial=$initial', () {
+        expect(() => FDateSelectionController.openRange(initial: initial), returnsNormally);
+      });
+    }
+
+    for (final (initial, date, expected) in <((DateTime?, DateTime?), DateTime, bool)>[
+      ((DateTime(2024), DateTime(2025)), DateTime.utc(2024), true), // start, inclusive
+      ((DateTime(2024), DateTime(2025)), DateTime(2024, 1, 1, 15), true), // start, truncates the time component
+      ((DateTime(2024), DateTime(2025)), DateTime.utc(2024, 6), true), // inside
+      ((DateTime(2024), DateTime(2025)), DateTime.utc(2025), true), // end, inclusive
+      ((DateTime(2024), DateTime(2025)), DateTime.utc(2023), false), // before
+      ((DateTime(2024), DateTime(2025)), DateTime.utc(2026), false), // after
+      ((DateTime(2024), null), DateTime.utc(2024), true), // the selected start
+      ((DateTime(2024), null), DateTime.utc(2025), false), // the open end matches nothing
+      ((null, DateTime(2025)), DateTime.utc(2025), true), // the selected end
+      ((null, DateTime(2025)), DateTime.utc(2024), false), // the open start matches nothing
+      ((null, null), DateTime.utc(2023), false),
+    ]) {
+      test('contains($date) initial=$initial', () {
+        final controller = FDateSelectionController.openRange(initial: initial);
+        expect(controller.contains(date), expected);
+      });
+    }
+
+    for (final (startFirst, initial, date, expected)
+        in <(bool, (DateTime?, DateTime?), DateTime, (DateTime?, DateTime?))>[
+          (true, (null, null), DateTime(2023), (DateTime.utc(2023), null)), // selects the start first
+          (false, (null, null), DateTime(2023), (null, DateTime.utc(2023))), // selects the end first
+          (true, (DateTime(2024), null), DateTime(2023), (DateTime.utc(2023), null)), // moves the start back
+          (true, (DateTime(2024), null), DateTime(2024), (DateTime.utc(2024), DateTime.utc(2024))), // completes one day
+          (true, (DateTime(2024), null), DateTime(2025), (DateTime.utc(2024), DateTime.utc(2025))), // completes
+          (true, (null, DateTime(2025)), DateTime(2026), (null, DateTime.utc(2026))), // moves the end forward
+          (true, (null, DateTime(2025)), DateTime(2025), (DateTime.utc(2025), DateTime.utc(2025))), // completes one day
+          (true, (null, DateTime(2025)), DateTime(2024), (DateTime.utc(2024), DateTime.utc(2025))), // completes
+          (true, (DateTime(2024), DateTime(2025)), DateTime(2024), (DateTime.utc(2024), null)), // restarts at the start
+          (true, (DateTime(2024), DateTime(2025)), DateTime(2025), (DateTime.utc(2025), null)), // restarts at the end
+          (true, (DateTime(2024), DateTime(2025)), DateTime(2026), (DateTime.utc(2026), null)), // restarts
+          (false, (DateTime(2024), DateTime(2025)), DateTime(2026), (null, DateTime.utc(2026))), // restarts at the end
+          (true, (DateTime(2024), DateTime(2027)), DateTime(2025), (DateTime.utc(2025), null)), // restarts from inside
+          (
+            true,
+            (DateTime(2024), null),
+            DateTime(2024, 6, 1, 8),
+            (DateTime.utc(2024), DateTime.utc(2024, 6)),
+          ), // truncates
+        ]) {
+      test('select($date) startFirst=$startFirst initial=$initial', () {
+        final controller = FDateSelectionController.openRange(initial: initial, startFirst: startFirst)..select(date);
+        expect(controller.value, expected);
+      });
+    }
+
+    for (final (initial, value, expected) in <((DateTime?, DateTime?), (DateTime?, DateTime?), (DateTime?, DateTime?))>[
+      (
+        (null, null),
+        (DateTime(2024, 11, 30, 12), DateTime(2024, 12, 12, 12)),
+        (DateTime.utc(2024, 11, 30), DateTime.utc(2024, 12, 12)),
+      ), // truncates
+      ((null, null), (DateTime(2024, 11, 30, 12), null), (DateTime.utc(2024, 11, 30), null)), // truncates an open end
+      ((null, null), (null, DateTime(2024, 12, 12, 12)), (null, DateTime.utc(2024, 12, 12))), // truncates an open start
+      ((DateTime(2024), DateTime(2025)), (null, null), (null, null)), // clears
+    ]) {
+      test('value setter initial=$initial value=$value', () {
+        final controller = FDateSelectionController.openRange(initial: initial)..value = value;
+        expect(controller.value, expected);
+      });
+    }
+  });
+
+  group('FDateSelectionControl.managedOpenRange(...)', () {
+    test('throws error when both controller and startFirst are provided', () {
+      expect(
+        () =>
+            FDateSelectionControl.managedOpenRange(controller: FDateSelectionController.openRange(), startFirst: false),
+        throwsAssertionError,
+      );
+    });
+
+    test('throws error when both controller and initial are provided', () {
+      expect(
+        () => FDateSelectionControl.managedOpenRange(
+          controller: FDateSelectionController.openRange(),
+          initial: (DateTime(2024), null),
+        ),
+        throwsAssertionError,
+      );
+    });
+  });
+
   group('FDateSelectionControl.liftedSingle(...)', () {
     for (final (date, expected) in [
       (DateTime(2024, 5, 4), true),
@@ -290,6 +425,51 @@ void main() {
         DateTime(2024, 12, 12, 12),
       );
       expect(changes.single, (DateTime.utc(2024, 11, 30), DateTime.utc(2024, 12, 12)));
+    });
+  });
+
+  group('FDateSelectionControl.liftedOpenRange(...)', () {
+    for (final (value, date, expected) in <((DateTime?, DateTime?), DateTime, bool)>[
+      ((DateTime(2024), DateTime(2025)), DateTime.utc(2024), true), // start, inclusive
+      ((DateTime(2024), DateTime(2025)), DateTime.utc(2024, 6), true), // inside
+      ((DateTime(2024), DateTime(2025)), DateTime.utc(2023), false), // before
+      ((DateTime(2024), null), DateTime.utc(2024), true), // the selected start
+      ((null, DateTime(2025)), DateTime.utc(2025), true), // the selected end
+      ((null, null), DateTime.utc(2023), false),
+    ]) {
+      test('contains($date) value=$value', () {
+        final controller = FDateSelectionControl.liftedOpenRange(value: value, onChange: (_) {}).create(() {});
+        expect(controller.contains(date), expected);
+      });
+    }
+
+    for (final (startFirst, value, date, expected)
+        in <(bool, (DateTime?, DateTime?), DateTime, (DateTime?, DateTime?))>[
+          (true, (null, null), DateTime(2023), (DateTime.utc(2023), null)), // selects the start first
+          (false, (null, null), DateTime(2023), (null, DateTime.utc(2023))), // selects the end first
+          (true, (DateTime(2024), null), DateTime(2023), (DateTime.utc(2023), null)), // moves the start back
+          (true, (DateTime(2024), null), DateTime(2025), (DateTime.utc(2024), DateTime.utc(2025))), // completes
+          (true, (DateTime(2024), DateTime(2025)), DateTime(2024), (DateTime.utc(2024), null)), // restarts at the start
+          (true, (DateTime(2024), DateTime(2025)), DateTime(2026), (DateTime.utc(2026), null)), // restarts
+        ]) {
+      test('select($date) forwards to onChange startFirst=$startFirst value=$value', () {
+        final changes = <(DateTime?, DateTime?)>[];
+        FDateSelectionControl.liftedOpenRange(
+          value: value,
+          onChange: changes.add,
+          startFirst: startFirst,
+        ).create(() {}).select(date);
+        expect(changes.single, expected);
+      });
+    }
+
+    test('value setter truncates and forwards to onChange', () {
+      final changes = <(DateTime?, DateTime?)>[];
+      FDateSelectionControl.liftedOpenRange(value: (null, null), onChange: changes.add).create(() {}).value = (
+        DateTime(2024, 11, 30, 12),
+        null,
+      );
+      expect(changes.single, (DateTime.utc(2024, 11, 30), null));
     });
   });
 }

--- a/forui/test/src/widgets/calendar/grid_calendar_test.dart
+++ b/forui/test/src/widgets/calendar/grid_calendar_test.dart
@@ -434,6 +434,50 @@ void main() {
       expect(selected, (DateTime.utc(2024, 7, 15), DateTime.utc(2024, 7, 20)));
     });
 
+    testWidgets('managedOpenRange opens, completes and restarts a range', (tester) async {
+      (DateTime?, DateTime?) selected = (null, null);
+      await tester.pumpWidget(
+        calendar(
+          selectionControl: .managedOpenRange(onChange: (range) => selected = range),
+          control: control(),
+        ),
+      );
+
+      await tester.tap(find.descendant(of: find.byType(DayPicker), matching: find.text('15')));
+      await tester.pumpAndSettle();
+      expect(selected, (DateTime.utc(2024, 7, 15), null));
+
+      await tester.tap(find.descendant(of: find.byType(DayPicker), matching: find.text('20')));
+      await tester.pumpAndSettle();
+      expect(selected, (DateTime.utc(2024, 7, 15), DateTime.utc(2024, 7, 20)));
+
+      await tester.tap(find.descendant(of: find.byType(DayPicker), matching: find.text('25')));
+      await tester.pumpAndSettle();
+      expect(selected, (DateTime.utc(2024, 7, 25), null));
+
+      await tester.tap(find.descendant(of: find.byType(DayPicker), matching: find.text('25')));
+      await tester.pumpAndSettle();
+      expect(selected, (DateTime.utc(2024, 7, 25), DateTime.utc(2024, 7, 25)));
+    });
+
+    testWidgets('managedOpenRange with startFirst: false selects the end first', (tester) async {
+      (DateTime?, DateTime?) selected = (null, null);
+      await tester.pumpWidget(
+        calendar(
+          selectionControl: .managedOpenRange(startFirst: false, onChange: (range) => selected = range),
+          control: control(),
+        ),
+      );
+
+      await tester.tap(find.descendant(of: find.byType(DayPicker), matching: find.text('20')));
+      await tester.pumpAndSettle();
+      expect(selected, (null, DateTime.utc(2024, 7, 20)));
+
+      await tester.tap(find.descendant(of: find.byType(DayPicker), matching: find.text('15')));
+      await tester.pumpAndSettle();
+      expect(selected, (DateTime.utc(2024, 7, 15), DateTime.utc(2024, 7, 20)));
+    });
+
     testWidgets('lifted calls select with the tapped day', (tester) async {
       DateTime? selected;
       await tester.pumpWidget(

--- a/forui_hooks/CHANGELOG.md
+++ b/forui_hooks/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.26.0
+
+### `FCalendar`
+* Add `useFOpenRangeSelectionController(...)`.
+
+
 ## 0.25.0
 Add support for Forui `0.25.0`.
 

--- a/forui_hooks/lib/src/date_selection_controller_hook.dart
+++ b/forui_hooks/lib/src/date_selection_controller_hook.dart
@@ -38,7 +38,8 @@ FDateSelectionController<Set<DateTime>> useFDatesSelectionController({
 
 /// Creates a [FDateSelectionController] that allows a single range to be selected and is automatically disposed.
 ///
-/// Both the start and end dates of the range are inclusive.
+/// Both the start and end dates of the range are inclusive. Unlike [useFOpenRangeSelectionController], selecting the
+/// first date returns a complete range, `(first date, first date)`.
 ///
 /// ## Contract
 /// Throws [AssertionError] if the end date is less than the start date.
@@ -54,9 +55,34 @@ FDateSelectionController<(DateTime, DateTime)?> useFRangeSelectionController({
   ),
 );
 
+/// Creates a [FDateSelectionController] that allows a range with an open bound to be selected and is automatically
+/// disposed.
+///
+/// Both the start and end dates of the range are inclusive. Unlike [useFRangeSelectionController], selecting the first
+/// date returns an open-bound range, `(first date, null)`/`(null, first date)`, depending on [startFirst].
+///
+/// [startFirst] determines whether the first selected date is the range's start or end. Defaults to true.
+///
+/// ## Contract
+/// Throws [AssertionError] if both bounds are given and the end date is less than the start date.
+FDateSelectionController<(DateTime?, DateTime?)> useFOpenRangeSelectionController({
+  (DateTime?, DateTime?) initial = (null, null),
+  bool startFirst = true,
+  List<Object?>? keys,
+}) => use(
+  _DateSelectionControllerHook<(DateTime?, DateTime?)>(
+    value: initial,
+    startFirst: startFirst,
+    debugLabel: 'useFOpenRangeSelectionController',
+    create: (hook) => .openRange(initial: hook.value, startFirst: hook.startFirst),
+    keys: keys,
+  ),
+);
+
 class _DateSelectionControllerHook<T> extends Hook<FDateSelectionController<T>> {
   final T value;
   final bool toggleable;
+  final bool startFirst;
   final String _debugLabel;
   final _Create<T> _create;
 
@@ -65,6 +91,7 @@ class _DateSelectionControllerHook<T> extends Hook<FDateSelectionController<T>> 
     required this._debugLabel,
     required this._create,
     this.toggleable = true,
+    this.startFirst = true,
     super.keys,
   });
 
@@ -76,7 +103,15 @@ class _DateSelectionControllerHook<T> extends Hook<FDateSelectionController<T>> 
     super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('initialSelection', value))
-      ..add(FlagProperty('toggleable', value: toggleable, ifTrue: 'toggleable'));
+      ..add(FlagProperty('toggleable', value: toggleable, ifTrue: 'toggleable'))
+      ..add(
+        FlagProperty(
+          'startFirst',
+          value: startFirst,
+          ifTrue: 'selects the start first',
+          ifFalse: 'selects the end first',
+        ),
+      );
   }
 }
 

--- a/forui_hooks/test/src/date_selection_controller_hook_test.dart
+++ b/forui_hooks/test/src/date_selection_controller_hook_test.dart
@@ -81,4 +81,30 @@ void main() {
 
     expect(controller.contains(DateTime.utc(2000)), true);
   });
+
+  testWidgets('useFOpenRangeSelectionController', (tester) async {
+    late FDateSelectionController<(DateTime?, DateTime?)> controller;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        builder: (_, child) => FTheme(data: FTheme.neutral.light.touch, child: child!),
+        home: HookBuilder(
+          builder: (context) {
+            controller = useFOpenRangeSelectionController();
+            return FCalendar.grid(
+              control: FGridCalendarControl(start: DateTime.utc(1900), end: DateTime.utc(2100)),
+              selectionControl: .managedOpenRange(controller: controller),
+            );
+          },
+        ),
+      ),
+    );
+
+    controller.value = (DateTime.utc(2000), null);
+
+    await tester.pumpAndSettle();
+
+    expect(controller.contains(DateTime.utc(2000)), true);
+    expect(controller.value, (DateTime.utc(2000), null));
+  });
 }


### PR DESCRIPTION
**Describe the changes**

Closes #1147.

Adds a date selection model that reports a partially selected range, so a single tap is distinguishable from a deliberate one-day range.

- Add `FDateSelectionController.openRange(...)`, holding a `(DateTime?, DateTime?)` where `(null, null)` is nothing selected and `(start, null)`/`(null, end)` mean only one bound has been chosen.
- Add `FDateSelectionControl.managedOpenRange(...)` and `FDateSelectionControl.liftedOpenRange(...)`.
- Add `useFOpenRangeSelectionController(...)` to `forui_hooks`.
- `startFirst` (defaults to true) decides whether the first date of a fresh selection fills the start or the end. Selecting a date that would invert the range moves the selected bound instead.
- Unlike `range`, tapping a bound of a complete range restarts the selection rather than clearing it, so `(null, null)` is only reachable programmatically. Clearing belongs to an explicit affordance such as a footer button.
- Align the `range`/`openRange` dartdocs across the controller, both control factories and both hooks so each cross-references its sibling.
- Add an Open Range Selection docs example, and show the formatted selection above both range calendars so the two models are visually distinguishable.

**Checklist**
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have included the relevant unit/golden tests.
- [x] I have included the relevant samples.
- [x] I have updated the documentation accordingly.
- [x] I have added the required flutters_hook for widget controllers.
- [x] I have updated the [CHANGELOG.md](../forui/CHANGELOG.md) if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)